### PR TITLE
Harden Soroban prompt contract storage + lifecycle invariants (#10)

### DIFF
--- a/contracts/prompt-hash/src/contract.rs
+++ b/contracts/prompt-hash/src/contract.rs
@@ -5,6 +5,25 @@ use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String, Vec};
 use stellar_access::ownable::{self as ownable, Ownable};
 use stellar_macros::{default_impl, only_owner};
 
+/// PromptHash Soroban contract.
+///
+/// ## Storage model
+/// - `DataKey::Prompt(id)` stores the prompt record. Prompt metadata is immutable after creation;
+///   only `active`, `price_stroops`, and `sales_count` may change through dedicated methods.
+/// - `DataKey::PromptCounter` stores the next prompt id (append-only, starts at `0`).
+/// - `DataKey::CreatorPrompts(creator)` is an append-only list of prompt ids created by `creator`,
+///   in creation order (ascending by id).
+/// - `DataKey::BuyerPrompts(buyer)` is an append-only list of prompt ids purchased by `buyer`,
+///   in purchase order.
+/// - `DataKey::Purchase(prompt_id, buyer)` stores a purchase right (never revoked).
+///
+/// ## Lifecycle invariants
+/// - `create_prompt`: field validation is enforced on-chain; prompt starts `active=true`.
+/// - `set_prompt_sale_status`: only the prompt creator may pause/reactivate; pausing prevents
+///   future purchases but does not revoke existing access.
+/// - `update_prompt_price`: only the prompt creator; price must be `> 0`; affects future purchases.
+/// - `buy_prompt`: requires active listing, buyer != creator, and no prior purchase.
+/// - `has_access`: creator always has access; buyers have access if purchased regardless of `active`.
 const DEFAULT_FEE_BPS: u32 = 500;
 const MAX_BPS: u32 = 10_000;
 const MAX_TITLE_LEN: u32 = 120;
@@ -26,6 +45,7 @@ impl PromptHashTrait for PromptHashContract {
         fee_wallet: Address,
         xlm_sac: Address,
     ) -> Result<(), Error> {
+        Storage::set_initialized(&env)?;
         ownable::set_owner(&env, &admin);
         Storage::set_fee_wallet(&env, &fee_wallet);
         Storage::set_fee_percentage(&env, &DEFAULT_FEE_BPS);
@@ -47,6 +67,7 @@ impl PromptHashTrait for PromptHashContract {
         content_hash: BytesN<32>,
         price_stroops: i128,
     ) -> Result<u128, Error> {
+        Storage::require_initialized(&env)?;
         creator.require_auth();
         validate_prompt_fields(
             &image_url,
@@ -77,7 +98,7 @@ impl PromptHashTrait for PromptHashContract {
         };
 
         Storage::save_prompt(&env, &prompt)?;
-        Storage::add_prompt_to_creator(&env, &creator, prompt_id);
+        Storage::add_prompt_to_creator(&env, &creator, prompt_id)?;
         Events::emit_prompt_created(&env, prompt_id, creator, price_stroops);
         Ok(prompt_id)
     }
@@ -88,9 +109,10 @@ impl PromptHashTrait for PromptHashContract {
         prompt_id: u128,
         active: bool,
     ) -> Result<(), Error> {
+        Storage::require_initialized(&env)?;
         creator.require_auth();
         let mut prompt = Storage::require_prompt(&env, prompt_id)?;
-        ensure(prompt.creator == creator, Error::Unauthorized)?;
+        ensure(prompt.creator == creator, Error::NotPromptCreator)?;
 
         prompt.active = active;
         Storage::update_prompt(&env, &prompt);
@@ -104,11 +126,12 @@ impl PromptHashTrait for PromptHashContract {
         prompt_id: u128,
         price_stroops: i128,
     ) -> Result<(), Error> {
+        Storage::require_initialized(&env)?;
         creator.require_auth();
         ensure(price_stroops > 0, Error::InvalidPrice)?;
 
         let mut prompt = Storage::require_prompt(&env, prompt_id)?;
-        ensure(prompt.creator == creator, Error::Unauthorized)?;
+        ensure(prompt.creator == creator, Error::NotPromptCreator)?;
         prompt.price_stroops = price_stroops;
 
         Storage::update_prompt(&env, &prompt);
@@ -117,9 +140,11 @@ impl PromptHashTrait for PromptHashContract {
     }
 
     fn buy_prompt(env: Env, buyer: Address, prompt_id: u128) -> Result<(), Error> {
+        Storage::require_initialized(&env)?;
         buyer.require_auth();
         let mut prompt = Storage::require_prompt(&env, prompt_id)?;
 
+        ensure(prompt.price_stroops > 0, Error::InvalidPrice)?;
         ensure(prompt.active, Error::PromptInactive)?;
         ensure(prompt.creator != buyer, Error::CreatorCannotBuy)?;
         ensure(!Storage::has_purchase(&env, prompt_id, &buyer), Error::AlreadyPurchased)?;
@@ -150,7 +175,7 @@ impl PromptHashTrait for PromptHashContract {
             .checked_add(1)
             .ok_or(Error::ArithmeticOverflow)?;
         Storage::update_prompt(&env, &prompt);
-        Storage::grant_purchase(&env, prompt_id, &buyer);
+        Storage::grant_purchase(&env, prompt_id, &buyer)?;
         Events::emit_prompt_purchased(
             &env,
             prompt_id,
@@ -171,15 +196,15 @@ impl PromptHashTrait for PromptHashContract {
     }
 
     fn get_all_prompts(env: Env) -> Result<Vec<Prompt>, Error> {
-        Ok(Storage::get_all_prompts(&env))
+        Storage::get_all_prompts(&env)
     }
 
     fn get_prompts_by_creator(env: Env, creator: Address) -> Result<Vec<Prompt>, Error> {
-        Ok(Storage::get_prompts_by_creator(&env, &creator))
+        Storage::get_prompts_by_creator(&env, &creator)
     }
 
     fn get_prompts_by_buyer(env: Env, buyer: Address) -> Result<Vec<Prompt>, Error> {
-        Ok(Storage::get_prompts_by_buyer(&env, &buyer))
+        Storage::get_prompts_by_buyer(&env, &buyer)
     }
 
     #[only_owner]

--- a/contracts/prompt-hash/src/mock_asset.rs
+++ b/contracts/prompt-hash/src/mock_asset.rs
@@ -1,6 +1,6 @@
 use soroban_sdk::{contract, contractimpl, Address, Env, String};
 use stellar_access::ownable::{self as ownable, Ownable};
-use stellar_macros::{default_impl, only_owner};
+use stellar_macros::default_impl;
 use stellar_tokens::fungible::{Base, FungibleToken};
 
 #[contract]

--- a/contracts/prompt-hash/src/storage.rs
+++ b/contracts/prompt-hash/src/storage.rs
@@ -1,14 +1,50 @@
+//! Contract storage helpers.
+//!
+//! This module centralizes persistent storage access and enforces key invariants:
+//! - Prompt ids are sequential and append-only (starting at `0`).
+//! - Creator and buyer indexes are append-only vectors that preserve insertion order.
+
 use super::types::{DataKey, Error, Prompt};
 use soroban_sdk::{token, Address, Env, Vec};
 
 pub struct Storage;
 
 impl Storage {
+    pub fn is_initialized(env: &Env) -> bool {
+        match env.storage().persistent().get::<_, bool>(&DataKey::Initialized) {
+            Some(value) => value,
+            None => Self::get_fee_wallet(env).is_some() && Self::get_xlm_address(env).is_some(),
+        }
+    }
+
+    pub fn set_initialized(env: &Env) -> Result<(), Error> {
+        ensure(!Self::is_initialized(env), Error::AlreadyInitialized)?;
+        env.storage().persistent().set(&DataKey::Initialized, &true);
+        Ok(())
+    }
+
+    pub fn require_initialized(env: &Env) -> Result<(), Error> {
+        ensure(Self::is_initialized(env), Error::ContractNotInitialized)
+    }
+
+    /// Saves a new prompt and bumps the prompt counter.
+    ///
+    /// Invariants:
+    /// - `prompt.id` must equal the current prompt counter.
+    /// - A prompt must not already exist at `prompt.id`.
+    /// - The prompt counter is append-only and always equals the next prompt id.
     pub fn save_prompt(env: &Env, prompt: &Prompt) -> Result<(), Error> {
+        let expected_prompt_id = Self::get_prompt_counter(env);
+        ensure(prompt.id == expected_prompt_id, Error::StorageCorrupt)?;
+        ensure(Self::get_prompt(env, prompt.id).is_none(), Error::PromptIdAlreadyExists)?;
+
         env.storage()
             .persistent()
             .set(&DataKey::Prompt(prompt.id), prompt);
-        let next_prompt_id = prompt.id.checked_add(1).ok_or(Error::ArithmeticOverflow)?;
+
+        let next_prompt_id = expected_prompt_id
+            .checked_add(1)
+            .ok_or(Error::ArithmeticOverflow)?;
         env.storage()
             .persistent()
             .set(&DataKey::PromptCounter, &next_prompt_id);
@@ -36,20 +72,19 @@ impl Storage {
             .unwrap_or(0)
     }
 
-    pub fn get_all_prompts(env: &Env) -> Vec<Prompt> {
+    pub fn get_all_prompts(env: &Env) -> Result<Vec<Prompt>, Error> {
         let prompt_count = Self::get_prompt_counter(env);
         let mut prompts = Vec::new(env);
 
         for prompt_id in 0..prompt_count {
-            if let Some(prompt) = Self::get_prompt(env, prompt_id) {
-                prompts.push_back(prompt);
-            }
+            let prompt = Self::get_prompt(env, prompt_id).ok_or(Error::StorageCorrupt)?;
+            prompts.push_back(prompt);
         }
 
-        prompts
+        Ok(prompts)
     }
 
-    pub fn get_prompts_by_creator(env: &Env, creator: &Address) -> Vec<Prompt> {
+    pub fn get_prompts_by_creator(env: &Env, creator: &Address) -> Result<Vec<Prompt>, Error> {
         let ids: Vec<u128> = env
             .storage()
             .persistent()
@@ -59,7 +94,7 @@ impl Storage {
         Self::prompts_from_ids(env, ids)
     }
 
-    pub fn get_prompts_by_buyer(env: &Env, buyer: &Address) -> Vec<Prompt> {
+    pub fn get_prompts_by_buyer(env: &Env, buyer: &Address) -> Result<Vec<Prompt>, Error> {
         let ids: Vec<u128> = env
             .storage()
             .persistent()
@@ -69,31 +104,37 @@ impl Storage {
         Self::prompts_from_ids(env, ids)
     }
 
-    fn prompts_from_ids(env: &Env, ids: Vec<u128>) -> Vec<Prompt> {
+    fn prompts_from_ids(env: &Env, ids: Vec<u128>) -> Result<Vec<Prompt>, Error> {
         let mut prompts = Vec::new(env);
 
         for index in 0..ids.len() {
             let prompt_id = ids.get(index).unwrap();
-            if let Some(prompt) = Self::get_prompt(env, prompt_id) {
-                prompts.push_back(prompt);
-            }
+            let prompt = Self::get_prompt(env, prompt_id).ok_or(Error::StorageCorrupt)?;
+            prompts.push_back(prompt);
         }
 
-        prompts
+        Ok(prompts)
     }
 
-    pub fn add_prompt_to_creator(env: &Env, creator: &Address, prompt_id: u128) {
+    pub fn add_prompt_to_creator(env: &Env, creator: &Address, prompt_id: u128) -> Result<(), Error> {
         let key = DataKey::CreatorPrompts(creator.clone());
         let mut ids: Vec<u128> = env
             .storage()
             .persistent()
             .get(&key)
             .unwrap_or_else(|| Vec::new(env));
+
+        if ids.len() > 0 {
+            let last_id = ids.get(ids.len() - 1).ok_or(Error::StorageCorrupt)?;
+            ensure(prompt_id > last_id, Error::StorageCorrupt)?;
+        }
+
         ids.push_back(prompt_id);
         env.storage().persistent().set(&key, &ids);
+        Ok(())
     }
 
-    pub fn add_prompt_to_buyer(env: &Env, buyer: &Address, prompt_id: u128) {
+    pub fn add_prompt_to_buyer(env: &Env, buyer: &Address, prompt_id: u128) -> Result<(), Error> {
         let key = DataKey::BuyerPrompts(buyer.clone());
         let mut ids: Vec<u128> = env
             .storage()
@@ -102,6 +143,7 @@ impl Storage {
             .unwrap_or_else(|| Vec::new(env));
         ids.push_back(prompt_id);
         env.storage().persistent().set(&key, &ids);
+        Ok(())
     }
 
     pub fn has_purchase(env: &Env, prompt_id: u128, buyer: &Address) -> bool {
@@ -111,11 +153,16 @@ impl Storage {
             .unwrap_or(false)
     }
 
-    pub fn grant_purchase(env: &Env, prompt_id: u128, buyer: &Address) {
+    pub fn grant_purchase(env: &Env, prompt_id: u128, buyer: &Address) -> Result<(), Error> {
+        ensure(
+            !Self::has_purchase(env, prompt_id, buyer),
+            Error::AlreadyPurchased,
+        )?;
         env.storage()
             .persistent()
             .set(&DataKey::Purchase(prompt_id, buyer.clone()), &true);
-        Self::add_prompt_to_buyer(env, buyer, prompt_id);
+        Self::add_prompt_to_buyer(env, buyer, prompt_id)?;
+        Ok(())
     }
 
     pub fn set_fee_percentage(env: &Env, fee_percentage: &u32) {
@@ -154,5 +201,13 @@ impl Storage {
     pub fn get_stellar_asset_contract(env: &'_ Env) -> Result<token::StellarAssetClient<'_>, Error> {
         let contract_id = Self::get_xlm_address(env).ok_or(Error::XlmAddressNotSet)?;
         Ok(token::StellarAssetClient::new(env, &contract_id))
+    }
+}
+
+fn ensure(condition: bool, error: Error) -> Result<(), Error> {
+    if condition {
+        Ok(())
+    } else {
+        Err(error)
     }
 }

--- a/contracts/prompt-hash/src/test.rs
+++ b/contracts/prompt-hash/src/test.rs
@@ -4,7 +4,10 @@ use crate::contract::{PromptHashContract, PromptHashContractClient};
 use crate::mock_asset::FungibleTokenContract;
 use crate::types::Error;
 extern crate std;
-use soroban_sdk::{testutils::Address as _, token, Address, BytesN, Env, String};
+use soroban_sdk::{
+    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    token, Address, BytesN, Env, IntoVal, String,
+};
 
 #[derive(Clone, Debug, PartialEq)]
 struct PromptHashContext {
@@ -16,6 +19,14 @@ struct PromptHashContext {
 
 fn setup(env: &Env) -> PromptHashContext {
     env.mock_all_auths();
+    setup_contract(env)
+}
+
+fn setup_without_auth_mock(env: &Env) -> PromptHashContext {
+    setup_contract(env)
+}
+
+fn setup_contract(env: &Env) -> PromptHashContext {
 
     let admin = Address::generate(env);
     let fee_wallet = Address::generate(env);
@@ -92,6 +103,25 @@ fn test_create_prompt_stores_encrypted_fields() {
 }
 
 #[test]
+fn test_prompt_ids_are_sequential_and_all_prompts_are_ordered() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+
+    let creator = Address::generate(&env);
+    let prompt_a = create_prompt(&env, &client, &creator, "Prompt A", 10_000);
+    let prompt_b = create_prompt(&env, &client, &creator, "Prompt B", 10_000);
+
+    assert_eq!(prompt_a, 0);
+    assert_eq!(prompt_b, 1);
+
+    let all_prompts = client.get_all_prompts();
+    assert_eq!(all_prompts.len(), 2);
+    assert_eq!(all_prompts.get(0).unwrap().id, prompt_a);
+    assert_eq!(all_prompts.get(1).unwrap().id, prompt_b);
+}
+
+#[test]
 fn test_creator_can_pause_reactivate_and_update_price() {
     let env: Env = Default::default();
     let context = setup(&env);
@@ -107,6 +137,22 @@ fn test_creator_can_pause_reactivate_and_update_price() {
     let prompt = client.get_prompt(&prompt_id);
     assert_eq!(prompt.price_stroops, 9_000);
     assert!(prompt.active);
+}
+
+#[test]
+fn test_update_prompt_price_requires_positive_price() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+
+    let creator = Address::generate(&env);
+    let prompt_id = create_prompt(&env, &client, &creator, "Price Guard", 5_000);
+
+    let result = client.try_update_prompt_price(&creator, &prompt_id, &0);
+    match result {
+        Err(Ok(error)) => assert_eq!(error, Error::InvalidPrice),
+        other => panic!("unexpected invalid price update result: {:?}", other),
+    }
 }
 
 #[test]
@@ -180,13 +226,19 @@ fn test_get_prompts_by_creator_and_buyer() {
     let creator = Address::generate(&env);
     let buyer = Address::generate(&env);
     let prompt_a = create_prompt(&env, &client, &creator, "Prompt A", 8_000);
-    create_prompt(&env, &client, &creator, "Prompt B", 9_000);
+    let prompt_b = create_prompt(&env, &client, &creator, "Prompt B", 9_000);
 
     fund_buyer(&xlm_client, &buyer, &context.contract, 100_000);
     client.buy_prompt(&buyer, &prompt_a);
 
-    assert_eq!(client.get_prompts_by_creator(&creator).len(), 2);
-    assert_eq!(client.get_prompts_by_buyer(&buyer).len(), 1);
+    let created = client.get_prompts_by_creator(&creator);
+    assert_eq!(created.len(), 2);
+    assert_eq!(created.get(0).unwrap().id, prompt_a);
+    assert_eq!(created.get(1).unwrap().id, prompt_b);
+
+    let purchased = client.get_prompts_by_buyer(&buyer);
+    assert_eq!(purchased.len(), 1);
+    assert_eq!(purchased.get(0).unwrap().id, prompt_a);
 }
 
 #[test]
@@ -245,4 +297,175 @@ fn test_inactive_prompt_cannot_be_bought() {
         Err(Ok(error)) => assert_eq!(error, Error::PromptInactive),
         other => panic!("unexpected inactive prompt result: {:?}", other),
     }
+}
+
+#[test]
+fn test_pausing_prompt_does_not_revoke_existing_access() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let prompt_id = create_prompt(&env, &client, &creator, "Pause Invariant", 4_000);
+
+    fund_buyer(&xlm_client, &buyer, &context.contract, 100_000);
+    client.buy_prompt(&buyer, &prompt_id);
+    assert!(client.has_access(&buyer, &prompt_id));
+
+    client.set_prompt_sale_status(&creator, &prompt_id, &false);
+    assert!(client.has_access(&buyer, &prompt_id));
+}
+
+#[test]
+fn test_non_creator_cannot_pause_or_update_price() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+
+    let creator = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let prompt_id = create_prompt(&env, &client, &creator, "Creator Only", 4_000);
+
+    let pause_attempt = client.try_set_prompt_sale_status(&attacker, &prompt_id, &false);
+    match pause_attempt {
+        Err(Ok(error)) => assert_eq!(error, Error::NotPromptCreator),
+        other => panic!("unexpected pause attempt result: {:?}", other),
+    }
+
+    let price_attempt = client.try_update_prompt_price(&attacker, &prompt_id, &9_000);
+    match price_attempt {
+        Err(Ok(error)) => assert_eq!(error, Error::NotPromptCreator),
+        other => panic!("unexpected price attempt result: {:?}", other),
+    }
+}
+
+#[test]
+fn test_create_prompt_enforces_title_length_limit() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+
+    let creator = Address::generate(&env);
+    let long_title: std::string::String = std::iter::repeat('a').take(121).collect();
+
+    let result = client.try_create_prompt(
+        &creator,
+        &String::from_str(&env, "https://example.com/prompt.png"),
+        &String::from_str(&env, &long_title),
+        &String::from_str(&env, "Software Development"),
+        &String::from_str(&env, "Generate a production-ready implementation plan."),
+        &String::from_str(&env, "ciphertext"),
+        &String::from_str(&env, "iv"),
+        &String::from_str(&env, "wrapped-key"),
+        &hash(&env, 7),
+        &10_000,
+    );
+
+    match result {
+        Err(Ok(error)) => assert_eq!(error, Error::InvalidTitleLength),
+        other => panic!("unexpected create_prompt result: {:?}", other),
+    }
+}
+
+#[test]
+fn test_buyer_index_preserves_purchase_order() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let prompt_a = create_prompt(&env, &client, &creator, "Prompt A", 8_000);
+    let prompt_b = create_prompt(&env, &client, &creator, "Prompt B", 9_000);
+
+    fund_buyer(&xlm_client, &buyer, &context.contract, 100_000);
+    client.buy_prompt(&buyer, &prompt_b);
+    client.buy_prompt(&buyer, &prompt_a);
+
+    let purchased = client.get_prompts_by_buyer(&buyer);
+    assert_eq!(purchased.len(), 2);
+    assert_eq!(purchased.get(0).unwrap().id, prompt_b);
+    assert_eq!(purchased.get(1).unwrap().id, prompt_a);
+}
+
+#[test]
+fn test_admin_fee_controls_require_owner_auth() {
+    let env: Env = Default::default();
+    let context = setup_without_auth_mock(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+
+    let new_fee_bps: u32 = 750;
+
+    // No auth => fails.
+    assert!(client.try_set_fee_percentage(&new_fee_bps).is_err());
+
+    // Non-owner auth => fails.
+    let attacker = Address::generate(&env);
+    env.mock_auths(&[MockAuth {
+        address: &attacker,
+        invoke: &MockAuthInvoke {
+            contract: &context.contract,
+            fn_name: "set_fee_percentage",
+            args: (&new_fee_bps,).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    assert!(client.try_set_fee_percentage(&new_fee_bps).is_err());
+
+    // Owner auth => succeeds.
+    env.mock_auths(&[MockAuth {
+        address: &context.admin,
+        invoke: &MockAuthInvoke {
+            contract: &context.contract,
+            fn_name: "set_fee_percentage",
+            args: (&new_fee_bps,).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.set_fee_percentage(&new_fee_bps);
+
+    // Owner auth + invalid fee => typed error.
+    let invalid_fee_bps: u32 = 10_001;
+    env.mock_auths(&[MockAuth {
+        address: &context.admin,
+        invoke: &MockAuthInvoke {
+            contract: &context.contract,
+            fn_name: "set_fee_percentage",
+            args: (&invalid_fee_bps,).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    let invalid_fee_attempt = client.try_set_fee_percentage(&invalid_fee_bps);
+    match invalid_fee_attempt {
+        Err(Ok(error)) => assert_eq!(error, Error::InvalidFeePercentage),
+        other => panic!("unexpected invalid fee update result: {:?}", other),
+    }
+
+    // Owner auth => can update fee wallet.
+    let new_fee_wallet = Address::generate(&env);
+    env.mock_auths(&[MockAuth {
+        address: &context.admin,
+        invoke: &MockAuthInvoke {
+            contract: &context.contract,
+            fn_name: "set_fee_wallet",
+            args: (&new_fee_wallet,).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.set_fee_wallet(&new_fee_wallet);
+
+    // Non-owner auth => cannot update fee wallet.
+    env.mock_auths(&[MockAuth {
+        address: &attacker,
+        invoke: &MockAuthInvoke {
+            contract: &context.contract,
+            fn_name: "set_fee_wallet",
+            args: (&new_fee_wallet,).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    assert!(client.try_set_fee_wallet(&new_fee_wallet).is_err());
 }

--- a/contracts/prompt-hash/src/types.rs
+++ b/contracts/prompt-hash/src/types.rs
@@ -21,6 +21,11 @@ pub enum Error {
     FeeWalletNotSet = 15,
     XlmAddressNotSet = 16,
     ArithmeticOverflow = 17,
+    AlreadyInitialized = 18,
+    ContractNotInitialized = 19,
+    NotPromptCreator = 20,
+    PromptIdAlreadyExists = 21,
+    StorageCorrupt = 22,
 }
 
 #[contracttype]
@@ -52,6 +57,7 @@ pub enum DataKey {
     CreatorPrompts(Address),
     BuyerPrompts(Address),
     Purchase(u128, Address),
+    Initialized,
 }
 
 pub trait PromptHashTrait {


### PR DESCRIPTION
**PR Description**
This hardens the `prompt-hash` Soroban contract storage model and enforces core prompt lifecycle invariants on-chain (rather than relying on UI assumptions).

**Key changes**
- Documented storage layout + lifecycle rules and made them auditable in code.
- Added initialization guard + stricter storage invariants (sequential prompt IDs, deterministic creator/buyer indexes, corruption detection).
- Refined typed errors for clearer downstream handling (e.g. `NotPromptCreator`, `ContractNotInitialized`, `StorageCorrupt`).
- Expanded tests for create/buy/access/pause/price-update rules and admin-only fee controls.

**Testing**
- `cargo test -p prompt-hash`

**Notes**
- Introduces `DataKey::Initialized` with a legacy-safe fallback so upgraded deployments that already have fee wallet + XLM SAC configured are treated as initialized.
closes #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened validation for prompt creation, pricing, and purchases
  * Improved error messages with clearer authorization feedback
  * Enhanced protection against duplicate purchases and invalid operations
  * Added storage integrity verification for data consistency

* **Documentation**
  * Expanded contract documentation with storage model and lifecycle details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->