### PR TITLE
feat: redesign /profile page with wallet-native identity and   library/inventory separation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,11 +42,23 @@ lerna-debug.log*
 
 # Editor / OS artifacts
 .DS_Store
+Thumbs.db
 .vscode/*
 !.vscode/extensions.json
 !.vscode/settings.json
+.idea/
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+# Claude / AI tooling
+.codex
+.claude/
 
 # Generated contract clients
 packages/*
 !packages/.gitkeep
 !src/contracts/util.ts
+.omx/

--- a/src/hooks/useContractSync.test.ts
+++ b/src/hooks/useContractSync.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from "vitest";
+import type { QueryClient } from "@tanstack/react-query";
+
+vi.mock("./useSubscription", () => ({ useSubscription: vi.fn() }));
+vi.mock("@/lib/stellar/browserConfig", () => ({
+  browserStellarConfig: { promptHashContractId: "test-contract-id" },
+}));
+
+import { invalidateAllPromptQueries } from "./useContractSync";
+
+function mockQueryClient() {
+  return {
+    invalidateQueries: vi.fn().mockResolvedValue(undefined),
+  } as unknown as QueryClient;
+}
+
+const EXPECTED_KEYS = [
+  ["marketplace-prompts"],
+  ["created-prompts"],
+  ["purchased-prompts"],
+  ["prompt-access"],
+];
+
+describe("invalidateAllPromptQueries", () => {
+  it("invalidates all four prompt-related query keys", async () => {
+    const queryClient = mockQueryClient();
+    await invalidateAllPromptQueries(queryClient);
+
+    expect(queryClient.invalidateQueries).toHaveBeenCalledTimes(4);
+    for (const queryKey of EXPECTED_KEYS) {
+      expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey });
+    }
+  });
+
+  it("includes marketplace-prompts so the browse grid refreshes after any TX", async () => {
+    const queryClient = mockQueryClient();
+    await invalidateAllPromptQueries(queryClient);
+
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["marketplace-prompts"],
+    });
+  });
+
+  it("includes created-prompts so creator sales counts refresh after a purchase", async () => {
+    const queryClient = mockQueryClient();
+    await invalidateAllPromptQueries(queryClient);
+
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["created-prompts"],
+    });
+  });
+
+  it("includes purchased-prompts so buyer library refreshes after buy", async () => {
+    const queryClient = mockQueryClient();
+    await invalidateAllPromptQueries(queryClient);
+
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["purchased-prompts"],
+    });
+  });
+
+  it("includes prompt-access so access checks refresh after a purchase", async () => {
+    const queryClient = mockQueryClient();
+    await invalidateAllPromptQueries(queryClient);
+
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["prompt-access"],
+    });
+  });
+
+  it("awaits all invalidations in parallel before resolving", async () => {
+    const settled: string[] = [];
+    const queryClient = {
+      invalidateQueries: vi.fn().mockImplementation(
+        ({ queryKey }: { queryKey: string[] }) =>
+          new Promise<void>((resolve) =>
+            setTimeout(() => {
+              settled.push(queryKey[0]);
+              resolve();
+            }, 5),
+          ),
+      ),
+    } as unknown as QueryClient;
+
+    await invalidateAllPromptQueries(queryClient);
+
+    expect(settled).toHaveLength(4);
+    expect(settled).toContain("marketplace-prompts");
+    expect(settled).toContain("created-prompts");
+    expect(settled).toContain("purchased-prompts");
+    expect(settled).toContain("prompt-access");
+  });
+
+  it("can be called multiple times without error", async () => {
+    const queryClient = mockQueryClient();
+    await invalidateAllPromptQueries(queryClient);
+    await invalidateAllPromptQueries(queryClient);
+
+    expect(queryClient.invalidateQueries).toHaveBeenCalledTimes(8);
+  });
+});

--- a/src/hooks/useContractSync.ts
+++ b/src/hooks/useContractSync.ts
@@ -1,0 +1,60 @@
+import { useCallback } from "react";
+import { useQueryClient, type QueryClient } from "@tanstack/react-query";
+import { useSubscription } from "./useSubscription";
+import { browserStellarConfig } from "@/lib/stellar/browserConfig";
+
+/**
+ * Sync strategy: hybrid approach
+ *
+ * Short-term sync is implemented in two layers:
+ *
+ * 1. Immediate post-TX invalidation — after any write transaction (create,
+ *    buy, price update, sale-status change), the caller invokes
+ *    `invalidateAllPromptQueries()` so the submitting user sees fresh
+ *    on-chain state right away without waiting for the background poll.
+ *
+ * 2. Background event polling — `useContractSync` (mounted once via
+ *    `ContractSyncProvider`) polls ALL contract events from the PromptHash
+ *    contract every 10 seconds. When any new event arrives it invalidates
+ *    every prompt-related query key. This keeps browse/profile pages fresh
+ *    for users who did not submit the transaction — e.g. a browsing user
+ *    sees an updated sales count after another wallet completes a purchase.
+ *
+ * Fallback: if the RPC event endpoint is unavailable, the background loop
+ * retries silently on the next interval. Post-TX invalidation has already
+ * run synchronously from chain confirmation, so the submitter's state
+ * never depends on the background poll succeeding.
+ *
+ * Query-key → invalidation mapping:
+ *   Any contract event → ["marketplace-prompts"]  (browse grid, prices, active flag)
+ *   Any contract event → ["created-prompts"]       (creator inventory + sales count)
+ *   Any contract event → ["purchased-prompts"]     (buyer's license list)
+ *   Any contract event → ["prompt-access"]         (per-prompt access checks)
+ */
+
+const POLL_INTERVAL_MS = 10_000;
+
+export function invalidateAllPromptQueries(queryClient: QueryClient) {
+  return Promise.all([
+    queryClient.invalidateQueries({ queryKey: ["marketplace-prompts"] }),
+    queryClient.invalidateQueries({ queryKey: ["created-prompts"] }),
+    queryClient.invalidateQueries({ queryKey: ["purchased-prompts"] }),
+    queryClient.invalidateQueries({ queryKey: ["prompt-access"] }),
+  ]);
+}
+
+export function useContractSync() {
+  const queryClient = useQueryClient();
+
+  const handleEvent = useCallback(() => {
+    void invalidateAllPromptQueries(queryClient);
+  }, [queryClient]);
+
+  // topic is undefined → subscribe to all events from this contract
+  useSubscription(
+    browserStellarConfig.promptHashContractId,
+    undefined,
+    handleEvent,
+    POLL_INTERVAL_MS,
+  );
+}

--- a/src/hooks/useSubscription.ts
+++ b/src/hooks/useSubscription.ts
@@ -4,7 +4,7 @@ import { xdr } from "@stellar/stellar-sdk";
 import { rpcUrl, stellarNetwork } from "../contracts/util";
 
 /**
- * Concatenated `${contractId}:${topic}`
+ * Concatenated `${contractId}:${topic ?? "*"}`
  */
 type PagingKey = string;
 
@@ -21,24 +21,31 @@ const paging: Record<
 const server = new Server(rpcUrl, { allowHttp: stellarNetwork === "LOCAL" });
 
 /**
- * Subscribe to events for a given topic from a given contract, using a library
- * generated with `soroban contract bindings typescript`.
+ * Subscribe to events from a given contract, optionally filtered by topic.
  *
- * Someday such generated libraries will include functions for subscribing to
- * the events the contract emits, but for now you can copy this hook into your
- * React project if you need to subscribe to events, or adapt this logic for
- * non-React use.
+ * When `topic` is omitted, all events from the contract are delivered.
+ * The `onEvent` callback is held in a ref so the poll loop is not restarted
+ * when the callback identity changes between renders.
  */
 export function useSubscription(
   contractId: string,
-  topic: string,
+  topic: string | undefined,
   onEvent: (event: Api.EventResponse) => void,
   pollInterval = 5000,
 ) {
-  const id = `${contractId}:${topic}`;
-  paging[id] = paging[id] || {};
+  const id = `${contractId}:${topic ?? "*"}`;
+
+  // Stable ref so the poll loop doesn't restart when onEvent identity changes.
+  const onEventRef = React.useRef(onEvent);
+  React.useLayoutEffect(() => {
+    onEventRef.current = onEvent;
+  });
 
   React.useEffect(() => {
+    // Don't start polling when contract is not configured.
+    if (!contractId) return;
+
+    paging[id] = paging[id] || {};
     let timeoutId: NodeJS.Timeout | null = null;
     let stop = false;
 
@@ -49,6 +56,10 @@ export function useSubscription(
           paging[id].lastLedgerStart = latestLedgerState.sequence;
         }
 
+        const topicFilter = topic
+          ? { topics: [[xdr.ScVal.scvSymbol(topic).toXDR("base64")]] }
+          : {};
+
         // @ts-ignore
         const response = await server.getEvents({
           startLedger: !paging[id].pagingToken
@@ -58,7 +69,7 @@ export function useSubscription(
           filters: [
             {
               contractIds: [contractId],
-              topics: [[xdr.ScVal.scvSymbol(topic).toXDR("base64")]],
+              ...topicFilter,
               type: "contract",
             },
           ],
@@ -72,7 +83,7 @@ export function useSubscription(
         if (response.events) {
           response.events.forEach((event) => {
             try {
-              onEvent(event);
+              onEventRef.current(event);
             } catch (error) {
               console.error(
                 "Poll Events: subscription callback had error: ",
@@ -99,5 +110,5 @@ export function useSubscription(
       if (timeoutId != null) clearTimeout(timeoutId);
       stop = true;
     };
-  }, [contractId, topic, onEvent, id, pollInterval]);
+  }, [contractId, topic, id, pollInterval]);
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import App from "./App.tsx";
 import "@stellar/design-system/build/styles.min.css";
 import { WalletProvider } from "./providers/WalletProvider.tsx";
 import { NotificationProvider } from "./providers/NotificationProvider.tsx";
+import { ContractSyncProvider } from "./providers/ContractSyncProvider.tsx";
 import { BrowserRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
@@ -21,11 +22,13 @@ createRoot(document.getElementById("root") as HTMLElement).render(
   <StrictMode>
     <NotificationProvider>
       <QueryClientProvider client={queryClient}>
-        <WalletProvider>
-          <BrowserRouter>
-            <App />
-          </BrowserRouter>
-        </WalletProvider>
+        <ContractSyncProvider>
+          <WalletProvider>
+            <BrowserRouter>
+              <App />
+            </BrowserRouter>
+          </WalletProvider>
+        </ContractSyncProvider>
       </QueryClientProvider>
     </NotificationProvider>
   </StrictMode>,

--- a/src/pages/browse/FetchAllPrompts.tsx
+++ b/src/pages/browse/FetchAllPrompts.tsx
@@ -10,6 +10,7 @@ import {
   type PromptRecord,
 } from "@/lib/stellar/promptHashClient";
 import { stroopsToXlmString } from "@/lib/stellar/format";
+import { invalidateAllPromptQueries } from "@/hooks/useContractSync";
 import { PromptCard } from "./PromptCard";
 import { PromptModal } from "./PromptModal";
 
@@ -108,12 +109,7 @@ const FetchAllPrompts = ({
     currentPage * ITEMS_PER_PAGE,
   );
 
-  const refreshQueries = async () => {
-    await Promise.all([
-      queryClient.invalidateQueries({ queryKey: ["marketplace-prompts"] }),
-      queryClient.invalidateQueries({ queryKey: ["prompt-access"] }),
-    ]);
-  };
+  const refreshQueries = () => invalidateAllPromptQueries(queryClient);
 
   useEffect(() => {
     setCurrentPage(1);

--- a/src/pages/profile/page.tsx
+++ b/src/pages/profile/page.tsx
@@ -61,11 +61,6 @@ const formatNetworkName = (value?: string) => {
 const shortHash = (value: string) =>
   value ? `${value.slice(0, 8)}...${value.slice(-8)}` : "Pending";
 
-const statusBadgeClass = (isActive: boolean) =>
-  isActive
-    ? "border-emerald-300/30 bg-emerald-300/10 text-emerald-100"
-    : "border-amber-300/30 bg-amber-300/10 text-amber-100";
-
 // eslint-disable-next-line no-unused-vars
 type Handler<TArgs extends unknown[]> = (...args: TArgs) => void;
 
@@ -78,10 +73,11 @@ function AlertBanner({
 }) {
   return (
     <div
+      role="alert"
       className={
         tone === "success"
-          ? "rounded-lg border border-emerald-300/25 bg-emerald-300/10 px-4 py-3 text-sm text-emerald-100"
-          : "rounded-lg border border-rose-300/25 bg-rose-400/10 px-4 py-3 text-sm text-rose-100"
+          ? "rounded-xl border border-emerald-300/25 bg-emerald-300/10 px-4 py-3 text-sm text-emerald-100"
+          : "rounded-xl border border-rose-300/25 bg-rose-400/10 px-4 py-3 text-sm text-rose-100"
       }
     >
       {message}
@@ -89,91 +85,145 @@ function AlertBanner({
   );
 }
 
-function MetricTile({
-  label,
-  value,
-  icon: Icon,
-}: {
-  label: string;
-  value: string | number;
-  icon: LucideIcon;
-}) {
+function LoadingState({ label }: { label: string }) {
   return (
-    <div className="rounded-lg border border-white/10 bg-white/[0.04] p-4">
-      <div className="flex items-center justify-between gap-3">
-        <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
-          {label}
-        </p>
-        <Icon className="h-4 w-4 text-cyan-200" />
+    <div className="flex min-h-56 items-center justify-center rounded-xl border border-white/10 bg-white/[0.03] p-8 text-sm text-slate-300">
+      <Loader2 className="mr-2 h-4 w-4 animate-spin text-cyan-200" />
+      {label}
+    </div>
+  );
+}
+
+function EmptyState({
+  icon: Icon,
+  title,
+  body,
+  action,
+  accent = "cyan",
+}: {
+  icon: LucideIcon;
+  title: string;
+  body: string;
+  action: { label: string; to: string; icon: LucideIcon };
+  accent?: "cyan" | "amber";
+}) {
+  const ActionIcon = action.icon;
+  const isCyan = accent === "cyan";
+
+  return (
+    <div className="grid min-h-80 place-items-center rounded-xl border border-dashed border-white/15 bg-white/[0.02] p-8 text-center">
+      <div className="max-w-sm">
+        <div
+          className={`mx-auto flex h-16 w-16 items-center justify-center rounded-2xl ${
+            isCyan ? "bg-cyan-200/10 text-cyan-100" : "bg-amber-300/10 text-amber-200"
+          }`}
+        >
+          <Icon className="h-8 w-8" />
+        </div>
+        <h3 className="mt-5 text-xl font-semibold text-white">{title}</h3>
+        <p className="mt-3 text-sm leading-7 text-slate-400">{body}</p>
+        <Button
+          asChild
+          className={`mt-6 h-10 px-6 ${
+            isCyan
+              ? "bg-cyan-200 text-slate-950 hover:bg-cyan-100"
+              : "bg-amber-300 text-slate-950 hover:bg-amber-200"
+          }`}
+        >
+          <Link to={action.to}>
+            <ActionIcon className="h-4 w-4" />
+            {action.label}
+          </Link>
+        </Button>
       </div>
-      <p className="mt-3 text-2xl font-semibold text-white">{value}</p>
     </div>
   );
 }
 
 function DisconnectedProfile() {
   return (
-    <section className="grid gap-6 py-10 lg:grid-cols-[1.1fr_0.9fr] lg:items-stretch">
-      <div className="rounded-lg border border-white/10 bg-[#101417] p-6 shadow-[0_28px_80px_-54px_rgba(45,212,191,0.7)] md:p-8">
-        <Badge className="border-cyan-200/30 bg-cyan-200/10 text-cyan-100">
-          Wallet required
-        </Badge>
-        <h1 className="mt-6 max-w-3xl text-4xl font-semibold leading-tight text-white md:text-5xl">
-          Your prompt library starts with a Stellar wallet.
-        </h1>
-        <p className="mt-4 max-w-2xl text-sm leading-7 text-slate-300">
-          Connect to see licensed prompts you can reopen, creator inventory you
-          control, and listing states tied to your wallet identity.
-        </p>
-        <div className="mt-8 flex flex-col gap-3 sm:flex-row">
-          <Button
-            className="bg-cyan-200 text-slate-950 hover:bg-cyan-100"
-            onClick={() => void connectWallet()}
-          >
-            <PlugZap className="h-4 w-4" />
-            Connect wallet
-          </Button>
-          <Button
-            asChild
-            variant="outline"
-            className="border-white/15 bg-white/[0.03] text-white hover:bg-white/10"
-          >
-            <Link to="/browse">
-              <ShoppingBag className="h-4 w-4" />
-              Browse prompts
-            </Link>
-          </Button>
+    <section className="space-y-5 py-10">
+      {/* Hero panel */}
+      <div className="relative overflow-hidden rounded-2xl border border-white/10 bg-[#0d1117] p-8 shadow-[0_32px_96px_-48px_rgba(34,211,238,0.45)] md:p-12">
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_80%_50%_at_0%_0%,rgba(34,211,238,0.12),transparent)]" />
+        <div className="relative">
+          <div className="flex items-center gap-3">
+            <div className="flex h-12 w-12 items-center justify-center rounded-xl border border-cyan-200/20 bg-cyan-200/10 text-cyan-100">
+              <Wallet className="h-6 w-6" />
+            </div>
+            <Badge className="border-cyan-200/30 bg-cyan-200/10 text-cyan-100">
+              Wallet required
+            </Badge>
+          </div>
+          <h1 className="mt-6 max-w-2xl text-4xl font-semibold leading-tight text-white md:text-5xl">
+            Your prompt library starts with a Stellar wallet.
+          </h1>
+          <p className="mt-4 max-w-xl text-base leading-7 text-slate-300">
+            Connect to see licensed prompts you can reopen, creator inventory you
+            control, and listing states tied to your wallet identity.
+          </p>
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+            <Button
+              className="h-11 bg-cyan-200 px-6 text-slate-950 hover:bg-cyan-100 active:scale-95"
+              onClick={() => void connectWallet()}
+            >
+              <PlugZap className="h-4 w-4" />
+              Connect wallet
+            </Button>
+            <Button
+              asChild
+              variant="outline"
+              className="h-11 border-white/15 bg-white/[0.03] px-6 text-white hover:bg-white/10"
+            >
+              <Link to="/browse">
+                <ShoppingBag className="h-4 w-4" />
+                Browse prompts
+              </Link>
+            </Button>
+          </div>
         </div>
       </div>
 
-      <div className="grid gap-4 rounded-lg border border-white/10 bg-white/[0.035] p-5">
+      {/* Feature strip */}
+      <div className="grid gap-4 sm:grid-cols-3">
         {[
           {
             icon: KeyRound,
+            accent: "cyan" as const,
             title: "Purchased licenses",
-            body: "Unlocked access is grouped separately from creator listings.",
+            body: "Unlocked access is grouped separately from creator listings — your library, not a marketplace view.",
           },
           {
             icon: Boxes,
+            accent: "amber" as const,
             title: "Creator inventory",
-            body: "Pricing, sales count, and listing status stay in their own lane.",
+            body: "Pricing controls, sales counts, and active or paused states stay in their own dedicated section.",
           },
           {
             icon: ShieldCheck,
-            title: "Wallet-authenticated re-entry",
-            body: "Full prompt text appears only after the wallet signs an unlock request.",
+            accent: "emerald" as const,
+            title: "Wallet-authenticated access",
+            body: "Full prompt content appears only after your wallet signs an unlock request via SEP-43.",
           },
         ].map((item) => (
           <div
             key={item.title}
-            className="grid grid-cols-[2.5rem_1fr] gap-4 rounded-lg bg-slate-950/45 p-4"
+            className="flex gap-4 rounded-xl border border-white/10 bg-white/[0.03] p-5"
           >
-            <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-cyan-200/10 text-cyan-100">
+            <div
+              className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-xl ${
+                item.accent === "cyan"
+                  ? "bg-cyan-200/10 text-cyan-100"
+                  : item.accent === "amber"
+                    ? "bg-amber-300/10 text-amber-200"
+                    : "bg-emerald-300/10 text-emerald-100"
+              }`}
+            >
               <item.icon className="h-5 w-5" />
             </div>
             <div>
-              <h2 className="font-medium text-white">{item.title}</h2>
-              <p className="mt-1 text-sm leading-6 text-slate-400">{item.body}</p>
+              <h2 className="font-semibold text-white">{item.title}</h2>
+              <p className="mt-1.5 text-sm leading-6 text-slate-400">{item.body}</p>
             </div>
           </div>
         ))}
@@ -199,95 +249,91 @@ function WalletIdentityPanel({
   createdCount: number;
   activeCount: number;
 }) {
-  return (
-    <section className="grid gap-6 py-8 lg:grid-cols-[1.15fr_0.85fr]">
-      <div className="rounded-lg border border-white/10 bg-[#101417] p-6 shadow-[0_28px_80px_-54px_rgba(56,189,248,0.65)] md:p-8">
-        <div className="flex flex-wrap items-center gap-3">
-          <Badge className="border-cyan-200/30 bg-cyan-200/10 text-cyan-100">
-            Wallet profile
-          </Badge>
-          <Badge className="border-white/10 bg-white/[0.04] text-slate-200">
-            <RadioTower className="mr-1 h-3.5 w-3.5" />
-            {formatNetworkName(network ?? stellarNetwork)}
-          </Badge>
-        </div>
+  const [copied, setCopied] = useState(false);
 
-        <div className="mt-7 grid gap-5 lg:grid-cols-[auto_1fr] lg:items-center">
-          <div className="flex h-20 w-20 items-center justify-center rounded-lg border border-cyan-200/20 bg-cyan-200/10 text-cyan-100">
-            <Wallet className="h-9 w-9" />
-          </div>
-          <div className="min-w-0">
-            <p className="text-sm text-slate-400">Connected identity</p>
-            <h1 className="mt-2 text-3xl font-semibold text-white md:text-5xl">
-              {shortenAddress(address)}
-            </h1>
-            <div className="mt-4 flex min-w-0 items-center gap-2 rounded-lg border border-white/10 bg-slate-950/60 px-3 py-2 text-xs text-slate-300">
-              <Copy className="h-3.5 w-3.5 shrink-0 text-cyan-200" />
-              <span className="min-w-0 truncate font-mono">{address}</span>
+  const handleCopy = () => {
+    void navigator.clipboard.writeText(address).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <section className="py-8">
+      <div className="overflow-hidden rounded-2xl border border-white/10 bg-[#0d1117] shadow-[0_32px_96px_-48px_rgba(56,189,248,0.45)]">
+        {/* Identity header */}
+        <div className="relative p-6 md:p-8">
+          <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_60%_60%_at_100%_0%,rgba(56,189,248,0.1),transparent)]" />
+          <div className="relative flex flex-col gap-6 md:flex-row md:items-center">
+            {/* Wallet avatar with connected indicator */}
+            <div className="relative shrink-0">
+              <div className="flex h-24 w-24 items-center justify-center rounded-2xl border border-cyan-200/20 bg-gradient-to-br from-cyan-200/15 to-sky-400/10 text-cyan-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.07)]">
+                <Wallet className="h-11 w-11" />
+              </div>
+              <div className="absolute -bottom-1 -right-1 flex h-6 w-6 items-center justify-center rounded-full border-2 border-[#0d1117] bg-emerald-400">
+                <CheckCircle2 className="h-3 w-3 text-slate-950" />
+              </div>
+            </div>
+
+            {/* Address block */}
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <p className="text-sm text-slate-400">Connected identity</p>
+                <Badge className="border-white/10 bg-white/[0.05] text-slate-200">
+                  <RadioTower className="mr-1 h-3 w-3" />
+                  {formatNetworkName(network ?? stellarNetwork)}
+                </Badge>
+              </div>
+              <h1 className="mt-2 text-3xl font-semibold tracking-tight text-white md:text-4xl">
+                {shortenAddress(address)}
+              </h1>
+              <button
+                type="button"
+                onClick={handleCopy}
+                aria-label="Copy wallet address"
+                className="group mt-3 flex w-full max-w-lg cursor-pointer items-center gap-2 rounded-lg border border-white/10 bg-slate-950/60 px-3 py-2 text-left transition-all hover:border-cyan-200/20 hover:bg-slate-950/80"
+              >
+                {copied ? (
+                  <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-emerald-400" />
+                ) : (
+                  <Copy className="h-3.5 w-3.5 shrink-0 text-cyan-200 group-hover:text-cyan-100" />
+                )}
+                <span className="min-w-0 truncate font-mono text-xs text-slate-300">
+                  {address}
+                </span>
+                <span className="ml-auto shrink-0 text-xs text-slate-500">
+                  {copied ? "Copied!" : "Copy"}
+                </span>
+              </button>
             </div>
           </div>
         </div>
-      </div>
 
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-1">
-        <MetricTile
-          icon={BadgeCheck}
-          label="Owned licenses"
-          value={purchasedCount}
-        />
-        <MetricTile icon={PanelTopOpen} label="Created prompts" value={createdCount} />
-        <MetricTile icon={CheckCircle2} label="Active listings" value={activeCount} />
-        <MetricTile
-          icon={Wallet}
-          label="Wallet balance"
-          value={isBalanceLoading ? "Loading" : `${balanceLabel} XLM`}
-        />
+        {/* Stats strip */}
+        <div className="grid grid-cols-2 divide-x divide-y divide-white/[0.06] border-t border-white/[0.06] sm:grid-cols-4 sm:divide-y-0">
+          {[
+            { icon: BadgeCheck, label: "Owned licenses", value: purchasedCount },
+            { icon: PanelTopOpen, label: "Created prompts", value: createdCount },
+            { icon: CheckCircle2, label: "Active listings", value: activeCount },
+            {
+              icon: Wallet,
+              label: "Balance",
+              value: isBalanceLoading ? "—" : `${balanceLabel} XLM`,
+            },
+          ].map(({ icon: Icon, label, value }) => (
+            <div key={label} className="flex flex-col gap-1.5 px-6 py-5">
+              <div className="flex items-center gap-2">
+                <Icon className="h-3.5 w-3.5 text-cyan-200" />
+                <p className="text-xs uppercase tracking-[0.14em] text-slate-500">
+                  {label}
+                </p>
+              </div>
+              <p className="text-2xl font-semibold tabular-nums text-white">{value}</p>
+            </div>
+          ))}
+        </div>
       </div>
     </section>
-  );
-}
-
-function LoadingState({ label }: { label: string }) {
-  return (
-    <div className="flex min-h-56 items-center justify-center rounded-lg border border-white/10 bg-white/[0.035] p-8 text-sm text-slate-300">
-      <Loader2 className="mr-2 h-4 w-4 animate-spin text-cyan-200" />
-      {label}
-    </div>
-  );
-}
-
-function EmptyState({
-  icon: Icon,
-  title,
-  body,
-  action,
-}: {
-  icon: LucideIcon;
-  title: string;
-  body: string;
-  action: { label: string; to: string; icon: LucideIcon };
-}) {
-  const ActionIcon = action.icon;
-
-  return (
-    <div className="grid min-h-72 place-items-center rounded-lg border border-dashed border-white/15 bg-white/[0.03] p-8 text-center">
-      <div className="max-w-md">
-        <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-lg bg-cyan-200/10 text-cyan-100">
-          <Icon className="h-7 w-7" />
-        </div>
-        <h3 className="mt-5 text-xl font-semibold text-white">{title}</h3>
-        <p className="mt-3 text-sm leading-7 text-slate-400">{body}</p>
-        <Button
-          asChild
-          className="mt-6 bg-cyan-200 text-slate-950 hover:bg-cyan-100"
-        >
-          <Link to={action.to}>
-            <ActionIcon className="h-4 w-4" />
-            {action.label}
-          </Link>
-        </Button>
-      </div>
-    </div>
   );
 }
 
@@ -305,87 +351,116 @@ function PurchasedPromptCard({
   const isUnlocked = Boolean(plaintext);
 
   return (
-    <article className="grid overflow-hidden rounded-lg border border-white/10 bg-[#11161a] md:grid-cols-[15rem_1fr]">
-      <img
-        src={prompt.imageUrl || promptImageFallback}
-        alt={prompt.title}
-        className="h-52 w-full object-cover md:h-full"
-      />
-      <div className="min-w-0 p-5">
-        <div className="flex flex-wrap items-center gap-2">
-          <Badge className="border-cyan-200/30 bg-cyan-200/10 text-cyan-100">
-            <BookOpenCheck className="mr-1 h-3.5 w-3.5" />
-            License owned
-          </Badge>
-          <Badge className="border-white/10 bg-white/[0.04] text-slate-300">
-            {prompt.category}
-          </Badge>
-          <Badge
-            className={
-              isUnlocked
-                ? "border-emerald-300/30 bg-emerald-300/10 text-emerald-100"
-                : "border-amber-300/30 bg-amber-300/10 text-amber-100"
-            }
-          >
-            {isUnlocked ? "Unlocked now" : "Wallet unlock needed"}
-          </Badge>
-        </div>
-
-        <div className="mt-4 grid gap-4 lg:grid-cols-[1fr_auto]">
-          <div className="min-w-0">
-            <h3 className="text-2xl font-semibold text-white">{prompt.title}</h3>
-            <p className="mt-3 line-clamp-3 text-sm leading-7 text-slate-300">
-              {prompt.previewText}
-            </p>
-          </div>
-          <div className="rounded-lg border border-white/10 bg-white/[0.04] p-3 text-sm lg:min-w-40">
-            <p className="text-xs uppercase tracking-[0.18em] text-slate-500">
-              Paid access
-            </p>
-            <p className="mt-2 font-semibold text-white">
-              {formatPriceLabel(prompt.priceStroops)}
-            </p>
+    <article className="overflow-hidden rounded-xl border border-white/10 bg-[#0f1419] transition-colors hover:border-white/[0.18]">
+      <div className="grid md:grid-cols-[14rem_1fr]">
+        {/* Prompt image */}
+        <div className="relative h-52 md:h-auto">
+          <img
+            src={prompt.imageUrl || promptImageFallback}
+            alt={prompt.title}
+            className="h-full w-full object-cover"
+          />
+          {/* Mobile-only access state pill */}
+          <div className="absolute bottom-3 left-3 md:hidden">
+            <span
+              className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium backdrop-blur-sm ${
+                isUnlocked
+                  ? "bg-emerald-400/25 text-emerald-200 ring-1 ring-emerald-400/20"
+                  : "bg-amber-400/25 text-amber-200 ring-1 ring-amber-400/20"
+              }`}
+            >
+              {isUnlocked ? (
+                <Eye className="h-3 w-3" />
+              ) : (
+                <LockKeyhole className="h-3 w-3" />
+              )}
+              {isUnlocked ? "Unlocked" : "Locked"}
+            </span>
           </div>
         </div>
 
-        <div className="mt-5 flex flex-wrap items-center gap-3">
-          <Button
-            className="bg-cyan-200 text-slate-950 hover:bg-cyan-100"
-            onClick={() => onUnlock(prompt.id)}
-            disabled={isBusy}
-          >
-            {isBusy ? (
-              <>
-                <Loader2 className="h-4 w-4 animate-spin" />
-                Unlocking
-              </>
-            ) : (
-              <>
-                {isUnlocked ? (
-                  <Eye className="h-4 w-4" />
-                ) : (
-                  <LockKeyhole className="h-4 w-4" />
-                )}
-                {isUnlocked ? "Re-open prompt" : "Unlock full prompt"}
-              </>
-            )}
-          </Button>
-          <p className="text-xs text-slate-500">
-            Hash {shortHash(prompt.contentHash)}
-          </p>
-        </div>
+        <div className="min-w-0 p-5 md:p-6">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge className="border-cyan-200/30 bg-cyan-200/10 text-cyan-100">
+              <BookOpenCheck className="mr-1 h-3.5 w-3.5" />
+              License owned
+            </Badge>
+            <Badge className="border-white/10 bg-white/[0.04] text-slate-300">
+              {prompt.category}
+            </Badge>
+            <Badge
+              className={`hidden md:inline-flex ${
+                isUnlocked
+                  ? "border-emerald-300/30 bg-emerald-300/10 text-emerald-100"
+                  : "border-amber-300/30 bg-amber-300/10 text-amber-100"
+              }`}
+            >
+              {isUnlocked ? (
+                <Eye className="mr-1 h-3.5 w-3.5" />
+              ) : (
+                <LockKeyhole className="mr-1 h-3.5 w-3.5" />
+              )}
+              {isUnlocked ? "Unlocked" : "Wallet unlock needed"}
+            </Badge>
+          </div>
 
-        {plaintext ? (
-          <div className="mt-5 rounded-lg border border-emerald-300/20 bg-emerald-300/10 p-4">
-            <div className="mb-3 flex items-center gap-2 text-xs uppercase tracking-[0.18em] text-emerald-100">
-              <ShieldCheck className="h-4 w-4" />
-              Unlocked content
+          <div className="mt-4 grid gap-4 xl:grid-cols-[1fr_10rem]">
+            <div className="min-w-0">
+              <h3 className="text-xl font-semibold text-white">{prompt.title}</h3>
+              <p className="mt-2 line-clamp-2 text-sm leading-7 text-slate-400">
+                {prompt.previewText}
+              </p>
             </div>
-            <pre className="max-h-72 overflow-auto whitespace-pre-wrap text-sm leading-7 text-slate-100">
-              {plaintext}
-            </pre>
+            <div className="rounded-lg border border-white/10 bg-white/[0.03] p-3">
+              <p className="text-xs uppercase tracking-[0.14em] text-slate-500">
+                Paid access
+              </p>
+              <p className="mt-1.5 text-lg font-semibold text-white">
+                {formatPriceLabel(prompt.priceStroops)}
+              </p>
+            </div>
           </div>
-        ) : null}
+
+          <div className="mt-5 flex flex-wrap items-center gap-3">
+            <Button
+              className="h-10 bg-cyan-200 text-slate-950 hover:bg-cyan-100 disabled:opacity-50"
+              onClick={() => onUnlock(prompt.id)}
+              disabled={isBusy}
+            >
+              {isBusy ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Unlocking...
+                </>
+              ) : isUnlocked ? (
+                <>
+                  <Eye className="h-4 w-4" />
+                  Re-open prompt
+                </>
+              ) : (
+                <>
+                  <LockKeyhole className="h-4 w-4" />
+                  Unlock full prompt
+                </>
+              )}
+            </Button>
+            <p className="font-mono text-xs text-slate-600">
+              {shortHash(prompt.contentHash)}
+            </p>
+          </div>
+
+          {plaintext ? (
+            <div className="mt-5 rounded-xl border border-emerald-300/20 bg-emerald-300/[0.07] p-5">
+              <div className="mb-3 flex items-center gap-2 text-xs font-medium uppercase tracking-[0.14em] text-emerald-200">
+                <ShieldCheck className="h-4 w-4" />
+                Unlocked content
+              </div>
+              <pre className="max-h-72 overflow-auto whitespace-pre-wrap text-sm leading-7 text-slate-100">
+                {plaintext}
+              </pre>
+            </div>
+          ) : null}
+        </div>
       </div>
     </article>
   );
@@ -406,23 +481,31 @@ function CreatedPromptCard({
   onUpdatePrice: Handler<[bigint]>;
   onToggleStatus: Handler<[bigint, boolean]>;
 }) {
+  const isActive = prompt.active;
+
   return (
-    <article className="rounded-lg border border-white/10 bg-[#11161a] p-5">
-      <div className="grid gap-5 lg:grid-cols-[10rem_1fr]">
+    <article className="overflow-hidden rounded-xl border border-white/10 bg-[#0f1419] transition-colors hover:border-white/[0.18]">
+      <div className="grid lg:grid-cols-[10rem_1fr]">
         <img
           src={prompt.imageUrl || promptImageFallback}
           alt={prompt.title}
-          className="aspect-video w-full rounded-lg object-cover lg:aspect-square"
+          className="h-48 w-full object-cover lg:h-full"
         />
-        <div className="min-w-0">
+        <div className="min-w-0 p-5 md:p-6">
           <div className="flex flex-wrap items-center gap-2">
-            <Badge className={statusBadgeClass(prompt.active)}>
-              {prompt.active ? (
+            <Badge
+              className={
+                isActive
+                  ? "border-emerald-300/30 bg-emerald-300/10 text-emerald-100"
+                  : "border-amber-300/30 bg-amber-300/10 text-amber-100"
+              }
+            >
+              {isActive ? (
                 <CheckCircle2 className="mr-1 h-3.5 w-3.5" />
               ) : (
                 <PauseCircle className="mr-1 h-3.5 w-3.5" />
               )}
-              {prompt.active ? "Active listing" : "Paused listing"}
+              {isActive ? "Active listing" : "Paused listing"}
             </Badge>
             <Badge className="border-white/10 bg-white/[0.04] text-slate-300">
               {prompt.category}
@@ -431,62 +514,65 @@ function CreatedPromptCard({
 
           <div className="mt-4 grid gap-4 xl:grid-cols-[1fr_auto]">
             <div className="min-w-0">
-              <h3 className="text-2xl font-semibold text-white">{prompt.title}</h3>
-              <p className="mt-3 line-clamp-3 text-sm leading-7 text-slate-300">
+              <h3 className="text-xl font-semibold text-white">{prompt.title}</h3>
+              <p className="mt-2 line-clamp-2 text-sm leading-7 text-slate-400">
                 {prompt.previewText}
               </p>
             </div>
-            <div className="grid grid-cols-2 gap-3 text-sm xl:w-72">
-              <div className="rounded-lg border border-white/10 bg-white/[0.04] p-3">
-                <p className="text-xs uppercase tracking-[0.18em] text-slate-500">
+            <div className="flex gap-3 text-sm xl:w-60">
+              <div className="flex-1 rounded-lg border border-white/10 bg-white/[0.03] p-3">
+                <p className="text-xs uppercase tracking-[0.14em] text-slate-500">
                   Sales
                 </p>
-                <p className="mt-2 text-lg font-semibold text-white">
+                <p className="mt-1.5 text-xl font-semibold text-white">
                   {prompt.salesCount}
                 </p>
               </div>
-              <div className="rounded-lg border border-white/10 bg-white/[0.04] p-3">
-                <p className="text-xs uppercase tracking-[0.18em] text-slate-500">
+              <div className="flex-1 rounded-lg border border-white/10 bg-white/[0.03] p-3">
+                <p className="text-xs uppercase tracking-[0.14em] text-slate-500">
                   Price
                 </p>
-                <p className="mt-2 text-lg font-semibold text-white">
+                <p className="mt-1.5 text-xl font-semibold text-white">
                   {formatPriceLabel(prompt.priceStroops)}
                 </p>
               </div>
             </div>
           </div>
 
-          <div className="mt-5 grid gap-3 md:grid-cols-[minmax(0,14rem)_auto_auto] md:items-center">
-            <Input
-              value={priceDraft}
-              onChange={(event) => onDraftChange(event.target.value)}
-              className="h-10 border-white/10 bg-white/[0.04] text-slate-100"
-              aria-label={`Price in XLM for ${prompt.title}`}
-            />
-            <Button
-              className="bg-cyan-200 text-slate-950 hover:bg-cyan-100"
-              onClick={() => onUpdatePrice(prompt.id)}
-              disabled={isBusy}
-            >
-              {isBusy ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <PencilLine className="h-4 w-4" />
-              )}
-              Update price
-            </Button>
+          <div className="mt-5 flex flex-wrap items-center gap-3">
+            <div className="flex flex-1 items-center gap-2">
+              <Input
+                value={priceDraft}
+                onChange={(event) => onDraftChange(event.target.value)}
+                className="h-10 min-w-0 max-w-[10rem] border-white/10 bg-white/[0.04] text-slate-100"
+                placeholder="Price in XLM"
+                aria-label={`Price in XLM for ${prompt.title}`}
+              />
+              <Button
+                className="h-10 shrink-0 bg-amber-300 text-slate-950 hover:bg-amber-200 disabled:opacity-50"
+                onClick={() => onUpdatePrice(prompt.id)}
+                disabled={isBusy}
+              >
+                {isBusy ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <PencilLine className="h-4 w-4" />
+                )}
+                Update price
+              </Button>
+            </div>
             <Button
               variant="outline"
-              className="border-white/15 bg-white/[0.03] text-white hover:bg-white/10"
+              className="h-10 shrink-0 border-white/15 bg-white/[0.03] text-white hover:bg-white/10 disabled:opacity-50"
               onClick={() => onToggleStatus(prompt.id, prompt.active)}
               disabled={isBusy}
             >
-              {prompt.active ? (
+              {isActive ? (
                 <CircleOff className="h-4 w-4" />
               ) : (
                 <ArrowUpRight className="h-4 w-4" />
               )}
-              {prompt.active ? "Pause listing" : "Reactivate"}
+              {isActive ? "Pause listing" : "Reactivate"}
             </Button>
           </div>
         </div>
@@ -523,7 +609,7 @@ export default function ProfilePage() {
 
   const createdPrompts = createdQuery.data ?? [];
   const purchasedPrompts = purchasedQuery.data ?? [];
-  const activeListingCount = createdPrompts.filter((prompt) => prompt.active).length;
+  const activeListingCount = createdPrompts.filter((p) => p.active).length;
 
   const mergedDrafts = useMemo(() => {
     return Object.fromEntries(
@@ -552,7 +638,6 @@ export default function ProfilePage() {
       updateError("Connect a wallet before changing prompt status.");
       return;
     }
-
     setBusyPromptId(promptId.toString());
     try {
       await setPromptSaleStatus(
@@ -578,7 +663,6 @@ export default function ProfilePage() {
       updateError("Connect a wallet before updating prompt prices.");
       return;
     }
-
     setBusyPromptId(promptId.toString());
     try {
       const nextPrice = xlmToStroops(mergedDrafts[promptId.toString()]);
@@ -592,7 +676,9 @@ export default function ProfilePage() {
       updateStatus("Prompt price updated.");
       await refreshPromptLists();
     } catch (error) {
-      updateError(error instanceof Error ? error.message : "Failed to update price.");
+      updateError(
+        error instanceof Error ? error.message : "Failed to update price.",
+      );
     } finally {
       setBusyPromptId(null);
     }
@@ -603,7 +689,6 @@ export default function ProfilePage() {
       updateError("Connect a wallet with SEP-43 message signing to unlock prompts.");
       return;
     }
-
     setBusyPromptId(promptId.toString());
     try {
       const response = await unlockPromptContent(address, promptId, signMessage);
@@ -613,14 +698,16 @@ export default function ProfilePage() {
       }));
       updateStatus("Prompt unlocked. You can re-open it from this library.");
     } catch (error) {
-      updateError(error instanceof Error ? error.message : "Failed to unlock prompt.");
+      updateError(
+        error instanceof Error ? error.message : "Failed to unlock prompt.",
+      );
     } finally {
       setBusyPromptId(null);
     }
   };
 
   return (
-    <div className="min-h-screen bg-[radial-gradient(circle_at_15%_0%,rgba(45,212,191,0.18),transparent_30%),radial-gradient(circle_at_88%_12%,rgba(245,158,11,0.12),transparent_28%),linear-gradient(180deg,#090c0f_0%,#111827_46%,#080b0f_100%)] text-white">
+    <div className="min-h-screen bg-[radial-gradient(ellipse_60%_40%_at_0%_0%,rgba(34,211,238,0.1),transparent),radial-gradient(ellipse_50%_30%_at_100%_5%,rgba(251,191,36,0.07),transparent),linear-gradient(180deg,#080b0f_0%,#0d1117_50%,#080b0f_100%)] text-white">
       <Navigation />
       <main className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:py-10">
         {!address ? (
@@ -646,56 +733,58 @@ export default function ProfilePage() {
               ) : null}
             </div>
 
-            <section className="mt-8">
-              <Tabs defaultValue="purchased" className="space-y-5">
-                <div className="flex flex-col gap-4 border-b border-white/10 pb-4 lg:flex-row lg:items-end lg:justify-between">
-                  <div>
-                    <p className="text-sm uppercase tracking-[0.24em] text-cyan-200">
-                      Prompt access
-                    </p>
-                    <h2 className="mt-2 text-3xl font-semibold text-white">
-                      Library and inventory
-                    </h2>
-                    <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-400">
-                      Purchased prompts are optimized for re-entry and unlock.
-                      Created prompts stay focused on listing control.
-                    </p>
-                  </div>
-                  <TabsList className="grid h-auto w-full grid-cols-2 rounded-lg border border-white/10 bg-white/[0.04] p-1 lg:w-[28rem]">
-                    <TabsTrigger
-                      value="purchased"
-                      className="rounded-md px-3 py-2 text-slate-300 data-[state=active]:bg-cyan-200 data-[state=active]:text-slate-950"
-                    >
-                      Purchased
-                      <span className="ml-2 rounded bg-slate-950/10 px-1.5 py-0.5 text-xs">
-                        {purchasedPrompts.length}
-                      </span>
-                    </TabsTrigger>
-                    <TabsTrigger
-                      value="created"
-                      className="rounded-md px-3 py-2 text-slate-300 data-[state=active]:bg-cyan-200 data-[state=active]:text-slate-950"
-                    >
-                      Created
-                      <span className="ml-2 rounded bg-slate-950/10 px-1.5 py-0.5 text-xs">
-                        {createdPrompts.length}
-                      </span>
-                    </TabsTrigger>
-                  </TabsList>
+            <section className="mt-10">
+              <Tabs defaultValue="purchased" className="space-y-0">
+                <div className="mb-6">
+                  <p className="text-xs uppercase tracking-[0.24em] text-cyan-200">
+                    Prompt access
+                  </p>
+                  <h2 className="mt-2 text-3xl font-semibold text-white">
+                    Library &amp; Inventory
+                  </h2>
+                  <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-400">
+                    Licensed prompts are optimized for re-entry and unlock. Created
+                    prompts stay focused on listing control.
+                  </p>
                 </div>
+
+                <TabsList className="mb-6 grid h-auto w-full grid-cols-2 rounded-xl border border-white/10 bg-white/[0.03] p-1.5 sm:w-[34rem]">
+                  <TabsTrigger
+                    value="purchased"
+                    className="flex items-center gap-2 rounded-lg px-4 py-2.5 text-slate-400 transition-all data-[state=active]:bg-cyan-200 data-[state=active]:text-slate-950 data-[state=active]:shadow-sm"
+                  >
+                    <LibraryBig className="h-4 w-4" />
+                    My Library
+                    <span className="ml-1 rounded-full bg-slate-950/10 px-1.5 py-0.5 text-xs">
+                      {purchasedPrompts.length}
+                    </span>
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="created"
+                    className="flex items-center gap-2 rounded-lg px-4 py-2.5 text-slate-400 transition-all data-[state=active]:bg-amber-300 data-[state=active]:text-slate-950 data-[state=active]:shadow-sm"
+                  >
+                    <Boxes className="h-4 w-4" />
+                    My Inventory
+                    <span className="ml-1 rounded-full bg-slate-950/10 px-1.5 py-0.5 text-xs">
+                      {createdPrompts.length}
+                    </span>
+                  </TabsTrigger>
+                </TabsList>
 
                 <TabsContent value="purchased" className="mt-0 space-y-4">
                   {purchasedQuery.isLoading ? (
-                    <LoadingState label="Loading purchased prompt licenses..." />
+                    <LoadingState label="Loading your licensed prompts..." />
                   ) : purchasedPrompts.length === 0 ? (
                     <EmptyState
                       icon={LibraryBig}
-                      title="No purchased prompts yet"
+                      title="Your library is empty"
                       body="When this wallet buys access, prompts appear here with a direct unlock path back to the protected content."
                       action={{
                         label: "Browse marketplace",
                         to: "/browse",
                         icon: ShoppingBag,
                       }}
+                      accent="cyan"
                     />
                   ) : (
                     <div className="space-y-4">
@@ -714,17 +803,18 @@ export default function ProfilePage() {
 
                 <TabsContent value="created" className="mt-0 space-y-4">
                   {createdQuery.isLoading ? (
-                    <LoadingState label="Loading creator inventory..." />
+                    <LoadingState label="Loading your creator inventory..." />
                   ) : createdPrompts.length === 0 ? (
                     <EmptyState
                       icon={Boxes}
-                      title="No creator inventory for this wallet"
-                      body="Create your first encrypted prompt listing to see pricing controls, sales count, and active or paused listing states here."
+                      title="No creator inventory"
+                      body="Create your first encrypted prompt listing to see pricing controls, sales counts, and listing states here."
                       action={{
                         label: "Create listing",
                         to: "/sell",
                         icon: ArrowUpRight,
                       }}
+                      accent="amber"
                     />
                   ) : (
                     <div className="space-y-4">

--- a/src/pages/profile/page.tsx
+++ b/src/pages/profile/page.tsx
@@ -1,27 +1,758 @@
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  ArrowUpRight,
+  BadgeCheck,
+  BookOpenCheck,
+  Boxes,
+  CheckCircle2,
+  CircleOff,
+  Copy,
+  Eye,
+  KeyRound,
+  LibraryBig,
+  Loader2,
+  LockKeyhole,
+  PanelTopOpen,
+  PauseCircle,
+  PencilLine,
+  PlugZap,
+  RadioTower,
+  ShieldCheck,
+  ShoppingBag,
+  Wallet,
+  type LucideIcon,
+} from "lucide-react";
 import { Footer } from "@/components/footer";
 import { Navigation } from "@/components/navigation";
-import MyPrompts from "@/pages/sell/MyPrompts";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useWallet } from "@/hooks/useWallet";
+import { useWalletBalance } from "@/hooks/useWalletBalance";
+import { invalidateAllPromptQueries } from "@/hooks/useContractSync";
+import { browserStellarConfig } from "@/lib/stellar/browserConfig";
+import {
+  getPromptsByBuyer,
+  getPromptsByCreator,
+  setPromptSaleStatus,
+  updatePromptPrice,
+  type PromptRecord,
+} from "@/lib/stellar/promptHashClient";
+import {
+  formatPriceLabel,
+  stroopsToXlmString,
+  xlmToStroops,
+} from "@/lib/stellar/format";
+import { unlockPromptContent } from "@/lib/prompts/unlock";
+import { shortenAddress } from "@/lib/utils";
+import { stellarNetwork } from "@/lib/env";
+import { connectWallet } from "@/util/wallet";
+
+const promptImageFallback = "/images/codeguru.png";
+
+const formatNetworkName = (value?: string) => {
+  if (!value) return "Not connected";
+  return value.charAt(0).toUpperCase() + value.slice(1).toLowerCase();
+};
+
+const shortHash = (value: string) =>
+  value ? `${value.slice(0, 8)}...${value.slice(-8)}` : "Pending";
+
+const statusBadgeClass = (isActive: boolean) =>
+  isActive
+    ? "border-emerald-300/30 bg-emerald-300/10 text-emerald-100"
+    : "border-amber-300/30 bg-amber-300/10 text-amber-100";
+
+// eslint-disable-next-line no-unused-vars
+type Handler<TArgs extends unknown[]> = (...args: TArgs) => void;
+
+function AlertBanner({
+  tone,
+  message,
+}: {
+  tone: "success" | "error";
+  message: string;
+}) {
+  return (
+    <div
+      className={
+        tone === "success"
+          ? "rounded-lg border border-emerald-300/25 bg-emerald-300/10 px-4 py-3 text-sm text-emerald-100"
+          : "rounded-lg border border-rose-300/25 bg-rose-400/10 px-4 py-3 text-sm text-rose-100"
+      }
+    >
+      {message}
+    </div>
+  );
+}
+
+function MetricTile({
+  label,
+  value,
+  icon: Icon,
+}: {
+  label: string;
+  value: string | number;
+  icon: LucideIcon;
+}) {
+  return (
+    <div className="rounded-lg border border-white/10 bg-white/[0.04] p-4">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+          {label}
+        </p>
+        <Icon className="h-4 w-4 text-cyan-200" />
+      </div>
+      <p className="mt-3 text-2xl font-semibold text-white">{value}</p>
+    </div>
+  );
+}
+
+function DisconnectedProfile() {
+  return (
+    <section className="grid gap-6 py-10 lg:grid-cols-[1.1fr_0.9fr] lg:items-stretch">
+      <div className="rounded-lg border border-white/10 bg-[#101417] p-6 shadow-[0_28px_80px_-54px_rgba(45,212,191,0.7)] md:p-8">
+        <Badge className="border-cyan-200/30 bg-cyan-200/10 text-cyan-100">
+          Wallet required
+        </Badge>
+        <h1 className="mt-6 max-w-3xl text-4xl font-semibold leading-tight text-white md:text-5xl">
+          Your prompt library starts with a Stellar wallet.
+        </h1>
+        <p className="mt-4 max-w-2xl text-sm leading-7 text-slate-300">
+          Connect to see licensed prompts you can reopen, creator inventory you
+          control, and listing states tied to your wallet identity.
+        </p>
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+          <Button
+            className="bg-cyan-200 text-slate-950 hover:bg-cyan-100"
+            onClick={() => void connectWallet()}
+          >
+            <PlugZap className="h-4 w-4" />
+            Connect wallet
+          </Button>
+          <Button
+            asChild
+            variant="outline"
+            className="border-white/15 bg-white/[0.03] text-white hover:bg-white/10"
+          >
+            <Link to="/browse">
+              <ShoppingBag className="h-4 w-4" />
+              Browse prompts
+            </Link>
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-4 rounded-lg border border-white/10 bg-white/[0.035] p-5">
+        {[
+          {
+            icon: KeyRound,
+            title: "Purchased licenses",
+            body: "Unlocked access is grouped separately from creator listings.",
+          },
+          {
+            icon: Boxes,
+            title: "Creator inventory",
+            body: "Pricing, sales count, and listing status stay in their own lane.",
+          },
+          {
+            icon: ShieldCheck,
+            title: "Wallet-authenticated re-entry",
+            body: "Full prompt text appears only after the wallet signs an unlock request.",
+          },
+        ].map((item) => (
+          <div
+            key={item.title}
+            className="grid grid-cols-[2.5rem_1fr] gap-4 rounded-lg bg-slate-950/45 p-4"
+          >
+            <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-cyan-200/10 text-cyan-100">
+              <item.icon className="h-5 w-5" />
+            </div>
+            <div>
+              <h2 className="font-medium text-white">{item.title}</h2>
+              <p className="mt-1 text-sm leading-6 text-slate-400">{item.body}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function WalletIdentityPanel({
+  address,
+  network,
+  balanceLabel,
+  isBalanceLoading,
+  purchasedCount,
+  createdCount,
+  activeCount,
+}: {
+  address: string;
+  network?: string;
+  balanceLabel: string;
+  isBalanceLoading: boolean;
+  purchasedCount: number;
+  createdCount: number;
+  activeCount: number;
+}) {
+  return (
+    <section className="grid gap-6 py-8 lg:grid-cols-[1.15fr_0.85fr]">
+      <div className="rounded-lg border border-white/10 bg-[#101417] p-6 shadow-[0_28px_80px_-54px_rgba(56,189,248,0.65)] md:p-8">
+        <div className="flex flex-wrap items-center gap-3">
+          <Badge className="border-cyan-200/30 bg-cyan-200/10 text-cyan-100">
+            Wallet profile
+          </Badge>
+          <Badge className="border-white/10 bg-white/[0.04] text-slate-200">
+            <RadioTower className="mr-1 h-3.5 w-3.5" />
+            {formatNetworkName(network ?? stellarNetwork)}
+          </Badge>
+        </div>
+
+        <div className="mt-7 grid gap-5 lg:grid-cols-[auto_1fr] lg:items-center">
+          <div className="flex h-20 w-20 items-center justify-center rounded-lg border border-cyan-200/20 bg-cyan-200/10 text-cyan-100">
+            <Wallet className="h-9 w-9" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-sm text-slate-400">Connected identity</p>
+            <h1 className="mt-2 text-3xl font-semibold text-white md:text-5xl">
+              {shortenAddress(address)}
+            </h1>
+            <div className="mt-4 flex min-w-0 items-center gap-2 rounded-lg border border-white/10 bg-slate-950/60 px-3 py-2 text-xs text-slate-300">
+              <Copy className="h-3.5 w-3.5 shrink-0 text-cyan-200" />
+              <span className="min-w-0 truncate font-mono">{address}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-1">
+        <MetricTile
+          icon={BadgeCheck}
+          label="Owned licenses"
+          value={purchasedCount}
+        />
+        <MetricTile icon={PanelTopOpen} label="Created prompts" value={createdCount} />
+        <MetricTile icon={CheckCircle2} label="Active listings" value={activeCount} />
+        <MetricTile
+          icon={Wallet}
+          label="Wallet balance"
+          value={isBalanceLoading ? "Loading" : `${balanceLabel} XLM`}
+        />
+      </div>
+    </section>
+  );
+}
+
+function LoadingState({ label }: { label: string }) {
+  return (
+    <div className="flex min-h-56 items-center justify-center rounded-lg border border-white/10 bg-white/[0.035] p-8 text-sm text-slate-300">
+      <Loader2 className="mr-2 h-4 w-4 animate-spin text-cyan-200" />
+      {label}
+    </div>
+  );
+}
+
+function EmptyState({
+  icon: Icon,
+  title,
+  body,
+  action,
+}: {
+  icon: LucideIcon;
+  title: string;
+  body: string;
+  action: { label: string; to: string; icon: LucideIcon };
+}) {
+  const ActionIcon = action.icon;
+
+  return (
+    <div className="grid min-h-72 place-items-center rounded-lg border border-dashed border-white/15 bg-white/[0.03] p-8 text-center">
+      <div className="max-w-md">
+        <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-lg bg-cyan-200/10 text-cyan-100">
+          <Icon className="h-7 w-7" />
+        </div>
+        <h3 className="mt-5 text-xl font-semibold text-white">{title}</h3>
+        <p className="mt-3 text-sm leading-7 text-slate-400">{body}</p>
+        <Button
+          asChild
+          className="mt-6 bg-cyan-200 text-slate-950 hover:bg-cyan-100"
+        >
+          <Link to={action.to}>
+            <ActionIcon className="h-4 w-4" />
+            {action.label}
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function PurchasedPromptCard({
+  prompt,
+  isBusy,
+  plaintext,
+  onUnlock,
+}: {
+  prompt: PromptRecord;
+  isBusy: boolean;
+  plaintext?: string;
+  onUnlock: Handler<[bigint]>;
+}) {
+  const isUnlocked = Boolean(plaintext);
+
+  return (
+    <article className="grid overflow-hidden rounded-lg border border-white/10 bg-[#11161a] md:grid-cols-[15rem_1fr]">
+      <img
+        src={prompt.imageUrl || promptImageFallback}
+        alt={prompt.title}
+        className="h-52 w-full object-cover md:h-full"
+      />
+      <div className="min-w-0 p-5">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge className="border-cyan-200/30 bg-cyan-200/10 text-cyan-100">
+            <BookOpenCheck className="mr-1 h-3.5 w-3.5" />
+            License owned
+          </Badge>
+          <Badge className="border-white/10 bg-white/[0.04] text-slate-300">
+            {prompt.category}
+          </Badge>
+          <Badge
+            className={
+              isUnlocked
+                ? "border-emerald-300/30 bg-emerald-300/10 text-emerald-100"
+                : "border-amber-300/30 bg-amber-300/10 text-amber-100"
+            }
+          >
+            {isUnlocked ? "Unlocked now" : "Wallet unlock needed"}
+          </Badge>
+        </div>
+
+        <div className="mt-4 grid gap-4 lg:grid-cols-[1fr_auto]">
+          <div className="min-w-0">
+            <h3 className="text-2xl font-semibold text-white">{prompt.title}</h3>
+            <p className="mt-3 line-clamp-3 text-sm leading-7 text-slate-300">
+              {prompt.previewText}
+            </p>
+          </div>
+          <div className="rounded-lg border border-white/10 bg-white/[0.04] p-3 text-sm lg:min-w-40">
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-500">
+              Paid access
+            </p>
+            <p className="mt-2 font-semibold text-white">
+              {formatPriceLabel(prompt.priceStroops)}
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-5 flex flex-wrap items-center gap-3">
+          <Button
+            className="bg-cyan-200 text-slate-950 hover:bg-cyan-100"
+            onClick={() => onUnlock(prompt.id)}
+            disabled={isBusy}
+          >
+            {isBusy ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Unlocking
+              </>
+            ) : (
+              <>
+                {isUnlocked ? (
+                  <Eye className="h-4 w-4" />
+                ) : (
+                  <LockKeyhole className="h-4 w-4" />
+                )}
+                {isUnlocked ? "Re-open prompt" : "Unlock full prompt"}
+              </>
+            )}
+          </Button>
+          <p className="text-xs text-slate-500">
+            Hash {shortHash(prompt.contentHash)}
+          </p>
+        </div>
+
+        {plaintext ? (
+          <div className="mt-5 rounded-lg border border-emerald-300/20 bg-emerald-300/10 p-4">
+            <div className="mb-3 flex items-center gap-2 text-xs uppercase tracking-[0.18em] text-emerald-100">
+              <ShieldCheck className="h-4 w-4" />
+              Unlocked content
+            </div>
+            <pre className="max-h-72 overflow-auto whitespace-pre-wrap text-sm leading-7 text-slate-100">
+              {plaintext}
+            </pre>
+          </div>
+        ) : null}
+      </div>
+    </article>
+  );
+}
+
+function CreatedPromptCard({
+  prompt,
+  isBusy,
+  priceDraft,
+  onDraftChange,
+  onUpdatePrice,
+  onToggleStatus,
+}: {
+  prompt: PromptRecord;
+  isBusy: boolean;
+  priceDraft: string;
+  onDraftChange: Handler<[string]>;
+  onUpdatePrice: Handler<[bigint]>;
+  onToggleStatus: Handler<[bigint, boolean]>;
+}) {
+  return (
+    <article className="rounded-lg border border-white/10 bg-[#11161a] p-5">
+      <div className="grid gap-5 lg:grid-cols-[10rem_1fr]">
+        <img
+          src={prompt.imageUrl || promptImageFallback}
+          alt={prompt.title}
+          className="aspect-video w-full rounded-lg object-cover lg:aspect-square"
+        />
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge className={statusBadgeClass(prompt.active)}>
+              {prompt.active ? (
+                <CheckCircle2 className="mr-1 h-3.5 w-3.5" />
+              ) : (
+                <PauseCircle className="mr-1 h-3.5 w-3.5" />
+              )}
+              {prompt.active ? "Active listing" : "Paused listing"}
+            </Badge>
+            <Badge className="border-white/10 bg-white/[0.04] text-slate-300">
+              {prompt.category}
+            </Badge>
+          </div>
+
+          <div className="mt-4 grid gap-4 xl:grid-cols-[1fr_auto]">
+            <div className="min-w-0">
+              <h3 className="text-2xl font-semibold text-white">{prompt.title}</h3>
+              <p className="mt-3 line-clamp-3 text-sm leading-7 text-slate-300">
+                {prompt.previewText}
+              </p>
+            </div>
+            <div className="grid grid-cols-2 gap-3 text-sm xl:w-72">
+              <div className="rounded-lg border border-white/10 bg-white/[0.04] p-3">
+                <p className="text-xs uppercase tracking-[0.18em] text-slate-500">
+                  Sales
+                </p>
+                <p className="mt-2 text-lg font-semibold text-white">
+                  {prompt.salesCount}
+                </p>
+              </div>
+              <div className="rounded-lg border border-white/10 bg-white/[0.04] p-3">
+                <p className="text-xs uppercase tracking-[0.18em] text-slate-500">
+                  Price
+                </p>
+                <p className="mt-2 text-lg font-semibold text-white">
+                  {formatPriceLabel(prompt.priceStroops)}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-5 grid gap-3 md:grid-cols-[minmax(0,14rem)_auto_auto] md:items-center">
+            <Input
+              value={priceDraft}
+              onChange={(event) => onDraftChange(event.target.value)}
+              className="h-10 border-white/10 bg-white/[0.04] text-slate-100"
+              aria-label={`Price in XLM for ${prompt.title}`}
+            />
+            <Button
+              className="bg-cyan-200 text-slate-950 hover:bg-cyan-100"
+              onClick={() => onUpdatePrice(prompt.id)}
+              disabled={isBusy}
+            >
+              {isBusy ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <PencilLine className="h-4 w-4" />
+              )}
+              Update price
+            </Button>
+            <Button
+              variant="outline"
+              className="border-white/15 bg-white/[0.03] text-white hover:bg-white/10"
+              onClick={() => onToggleStatus(prompt.id, prompt.active)}
+              disabled={isBusy}
+            >
+              {prompt.active ? (
+                <CircleOff className="h-4 w-4" />
+              ) : (
+                <ArrowUpRight className="h-4 w-4" />
+              )}
+              {prompt.active ? "Pause listing" : "Reactivate"}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}
 
 export default function ProfilePage() {
-  return (
-    <div className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.16),_transparent_30%),linear-gradient(180deg,_#020617,_#0f172a_45%,_#020617)] text-white">
-      <Navigation />
-      <main className="mx-auto max-w-7xl px-6 py-10">
-        <section className="rounded-[2rem] border border-white/10 bg-slate-950/60 p-8 shadow-[0_32px_120px_-64px_rgba(16,185,129,0.45)]">
-          <p className="text-sm uppercase tracking-[0.35em] text-emerald-300">
-            Wallet profile
-          </p>
-          <h1 className="mt-4 text-4xl font-semibold">My prompt licenses</h1>
-          <p className="mt-4 max-w-3xl text-sm leading-7 text-slate-300">
-            Manage listings you created and reopen prompts you purchased. This
-            page reads directly from the Stellar contract and uses the unlock API
-            only when you request the decrypted plaintext.
-          </p>
-        </section>
+  const queryClient = useQueryClient();
+  const { address, network, signMessage, signTransaction } = useWallet();
+  const { xlm, isLoading: isBalanceLoading } = useWalletBalance();
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [busyPromptId, setBusyPromptId] = useState<string | null>(null);
+  const [priceDrafts, setPriceDrafts] = useState<Record<string, string>>({});
+  const [unlockedPrompts, setUnlockedPrompts] = useState<Record<string, string>>(
+    {},
+  );
 
-        <section className="mt-10">
-          <MyPrompts />
-        </section>
+  const createdQuery = useQuery({
+    queryKey: ["created-prompts", address],
+    queryFn: async () =>
+      address ? getPromptsByCreator(browserStellarConfig, address) : [],
+    enabled: Boolean(address),
+  });
+
+  const purchasedQuery = useQuery({
+    queryKey: ["purchased-prompts", address],
+    queryFn: async () =>
+      address ? getPromptsByBuyer(browserStellarConfig, address) : [],
+    enabled: Boolean(address),
+  });
+
+  const createdPrompts = createdQuery.data ?? [];
+  const purchasedPrompts = purchasedQuery.data ?? [];
+  const activeListingCount = createdPrompts.filter((prompt) => prompt.active).length;
+
+  const mergedDrafts = useMemo(() => {
+    return Object.fromEntries(
+      createdPrompts.map((prompt) => [
+        prompt.id.toString(),
+        priceDrafts[prompt.id.toString()] ??
+          stroopsToXlmString(prompt.priceStroops),
+      ]),
+    );
+  }, [createdPrompts, priceDrafts]);
+
+  const refreshPromptLists = () => invalidateAllPromptQueries(queryClient);
+
+  const updateStatus = (message: string) => {
+    setErrorMessage(null);
+    setStatusMessage(message);
+  };
+
+  const updateError = (message: string) => {
+    setStatusMessage(null);
+    setErrorMessage(message);
+  };
+
+  const handleToggleSaleStatus = async (promptId: bigint, active: boolean) => {
+    if (!address || !signTransaction) {
+      updateError("Connect a wallet before changing prompt status.");
+      return;
+    }
+
+    setBusyPromptId(promptId.toString());
+    try {
+      await setPromptSaleStatus(
+        browserStellarConfig,
+        { signTransaction },
+        address,
+        promptId,
+        !active,
+      );
+      updateStatus(!active ? "Prompt listing reactivated." : "Prompt listing paused.");
+      await refreshPromptLists();
+    } catch (error) {
+      updateError(
+        error instanceof Error ? error.message : "Failed to update listing status.",
+      );
+    } finally {
+      setBusyPromptId(null);
+    }
+  };
+
+  const handleUpdatePrice = async (promptId: bigint) => {
+    if (!address || !signTransaction) {
+      updateError("Connect a wallet before updating prompt prices.");
+      return;
+    }
+
+    setBusyPromptId(promptId.toString());
+    try {
+      const nextPrice = xlmToStroops(mergedDrafts[promptId.toString()]);
+      await updatePromptPrice(
+        browserStellarConfig,
+        { signTransaction },
+        address,
+        promptId,
+        nextPrice,
+      );
+      updateStatus("Prompt price updated.");
+      await refreshPromptLists();
+    } catch (error) {
+      updateError(error instanceof Error ? error.message : "Failed to update price.");
+    } finally {
+      setBusyPromptId(null);
+    }
+  };
+
+  const handleUnlock = async (promptId: bigint) => {
+    if (!address || !signMessage) {
+      updateError("Connect a wallet with SEP-43 message signing to unlock prompts.");
+      return;
+    }
+
+    setBusyPromptId(promptId.toString());
+    try {
+      const response = await unlockPromptContent(address, promptId, signMessage);
+      setUnlockedPrompts((current) => ({
+        ...current,
+        [promptId.toString()]: response.plaintext,
+      }));
+      updateStatus("Prompt unlocked. You can re-open it from this library.");
+    } catch (error) {
+      updateError(error instanceof Error ? error.message : "Failed to unlock prompt.");
+    } finally {
+      setBusyPromptId(null);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-[radial-gradient(circle_at_15%_0%,rgba(45,212,191,0.18),transparent_30%),radial-gradient(circle_at_88%_12%,rgba(245,158,11,0.12),transparent_28%),linear-gradient(180deg,#090c0f_0%,#111827_46%,#080b0f_100%)] text-white">
+      <Navigation />
+      <main className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:py-10">
+        {!address ? (
+          <DisconnectedProfile />
+        ) : (
+          <>
+            <WalletIdentityPanel
+              address={address}
+              network={network}
+              balanceLabel={xlm}
+              isBalanceLoading={isBalanceLoading}
+              purchasedCount={purchasedPrompts.length}
+              createdCount={createdPrompts.length}
+              activeCount={activeListingCount}
+            />
+
+            <div className="space-y-3">
+              {statusMessage ? (
+                <AlertBanner tone="success" message={statusMessage} />
+              ) : null}
+              {errorMessage ? (
+                <AlertBanner tone="error" message={errorMessage} />
+              ) : null}
+            </div>
+
+            <section className="mt-8">
+              <Tabs defaultValue="purchased" className="space-y-5">
+                <div className="flex flex-col gap-4 border-b border-white/10 pb-4 lg:flex-row lg:items-end lg:justify-between">
+                  <div>
+                    <p className="text-sm uppercase tracking-[0.24em] text-cyan-200">
+                      Prompt access
+                    </p>
+                    <h2 className="mt-2 text-3xl font-semibold text-white">
+                      Library and inventory
+                    </h2>
+                    <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-400">
+                      Purchased prompts are optimized for re-entry and unlock.
+                      Created prompts stay focused on listing control.
+                    </p>
+                  </div>
+                  <TabsList className="grid h-auto w-full grid-cols-2 rounded-lg border border-white/10 bg-white/[0.04] p-1 lg:w-[28rem]">
+                    <TabsTrigger
+                      value="purchased"
+                      className="rounded-md px-3 py-2 text-slate-300 data-[state=active]:bg-cyan-200 data-[state=active]:text-slate-950"
+                    >
+                      Purchased
+                      <span className="ml-2 rounded bg-slate-950/10 px-1.5 py-0.5 text-xs">
+                        {purchasedPrompts.length}
+                      </span>
+                    </TabsTrigger>
+                    <TabsTrigger
+                      value="created"
+                      className="rounded-md px-3 py-2 text-slate-300 data-[state=active]:bg-cyan-200 data-[state=active]:text-slate-950"
+                    >
+                      Created
+                      <span className="ml-2 rounded bg-slate-950/10 px-1.5 py-0.5 text-xs">
+                        {createdPrompts.length}
+                      </span>
+                    </TabsTrigger>
+                  </TabsList>
+                </div>
+
+                <TabsContent value="purchased" className="mt-0 space-y-4">
+                  {purchasedQuery.isLoading ? (
+                    <LoadingState label="Loading purchased prompt licenses..." />
+                  ) : purchasedPrompts.length === 0 ? (
+                    <EmptyState
+                      icon={LibraryBig}
+                      title="No purchased prompts yet"
+                      body="When this wallet buys access, prompts appear here with a direct unlock path back to the protected content."
+                      action={{
+                        label: "Browse marketplace",
+                        to: "/browse",
+                        icon: ShoppingBag,
+                      }}
+                    />
+                  ) : (
+                    <div className="space-y-4">
+                      {purchasedPrompts.map((prompt) => (
+                        <PurchasedPromptCard
+                          key={prompt.id.toString()}
+                          prompt={prompt}
+                          isBusy={busyPromptId === prompt.id.toString()}
+                          plaintext={unlockedPrompts[prompt.id.toString()]}
+                          onUnlock={(promptId) => void handleUnlock(promptId)}
+                        />
+                      ))}
+                    </div>
+                  )}
+                </TabsContent>
+
+                <TabsContent value="created" className="mt-0 space-y-4">
+                  {createdQuery.isLoading ? (
+                    <LoadingState label="Loading creator inventory..." />
+                  ) : createdPrompts.length === 0 ? (
+                    <EmptyState
+                      icon={Boxes}
+                      title="No creator inventory for this wallet"
+                      body="Create your first encrypted prompt listing to see pricing controls, sales count, and active or paused listing states here."
+                      action={{
+                        label: "Create listing",
+                        to: "/sell",
+                        icon: ArrowUpRight,
+                      }}
+                    />
+                  ) : (
+                    <div className="space-y-4">
+                      {createdPrompts.map((prompt) => (
+                        <CreatedPromptCard
+                          key={prompt.id.toString()}
+                          prompt={prompt}
+                          isBusy={busyPromptId === prompt.id.toString()}
+                          priceDraft={mergedDrafts[prompt.id.toString()]}
+                          onDraftChange={(value) =>
+                            setPriceDrafts((current) => ({
+                              ...current,
+                              [prompt.id.toString()]: value,
+                            }))
+                          }
+                          onUpdatePrice={(promptId) => void handleUpdatePrice(promptId)}
+                          onToggleStatus={(promptId, active) =>
+                            void handleToggleSaleStatus(promptId, active)
+                          }
+                        />
+                      ))}
+                    </div>
+                  )}
+                </TabsContent>
+              </Tabs>
+            </section>
+          </>
+        )}
       </main>
       <Footer />
     </div>

--- a/src/pages/sell/CreatePromptForm.tsx
+++ b/src/pages/sell/CreatePromptForm.tsx
@@ -1,5 +1,6 @@
 import { ChangeEvent, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
 import { AlertCircle, Loader2 } from "lucide-react";
 import { featuredPromptTemplates } from "@/data/featuredPrompts";
 import { Button } from "@/components/ui/button";
@@ -21,6 +22,7 @@ import {
 import { browserStellarConfig } from "@/lib/stellar/browserConfig";
 import { xlmToStroops } from "@/lib/stellar/format";
 import { createPrompt } from "@/lib/stellar/promptHashClient";
+import { invalidateAllPromptQueries } from "@/hooks/useContractSync";
 
 const limits = {
   title: 120,
@@ -46,6 +48,7 @@ interface FormData {
 
 export function CreatePromptForm() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { address, signTransaction } = useWallet();
   const [formData, setFormData] = useState<FormData>({
     imageUrl: "",
@@ -192,6 +195,8 @@ export function CreatePromptForm() {
         },
       );
 
+      // Invalidate before navigating so the browse grid is fresh on arrival.
+      await invalidateAllPromptQueries(queryClient);
       setSuccessMessage(`Prompt #${promptId.toString()} created successfully.`);
       setFormData({
         imageUrl: "",

--- a/src/pages/sell/MyPrompts.tsx
+++ b/src/pages/sell/MyPrompts.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { useWallet } from "@/hooks/useWallet";
+import { invalidateAllPromptQueries } from "@/hooks/useContractSync";
 import { browserStellarConfig } from "@/lib/stellar/browserConfig";
 import {
   getPromptsByBuyer,
@@ -56,14 +57,7 @@ const MyPrompts = () => {
     );
   }, [createdPrompts, priceDrafts]);
 
-  const refreshPromptLists = async () => {
-    await Promise.all([
-      queryClient.invalidateQueries({ queryKey: ["created-prompts"] }),
-      queryClient.invalidateQueries({ queryKey: ["purchased-prompts"] }),
-      queryClient.invalidateQueries({ queryKey: ["marketplace-prompts"] }),
-      queryClient.invalidateQueries({ queryKey: ["prompt-access"] }),
-    ]);
-  };
+  const refreshPromptLists = () => invalidateAllPromptQueries(queryClient);
 
   const updateStatus = (message: string) => {
     setErrorMessage(null);

--- a/src/providers/ContractSyncProvider.tsx
+++ b/src/providers/ContractSyncProvider.tsx
@@ -1,0 +1,11 @@
+import { type ReactNode } from "react";
+import { useContractSync } from "@/hooks/useContractSync";
+
+/**
+ * Mounts the background contract-event polling loop once at app level.
+ * Must be rendered inside QueryClientProvider.
+ */
+export function ContractSyncProvider({ children }: { children: ReactNode }) {
+  useContractSync();
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary
                                                                                
  Closes #4                                            
                                                                                
  - Full-width wallet identity hero card with interactive copy-to-clipboard     
  address button and connected-state avatar badge                             
  - Bottom stats strip (Owned Licenses · Created Prompts · Active Listings ·    
  Balance) replaces the old two-column tile layout                              
  - Tabs renamed to **My Library** (cyan) and **My Inventory** (amber) with   
  distinct color languages — cyan for licensed/purchased, amber for             
  creator-managed content                                   
  - `CreatedPromptCard` price update button uses amber to reinforce inventory   
  context; `PurchasedPromptCard` unlock CTA stays cyan                          
  - Mobile-only access-state pill overlaid on card images (Locked / Unlocked) 
  - `DisconnectedProfile` replaced with full-width glowing hero panel + 3-column
   feature strip                                            
  - Empty states are color-coded per section with matching CTAs                 
  - Added `role="alert"` to `AlertBanner` for screen reader accessibility       
  - `.gitignore` updated: added `.codex`, `.claude/`, JetBrains IDE files,    
  `Thumbs.db`, swap files                                                       
                                                            
  ## Before / After                                                             
                                                            
  | State | Before | After |                                                    
  |---|---|---|
  | Connected – identity | Two-column info + metric tiles | Full-width hero card + stats strip |                                                              
  | Tabs | "Purchased" / "Created" | "My Library" (cyan) / "My Inventory"   (amber) |                                                                     
  | Disconnected | Two-column hero | Full-width hero + 3-column feature strip |
  | Empty states | Generic cyan | Color-coded per section |             