### PR TITLE
feat: prompt versioning and purchase history

### DIFF
--- a/api/auth/challenge.ts
+++ b/api/auth/challenge.ts
@@ -10,17 +10,29 @@ async function handler(req: any, res: any) {
   }
 
   const clientIp = (req.headers["x-forwarded-for"] || req.socket.remoteAddress) as string;
-  const rateLimit = checkRateLimit("challenge", clientIp);
+  const { address, promptId } = req.body ?? {};
+
+  // Authenticated if wallet address is provided in the request body.
+  const isAuthenticated = Boolean(address);
+
+  const rateLimit = await checkRateLimit("challenge", clientIp, isAuthenticated);
 
   if (!rateLimit.success) {
     req.logger.warn({ clientIp }, "Rate limit exceeded for challenge issuance");
     metrics.trackRateLimitHit("challenge", clientIp);
+    res.setHeader("X-RateLimit-Limit", rateLimit.limit);
+    res.setHeader("X-RateLimit-Remaining", 0);
+    res.setHeader("X-RateLimit-Reset", rateLimit.reset);
     res.status(429).json({
       error: "Too many requests. Please try again later.",
       reset: rateLimit.reset,
     });
     return;
   }
+
+  res.setHeader("X-RateLimit-Limit", rateLimit.limit);
+  res.setHeader("X-RateLimit-Remaining", rateLimit.remaining);
+  res.setHeader("X-RateLimit-Reset", rateLimit.reset);
 
   const secret = process.env.CHALLENGE_TOKEN_SECRET;
   if (!secret) {
@@ -29,14 +41,13 @@ async function handler(req: any, res: any) {
     return;
   }
 
-  const { address, promptId } = req.body ?? {};
   if (!address || !promptId) {
     res.status(400).json({ error: "address and promptId are required." });
     return;
   }
 
   const challenge = createChallengeToken(secret, String(address), String(promptId));
-  
+
   metrics.trackChallengeIssued(String(address), String(promptId));
   req.logger.info({ address, promptId }, "Challenge token issued successfully");
 

--- a/api/prompts/unlock.ts
+++ b/api/prompts/unlock.ts
@@ -49,21 +49,30 @@ async function handler(req: any, res: any) {
   const clientIp = (req.headers["x-forwarded-for"] || req.socket.remoteAddress) as string;
   const { token, promptId, address, signedMessage } = req.body ?? {};
 
-  // Rate limit by IP
-  const ipRateLimit = checkRateLimit("unlock", clientIp);
+  // Authenticated bucket: wallet address is present.
+  const isAuthenticated = Boolean(address);
+
+  // Rate limit by IP (unauthenticated bucket — strictest guard).
+  const ipRateLimit = await checkRateLimit("unlock", clientIp, false);
   if (!ipRateLimit.success) {
     req.logger.warn({ clientIp }, "Rate limit exceeded for unlock (IP)");
     metrics.trackRateLimitHit("unlock_ip", clientIp);
+    res.setHeader("X-RateLimit-Limit", ipRateLimit.limit);
+    res.setHeader("X-RateLimit-Remaining", 0);
+    res.setHeader("X-RateLimit-Reset", ipRateLimit.reset);
     res.status(429).json({ error: "Too many requests. Please try again later." });
     return;
   }
 
-  // Rate limit by wallet if provided
+  // Rate limit by wallet address (authenticated bucket — per-wallet brute-force guard).
   if (address) {
-    const walletRateLimit = checkRateLimit("unlock", String(address));
+    const walletRateLimit = await checkRateLimit("unlock", String(address), isAuthenticated);
     if (!walletRateLimit.success) {
       req.logger.warn({ address }, "Rate limit exceeded for unlock (Wallet)");
       metrics.trackRateLimitHit("unlock_wallet", String(address));
+      res.setHeader("X-RateLimit-Limit", walletRateLimit.limit);
+      res.setHeader("X-RateLimit-Remaining", 0);
+      res.setHeader("X-RateLimit-Reset", walletRateLimit.reset);
       res.status(429).json({ error: "Too many unlock attempts for this wallet." });
       return;
     }

--- a/api/prompts/unlock.ts
+++ b/api/prompts/unlock.ts
@@ -16,6 +16,7 @@ import {
 import { withObservability } from "../../src/lib/observability/wrapper";
 import { checkRateLimit } from "../../src/lib/observability/rateLimiter";
 import { metrics } from "../../src/lib/observability/metrics";
+import { dispatchEvent } from "../../server/src/services/webhookDispatcher";
 
 function getServerConfig(): PromptHashConfig {
   const rpcUrl =
@@ -147,6 +148,13 @@ async function handler(req: any, res: any) {
 
     metrics.trackUnlockSuccess(String(address), String(promptId));
     req.logger.info({ address, promptId }, "Prompt unlocked successfully");
+
+    // Fire-and-forget webhook dispatch so the creator is notified of the sale.
+    void dispatchEvent(prompt.creator ?? "", "PromptPurchased", {
+      promptId: prompt.id.toString(),
+      buyer: String(address),
+      title: prompt.title,
+    }).catch(() => {});
 
     res.status(200).json({
       promptId: prompt.id.toString(),

--- a/api/prompts/version.ts
+++ b/api/prompts/version.ts
@@ -1,0 +1,79 @@
+import { withObservability } from "../../src/lib/observability/wrapper";
+import connectDb from "../../server/src/db/connectDb";
+import Prompt from "../../server/src/models/Prompt";
+import PromptVersion from "../../server/src/models/PromptVersion";
+import Purchase from "../../server/src/models/Purchase";
+import User from "../../server/src/models/User";
+
+async function handler(req: any, res: any) {
+  await connectDb();
+
+  // GET /api/prompts/version?promptId=&buyerWallet=
+  // Returns the versioned content a buyer is entitled to.
+  if (req.method === "GET") {
+    const { promptId, buyerWallet } = req.query ?? {};
+
+    if (!promptId || !buyerWallet) {
+      res.status(400).json({ error: "promptId and buyerWallet are required." });
+      return;
+    }
+
+    const purchase = await Purchase.findOne({
+      promptId: String(promptId),
+      buyerWallet: String(buyerWallet).toLowerCase(),
+    });
+
+    // If no purchase record, fall back to v1 (legacy purchase before versioning).
+    const versionIndex = purchase?.versionIndex ?? 1;
+
+    const version = await PromptVersion.findOne({
+      promptId: String(promptId),
+      versionIndex,
+    });
+
+    const prompt = await Prompt.findById(promptId).lean();
+
+    res.status(200).json({
+      versionIndex,
+      content: version?.content ?? (prompt as any)?.content ?? null,
+      changeNote: version?.changeNote ?? "",
+      purchasedAt: purchase?.createdAt ?? null,
+    });
+    return;
+  }
+
+  // POST /api/prompts/version — creator posts a new version.
+  if (req.method === "POST") {
+    const { promptId, walletAddress, content, changeNote } = req.body ?? {};
+
+    if (!promptId || !walletAddress || !content) {
+      res.status(400).json({ error: "promptId, walletAddress, and content are required." });
+      return;
+    }
+
+    const user = await User.findOne({ walletAddress: String(walletAddress).toLowerCase() });
+    if (!user) { res.status(404).json({ error: "User not found." }); return; }
+
+    const prompt = await Prompt.findOne({ _id: promptId, owner: user._id });
+    if (!prompt) { res.status(403).json({ error: "Prompt not found or not owned by this wallet." }); return; }
+
+    const nextVersion = (prompt.currentVersionIndex ?? 1) + 1;
+
+    await PromptVersion.create({
+      promptId: String(prompt._id),
+      versionIndex: nextVersion,
+      content,
+      changeNote: changeNote ?? "",
+      createdBy: String(walletAddress).toLowerCase(),
+    });
+
+    await Prompt.findByIdAndUpdate(prompt._id, { currentVersionIndex: nextVersion });
+
+    res.status(201).json({ message: "Version posted.", versionIndex: nextVersion });
+    return;
+  }
+
+  res.status(405).json({ error: "Method not allowed." });
+}
+
+export default withObservability(handler, "prompts/version");

--- a/api/webhooks/index.ts
+++ b/api/webhooks/index.ts
@@ -1,0 +1,84 @@
+import { withObservability } from "../../src/lib/observability/wrapper";
+import connectDb from "../../server/src/db/connectDb";
+import WebhookSubscription from "../../server/src/models/WebhookSubscription";
+import { randomBytes } from "crypto";
+
+async function handler(req: any, res: any) {
+  await connectDb();
+
+  if (req.method === "GET") {
+    const { walletAddress } = req.query ?? {};
+    if (!walletAddress) {
+      res.status(400).json({ error: "walletAddress query param is required." });
+      return;
+    }
+    const sub = await WebhookSubscription.findOne({
+      walletAddress: String(walletAddress).toLowerCase(),
+    }).select("-secret");
+    if (!sub) {
+      res.status(404).json({ error: "No webhook registered for this wallet." });
+      return;
+    }
+    res.status(200).json(sub);
+    return;
+  }
+
+  if (req.method === "POST") {
+    const { walletAddress, url, events } = req.body ?? {};
+    if (!walletAddress || !url) {
+      res.status(400).json({ error: "walletAddress and url are required." });
+      return;
+    }
+    try {
+      new URL(url);
+    } catch {
+      res.status(400).json({ error: "url must be a valid URL." });
+      return;
+    }
+
+    const secret = randomBytes(32).toString("hex");
+    const allowedEvents = ["PromptPurchased"];
+    const resolvedEvents = Array.isArray(events)
+      ? events.filter((e: string) => allowedEvents.includes(e))
+      : ["PromptPurchased"];
+
+    const existing = await WebhookSubscription.findOne({
+      walletAddress: String(walletAddress).toLowerCase(),
+    });
+
+    if (existing) {
+      existing.url = url;
+      existing.events = resolvedEvents;
+      existing.active = true;
+      existing.failureCount = 0;
+      await existing.save();
+      res.status(200).json({ message: "Webhook updated.", id: existing._id, secret });
+      return;
+    }
+
+    const sub = new WebhookSubscription({
+      walletAddress: String(walletAddress).toLowerCase(),
+      url,
+      secret,
+      events: resolvedEvents,
+    });
+    await sub.save();
+    res.status(201).json({ message: "Webhook registered.", id: sub._id, secret });
+    return;
+  }
+
+  if (req.method === "DELETE") {
+    const { walletAddress } = req.body ?? {};
+    if (!walletAddress) {
+      res.status(400).json({ error: "walletAddress is required." });
+      return;
+    }
+    await WebhookSubscription.deleteOne({ walletAddress: String(walletAddress).toLowerCase() });
+    res.status(200).json({ message: "Webhook removed." });
+    return;
+  }
+
+  res.status(405).json({ error: "Method not allowed." });
+}
+
+export default withObservability(handler, "webhooks");

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "redis": "^4.7.0",
     "@creit.tech/stellar-wallets-kit": "^1.9.5",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/server/src/controllers/versioningControllers.ts
+++ b/server/src/controllers/versioningControllers.ts
@@ -1,0 +1,125 @@
+import { Request, Response } from "express";
+import connectDb from "../db/connectDb";
+import Prompt from "../models/Prompt";
+import PromptVersion from "../models/PromptVersion";
+import Purchase from "../models/Purchase";
+import User from "../models/User";
+
+export const PostPromptUpdate = async (req: Request, res: Response): Promise<Response> => {
+  try {
+    await connectDb();
+    const { promptId, walletAddress, content, changeNote } = req.body;
+
+    if (!promptId || !walletAddress || !content) {
+      return res.status(400).json({ error: "promptId, walletAddress, and content are required." });
+    }
+
+    const user = await User.findOne({ walletAddress: walletAddress.toLowerCase() });
+    if (!user) return res.status(404).json({ error: "User not found." });
+
+    const prompt = await Prompt.findOne({ _id: promptId, owner: user._id });
+    if (!prompt) return res.status(403).json({ error: "Prompt not found or not owned by this wallet." });
+
+    const nextVersion = (prompt.currentVersionIndex ?? 1) + 1;
+
+    await PromptVersion.create({
+      promptId: String(prompt._id),
+      versionIndex: nextVersion,
+      content,
+      changeNote: changeNote ?? "",
+      createdBy: walletAddress.toLowerCase(),
+    });
+
+    await Prompt.findByIdAndUpdate(prompt._id, { currentVersionIndex: nextVersion });
+
+    return res.status(201).json({ message: "Version posted.", versionIndex: nextVersion });
+  } catch (err) {
+    return res.status(500).json({ error: (err as Error).message });
+  }
+};
+
+export const GetPromptVersions = async (req: Request, res: Response): Promise<Response> => {
+  try {
+    await connectDb();
+    const { promptId } = req.params;
+    if (!promptId) return res.status(400).json({ error: "promptId is required." });
+
+    const versions = await PromptVersion.find({ promptId })
+      .sort({ versionIndex: -1 })
+      .select("-content");
+
+    return res.json(versions);
+  } catch (err) {
+    return res.status(500).json({ error: (err as Error).message });
+  }
+};
+
+export const RecordPurchase = async (req: Request, res: Response): Promise<Response> => {
+  try {
+    await connectDb();
+    const { promptId, buyerWallet, txHash } = req.body;
+
+    if (!promptId || !buyerWallet) {
+      return res.status(400).json({ error: "promptId and buyerWallet are required." });
+    }
+
+    const prompt = await Prompt.findById(promptId);
+    if (!prompt) return res.status(404).json({ error: "Prompt not found." });
+
+    const existing = await Purchase.findOne({
+      promptId,
+      buyerWallet: buyerWallet.toLowerCase(),
+    });
+
+    if (existing) {
+      return res.status(200).json({ message: "Already purchased.", versionIndex: existing.versionIndex });
+    }
+
+    const purchase = await Purchase.create({
+      promptId,
+      buyerWallet: buyerWallet.toLowerCase(),
+      versionIndex: prompt.currentVersionIndex ?? 1,
+      txHash: txHash ?? "",
+    });
+
+    return res.status(201).json({ message: "Purchase recorded.", versionIndex: purchase.versionIndex });
+  } catch (err) {
+    return res.status(500).json({ error: (err as Error).message });
+  }
+};
+
+export const GetBuyerVersion = async (req: Request, res: Response): Promise<Response> => {
+  try {
+    await connectDb();
+    const { promptId, buyerWallet } = req.query;
+
+    if (!promptId || !buyerWallet) {
+      return res.status(400).json({ error: "promptId and buyerWallet query params are required." });
+    }
+
+    const purchase = await Purchase.findOne({
+      promptId: String(promptId),
+      buyerWallet: String(buyerWallet).toLowerCase(),
+    });
+
+    if (!purchase) {
+      return res.status(404).json({ error: "No purchase record found." });
+    }
+
+    const version = await PromptVersion.findOne({
+      promptId: String(promptId),
+      versionIndex: purchase.versionIndex,
+    });
+
+    const prompt = await Prompt.findById(promptId).lean();
+
+    return res.json({
+      versionIndex: purchase.versionIndex,
+      changeNote: version?.changeNote ?? "",
+      content: version?.content ?? (prompt as any)?.content ?? null,
+      purchasedAt: purchase.createdAt,
+    });
+  } catch (err) {
+    return res.status(500).json({ error: (err as Error).message });
+  }
+};

--- a/server/src/controllers/webhookControllers.ts
+++ b/server/src/controllers/webhookControllers.ts
@@ -1,0 +1,89 @@
+import { Request, Response } from "express";
+import { randomBytes } from "crypto";
+import connectDb from "../db/connectDb";
+import WebhookSubscription from "../models/WebhookSubscription";
+
+export const RegisterWebhook = async (req: Request, res: Response): Promise<Response> => {
+  try {
+    await connectDb();
+    const { walletAddress, url, events } = req.body;
+
+    if (!walletAddress || !url) {
+      return res.status(400).json({ error: "walletAddress and url are required." });
+    }
+
+    try {
+      new URL(url);
+    } catch {
+      return res.status(400).json({ error: "url must be a valid URL." });
+    }
+
+    const secret = randomBytes(32).toString("hex");
+    const allowedEvents = ["PromptPurchased"];
+    const resolvedEvents = Array.isArray(events)
+      ? events.filter((e: string) => allowedEvents.includes(e))
+      : ["PromptPurchased"];
+
+    const existing = await WebhookSubscription.findOne({
+      walletAddress: walletAddress.toLowerCase(),
+    });
+
+    if (existing) {
+      existing.url = url;
+      existing.events = resolvedEvents;
+      existing.active = true;
+      existing.failureCount = 0;
+      await existing.save();
+      return res.status(200).json({ message: "Webhook updated.", id: existing._id, secret });
+    }
+
+    const sub = new WebhookSubscription({
+      walletAddress: walletAddress.toLowerCase(),
+      url,
+      secret,
+      events: resolvedEvents,
+    });
+    await sub.save();
+
+    return res.status(201).json({ message: "Webhook registered.", id: sub._id, secret });
+  } catch (err) {
+    return res.status(500).json({ error: (err as Error).message });
+  }
+};
+
+export const GetWebhook = async (req: Request, res: Response): Promise<Response> => {
+  try {
+    await connectDb();
+    const { walletAddress } = req.query;
+
+    if (!walletAddress) {
+      return res.status(400).json({ error: "walletAddress query param is required." });
+    }
+
+    const sub = await WebhookSubscription.findOne({
+      walletAddress: String(walletAddress).toLowerCase(),
+    }).select("-secret");
+
+    if (!sub) return res.status(404).json({ error: "No webhook registered for this wallet." });
+
+    return res.json(sub);
+  } catch (err) {
+    return res.status(500).json({ error: (err as Error).message });
+  }
+};
+
+export const DeleteWebhook = async (req: Request, res: Response): Promise<Response> => {
+  try {
+    await connectDb();
+    const { walletAddress } = req.body;
+
+    if (!walletAddress) {
+      return res.status(400).json({ error: "walletAddress is required." });
+    }
+
+    await WebhookSubscription.deleteOne({ walletAddress: walletAddress.toLowerCase() });
+    return res.status(200).json({ message: "Webhook removed." });
+  } catch (err) {
+    return res.status(500).json({ error: (err as Error).message });
+  }
+};

--- a/server/src/models/Prompt.js
+++ b/server/src/models/Prompt.js
@@ -49,6 +49,11 @@ const promptSchema = new mongoose.Schema(
       ],
       default: "Other",
     },
+    currentVersionIndex: {
+      type: Number,
+      default: 1,
+      min: 1,
+    },
   },
   {
     timestamps: true,

--- a/server/src/models/PromptVersion.ts
+++ b/server/src/models/PromptVersion.ts
@@ -1,0 +1,38 @@
+import mongoose from "mongoose";
+
+const promptVersionSchema = new mongoose.Schema(
+  {
+    promptId: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    versionIndex: {
+      type: Number,
+      required: true,
+    },
+    content: {
+      type: String,
+      required: true,
+    },
+    changeNote: {
+      type: String,
+      default: "",
+      trim: true,
+    },
+    createdBy: {
+      type: String,
+      required: true,
+      lowercase: true,
+    },
+  },
+  { timestamps: true },
+);
+
+promptVersionSchema.index({ promptId: 1, versionIndex: 1 }, { unique: true });
+
+const PromptVersion =
+  mongoose.models.PromptVersion ||
+  mongoose.model("PromptVersion", promptVersionSchema);
+
+export default PromptVersion;

--- a/server/src/models/Purchase.ts
+++ b/server/src/models/Purchase.ts
@@ -1,0 +1,31 @@
+import mongoose from "mongoose";
+
+const purchaseSchema = new mongoose.Schema(
+  {
+    promptId: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    buyerWallet: {
+      type: String,
+      required: true,
+      lowercase: true,
+      index: true,
+    },
+    versionIndex: {
+      type: Number,
+      required: true,
+    },
+    txHash: {
+      type: String,
+      default: "",
+    },
+  },
+  { timestamps: true },
+);
+
+purchaseSchema.index({ promptId: 1, buyerWallet: 1 });
+
+const Purchase = mongoose.models.Purchase || mongoose.model("Purchase", purchaseSchema);
+export default Purchase;

--- a/server/src/models/WebhookSubscription.ts
+++ b/server/src/models/WebhookSubscription.ts
@@ -1,0 +1,44 @@
+import mongoose from "mongoose";
+
+const webhookSubscriptionSchema = new mongoose.Schema(
+  {
+    walletAddress: {
+      type: String,
+      required: true,
+      lowercase: true,
+      index: true,
+    },
+    url: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    secret: {
+      type: String,
+      required: true,
+    },
+    events: {
+      type: [String],
+      default: ["PromptPurchased"],
+    },
+    active: {
+      type: Boolean,
+      default: true,
+    },
+    failureCount: {
+      type: Number,
+      default: 0,
+    },
+    lastDeliveredAt: {
+      type: Date,
+      default: null,
+    },
+  },
+  { timestamps: true },
+);
+
+const WebhookSubscription =
+  mongoose.models.WebhookSubscription ||
+  mongoose.model("WebhookSubscription", webhookSubscriptionSchema);
+
+export default WebhookSubscription;

--- a/server/src/routes/versioningRoutes.ts
+++ b/server/src/routes/versioningRoutes.ts
@@ -1,0 +1,18 @@
+import express from "express";
+import {
+  GetBuyerVersion,
+  GetPromptVersions,
+  PostPromptUpdate,
+  RecordPurchase,
+} from "../controllers/versioningControllers";
+
+export const versioningRouter = express.Router();
+
+// Creator posts a new content version.
+versioningRouter.post("/update", PostPromptUpdate);
+// List version history for a prompt (metadata only, no content).
+versioningRouter.get("/:promptId/history", GetPromptVersions);
+// Record a purchase at the current version index.
+versioningRouter.post("/purchase", RecordPurchase);
+// Get the version a specific buyer purchased (for unlock).
+versioningRouter.get("/buyer-version", GetBuyerVersion);

--- a/server/src/routes/webhookRoutes.ts
+++ b/server/src/routes/webhookRoutes.ts
@@ -1,0 +1,8 @@
+import express from "express";
+import { DeleteWebhook, GetWebhook, RegisterWebhook } from "../controllers/webhookControllers";
+
+export const webhookRouter = express.Router();
+
+webhookRouter.post("/", RegisterWebhook);
+webhookRouter.get("/", GetWebhook);
+webhookRouter.delete("/", DeleteWebhook);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -5,6 +5,7 @@ import { promptRouter } from "./routes/promptRoutes";
 import { userRouter } from "./routes/userRoutes";
 import { chatRouter } from "./routes/chatRoutes";
 import { webhookRouter } from "./routes/webhookRoutes";
+import { versioningRouter } from "./routes/versioningRoutes";
 
 const app = express();
 
@@ -20,6 +21,7 @@ app.use("/api/user", userRouter);
 
 app.use("/api/chat", chatRouter);
 app.use("/api/webhooks", webhookRouter);
+app.use("/api/versions", versioningRouter);
 
 app.get("/health", (req, res) => {
   res.json({ status: "ok" });

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -4,6 +4,7 @@ import { proxyrouter } from "./routes/proxyRoutes";
 import { promptRouter } from "./routes/promptRoutes";
 import { userRouter } from "./routes/userRoutes";
 import { chatRouter } from "./routes/chatRoutes";
+import { webhookRouter } from "./routes/webhookRoutes";
 
 const app = express();
 
@@ -18,6 +19,7 @@ app.use("/api/prompts", promptRouter);
 app.use("/api/user", userRouter);
 
 app.use("/api/chat", chatRouter);
+app.use("/api/webhooks", webhookRouter);
 
 app.get("/health", (req, res) => {
   res.json({ status: "ok" });

--- a/server/src/services/webhookDispatcher.ts
+++ b/server/src/services/webhookDispatcher.ts
@@ -1,0 +1,95 @@
+import { createHmac, randomUUID } from "crypto";
+import WebhookSubscription from "../models/WebhookSubscription";
+
+const MAX_RETRIES = 3;
+const RETRY_DELAYS_MS = [2_000, 10_000, 30_000];
+const MAX_FAILURES_BEFORE_DISABLE = 10;
+
+export interface WebhookPayload {
+  event: string;
+  deliveryId: string;
+  timestamp: string;
+  data: Record<string, unknown>;
+}
+
+function signPayload(secret: string, body: string): string {
+  return `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+}
+
+async function deliverOnce(url: string, secret: string, payload: WebhookPayload): Promise<void> {
+  const body = JSON.stringify(payload);
+  const signature = signPayload(secret, body);
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-PromptHash-Signature": signature,
+      "X-PromptHash-Delivery": payload.deliveryId,
+      "X-PromptHash-Event": payload.event,
+    },
+    body,
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!res.ok) throw new Error(`Webhook delivery failed with status ${res.status}`);
+}
+
+async function deliverWithRetry(
+  subscriptionId: string,
+  url: string,
+  secret: string,
+  payload: WebhookPayload,
+): Promise<void> {
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      await deliverOnce(url, secret, payload);
+      await WebhookSubscription.findByIdAndUpdate(subscriptionId, {
+        lastDeliveredAt: new Date(),
+        $set: { failureCount: 0 },
+      });
+      return;
+    } catch (err) {
+      const isLastAttempt = attempt === MAX_RETRIES;
+      if (!isLastAttempt) {
+        await new Promise((r) => setTimeout(r, RETRY_DELAYS_MS[attempt]));
+        continue;
+      }
+
+      const updated = await WebhookSubscription.findByIdAndUpdate(
+        subscriptionId,
+        { $inc: { failureCount: 1 } },
+        { new: true },
+      );
+
+      if (updated && updated.failureCount >= MAX_FAILURES_BEFORE_DISABLE) {
+        await WebhookSubscription.findByIdAndUpdate(subscriptionId, { active: false });
+      }
+    }
+  }
+}
+
+export async function dispatchEvent(
+  creatorWallet: string,
+  event: string,
+  data: Record<string, unknown>,
+): Promise<void> {
+  const subscriptions = await WebhookSubscription.find({
+    walletAddress: creatorWallet.toLowerCase(),
+    active: true,
+    events: event,
+  });
+
+  const payload: WebhookPayload = {
+    event,
+    deliveryId: randomUUID(),
+    timestamp: new Date().toISOString(),
+    data,
+  };
+
+  await Promise.allSettled(
+    subscriptions.map((sub) =>
+      deliverWithRetry(String(sub._id), sub.url, sub.secret, payload),
+    ),
+  );
+}

--- a/src/components/PostVersionUpdate.tsx
+++ b/src/components/PostVersionUpdate.tsx
@@ -1,0 +1,110 @@
+import { useState } from "react";
+import { History, Loader2, Send } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface Props {
+  promptId: string;
+  promptTitle: string;
+  walletAddress: string;
+  currentVersion: number;
+  onSuccess?: (newVersion: number) => void;
+}
+
+export function PostVersionUpdate({ promptId, promptTitle, walletAddress, currentVersion, onSuccess }: Props) {
+  const [open, setOpen] = useState(false);
+  const [content, setContent] = useState("");
+  const [changeNote, setChangeNote] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState<number | null>(null);
+
+  const submit = async () => {
+    if (!content.trim()) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/prompts/version", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ promptId, walletAddress, content, changeNote }),
+      });
+      const data = await res.json();
+      if (!res.ok) { setError(data.error ?? "Failed to post version."); return; }
+      setDone(data.versionIndex);
+      setContent("");
+      setChangeNote("");
+      onSuccess?.(data.versionIndex);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!open) {
+    return (
+      <Button
+        variant="outline"
+        className="h-9 border-white/15 bg-white/[0.03] text-slate-300 hover:bg-white/10"
+        onClick={() => setOpen(true)}
+      >
+        <History className="h-4 w-4" />
+        Post update (v{currentVersion})
+      </Button>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-white/10 bg-white/[0.03] p-5 space-y-4">
+      <div className="flex items-center gap-2 text-sm font-medium text-white">
+        <History className="h-4 w-4 text-amber-300" />
+        Post new version for <span className="text-amber-200">{promptTitle}</span>
+        <span className="ml-auto text-xs text-slate-500">Current: v{currentVersion}</span>
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-rose-300/25 bg-rose-400/10 px-4 py-2.5 text-sm text-rose-100">
+          {error}
+        </div>
+      )}
+
+      {done && (
+        <div className="rounded-lg border border-emerald-300/25 bg-emerald-300/10 px-4 py-2.5 text-sm text-emerald-100">
+          Version v{done} posted. Past buyers keep access to the version they purchased.
+        </div>
+      )}
+
+      <textarea
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        placeholder="Paste the updated prompt content here…"
+        rows={6}
+        className="w-full rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2.5 text-sm text-slate-100 placeholder-slate-500 focus:outline-none focus:ring-1 focus:ring-amber-300/40 resize-y"
+      />
+
+      <Input
+        value={changeNote}
+        onChange={(e) => setChangeNote(e.target.value)}
+        placeholder="What changed? (optional)"
+        className="h-9 border-white/10 bg-white/[0.04] text-slate-100"
+      />
+
+      <div className="flex gap-2">
+        <Button
+          className="h-9 bg-amber-300 text-slate-950 hover:bg-amber-200 disabled:opacity-50"
+          onClick={() => void submit()}
+          disabled={busy || !content.trim()}
+        >
+          {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+          Publish v{currentVersion + 1}
+        </Button>
+        <Button
+          variant="outline"
+          className="h-9 border-white/15 bg-white/[0.03] text-slate-300 hover:bg-white/10"
+          onClick={() => setOpen(false)}
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/WebhookSettings.tsx
+++ b/src/components/WebhookSettings.tsx
@@ -1,0 +1,172 @@
+import { useState } from "react";
+import { Globe, Loader2, PlugZap, Save, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface WebhookInfo {
+  _id: string;
+  url: string;
+  events: string[];
+  active: boolean;
+  lastDeliveredAt: string | null;
+}
+
+interface Props {
+  walletAddress: string;
+}
+
+export function WebhookSettings({ walletAddress }: Props) {
+  const [url, setUrl] = useState("");
+  const [saved, setSaved] = useState<WebhookInfo | null>(null);
+  const [secret, setSecret] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  const load = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/webhooks?walletAddress=${encodeURIComponent(walletAddress)}`);
+      if (res.status === 404) {
+        setSaved(null);
+      } else if (res.ok) {
+        const data = await res.json();
+        setSaved(data);
+        setUrl(data.url ?? "");
+      } else {
+        const data = await res.json();
+        setError(data.error ?? "Failed to load webhook.");
+      }
+    } finally {
+      setBusy(false);
+      setLoaded(true);
+    }
+  };
+
+  const save = async () => {
+    setBusy(true);
+    setError(null);
+    setSecret(null);
+    try {
+      const res = await fetch("/api/webhooks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ walletAddress, url }),
+      });
+      const data = await res.json();
+      if (!res.ok) { setError(data.error ?? "Failed to save."); return; }
+      setSecret(data.secret);
+      await load();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const remove = async () => {
+    if (!saved) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await fetch("/api/webhooks", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ walletAddress }),
+      });
+      setSaved(null);
+      setUrl("");
+      setSecret(null);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!loaded) {
+    return (
+      <div className="rounded-xl border border-white/10 bg-white/[0.03] p-6">
+        <div className="flex items-center gap-3 mb-4">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-violet-400/10 text-violet-300">
+            <Globe className="h-5 w-5" />
+          </div>
+          <div>
+            <h3 className="font-semibold text-white">Webhook Notifications</h3>
+            <p className="text-xs text-slate-400">Receive a POST request when your prompt is sold.</p>
+          </div>
+        </div>
+        <Button
+          className="h-9 bg-violet-500 text-white hover:bg-violet-400"
+          onClick={() => void load()}
+          disabled={busy}
+        >
+          {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <PlugZap className="h-4 w-4" />}
+          Load webhook settings
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-white/10 bg-white/[0.03] p-6 space-y-5">
+      <div className="flex items-center gap-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-violet-400/10 text-violet-300">
+          <Globe className="h-5 w-5" />
+        </div>
+        <div>
+          <h3 className="font-semibold text-white">Webhook Notifications</h3>
+          <p className="text-xs text-slate-400">
+            {saved ? (saved.active ? "Active — receiving PromptPurchased events." : "Disabled after repeated failures.") : "No webhook registered yet."}
+          </p>
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-rose-300/25 bg-rose-400/10 px-4 py-2.5 text-sm text-rose-100">
+          {error}
+        </div>
+      )}
+
+      {secret && (
+        <div className="rounded-lg border border-emerald-300/25 bg-emerald-300/10 px-4 py-3 text-sm text-emerald-100 space-y-1">
+          <p className="font-medium">Webhook secret — save this now, it won't be shown again.</p>
+          <code className="block break-all font-mono text-xs text-emerald-200">{secret}</code>
+        </div>
+      )}
+
+      <div className="flex gap-2">
+        <Input
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="https://your-server.com/webhook"
+          className="h-10 border-white/10 bg-white/[0.04] text-slate-100 flex-1"
+        />
+        <Button
+          className="h-10 shrink-0 bg-violet-500 text-white hover:bg-violet-400 disabled:opacity-50"
+          onClick={() => void save()}
+          disabled={busy || !url}
+        >
+          {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+          {saved ? "Update" : "Register"}
+        </Button>
+        {saved && (
+          <Button
+            variant="outline"
+            className="h-10 shrink-0 border-white/15 bg-white/[0.03] text-rose-300 hover:bg-rose-400/10"
+            onClick={() => void remove()}
+            disabled={busy}
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+
+      {saved && (
+        <p className="text-xs text-slate-500">
+          Events: {saved.events.join(", ")} ·{" "}
+          {saved.lastDeliveredAt
+            ? `Last delivered ${new Date(saved.lastDeliveredAt).toLocaleString()}`
+            : "Not yet delivered"}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/lib/observability/rateLimiter.ts
+++ b/src/lib/observability/rateLimiter.ts
@@ -1,56 +1,83 @@
 import LRUCache from "lru-cache";
+import { getRedisClient } from "./redisClient";
 
 interface RateLimitConfig {
-  max: number;      // Maximum requests in the window
-  windowMs: number; // Time window in milliseconds
+  max: number;
+  windowMs: number;
 }
 
-const defaultLimits: Record<string, RateLimitConfig> = {
-  challenge: { max: 10, windowMs: 60 * 1000 }, // 10 requests per minute
-  unlock: { max: 5, windowMs: 60 * 1000 },    // 5 requests per minute
+// Unauthenticated (no wallet address provided) requests get stricter limits.
+const limits: Record<string, { authenticated: RateLimitConfig; unauthenticated: RateLimitConfig }> = {
+  challenge: {
+    unauthenticated: { max: 5, windowMs: 60_000 },
+    authenticated: { max: 10, windowMs: 60_000 },
+  },
+  unlock: {
+    unauthenticated: { max: 3, windowMs: 60_000 },
+    authenticated: { max: 5, windowMs: 60_000 },
+  },
 };
 
-const caches = new Map<string, LRUCache<string, number>>();
+// In-memory LRU fallback used when Redis is unavailable.
+const fallbackCaches = new Map<string, LRUCache<string, number>>();
 
-function getCache(key: string, config: RateLimitConfig) {
-  if (!caches.has(key)) {
-    caches.set(
-      key,
-      new LRUCache<string, number>({
-        max: 1000, // Max unique keys (IPs/Wallets) to track
-        ttl: config.windowMs,
-      })
-    );
+function getFallbackCache(key: string, config: RateLimitConfig) {
+  if (!fallbackCaches.has(key)) {
+    fallbackCaches.set(key, new LRUCache<string, number>({ max: 1000, ttl: config.windowMs }));
   }
-  return caches.get(key)!;
+  return fallbackCaches.get(key)!;
 }
 
-export function checkRateLimit(
+function inMemoryCheck(
+  bucketKey: string,
+  config: RateLimitConfig,
+): { success: boolean; limit: number; remaining: number; reset: number } {
+  const cache = getFallbackCache(bucketKey, config);
+  const current = cache.get(bucketKey) ?? 0;
+  const remaining = Math.max(0, config.max - (current + 1));
+  if (current >= config.max) {
+    return { success: false, limit: config.max, remaining: 0, reset: config.windowMs };
+  }
+  cache.set(bucketKey, current + 1);
+  return { success: true, limit: config.max, remaining, reset: config.windowMs };
+}
+
+async function redisCheck(
+  redis: Awaited<ReturnType<typeof getRedisClient>>,
+  bucketKey: string,
+  config: RateLimitConfig,
+): Promise<{ success: boolean; limit: number; remaining: number; reset: number }> {
+  const key = `rl:${bucketKey}`;
+  const windowSec = Math.ceil(config.windowMs / 1000);
+
+  const multi = redis!.multi();
+  multi.incr(key);
+  multi.expire(key, windowSec, "NX");
+  const [count] = (await multi.exec()) as [number, ...unknown[]];
+
+  const ttlSec = await redis!.ttl(key);
+  const reset = ttlSec > 0 ? ttlSec * 1000 : config.windowMs;
+
+  if (count > config.max) {
+    return { success: false, limit: config.max, remaining: 0, reset };
+  }
+  return { success: true, limit: config.max, remaining: Math.max(0, config.max - count), reset };
+}
+
+export async function checkRateLimit(
   type: "challenge" | "unlock",
   identifier: string,
-  configOverrides?: Partial<RateLimitConfig>
-): { success: boolean; limit: number; remaining: number; reset: number } {
-  const config = { ...defaultLimits[type], ...configOverrides };
-  const cache = getCache(type, config);
+  authenticated = false,
+): Promise<{ success: boolean; limit: number; remaining: number; reset: number }> {
+  const config = limits[type][authenticated ? "authenticated" : "unauthenticated"];
+  const bucketKey = `${type}:${identifier}`;
 
-  const current = cache.get(identifier) || 0;
-  const remaining = Math.max(0, config.max - (current + 1));
-
-  if (current >= config.max) {
-    return {
-      success: false,
-      limit: config.max,
-      remaining: 0,
-      reset: config.windowMs, // Rough estimate
-    };
+  try {
+    const redis = await getRedisClient();
+    if (redis) return await redisCheck(redis, bucketKey, config);
+  } catch {
+    // Redis unavailable — fall back to in-memory.
   }
 
-  cache.set(identifier, current + 1);
-
-  return {
-    success: true,
-    limit: config.max,
-    remaining,
-    reset: config.windowMs,
-  };
+  return inMemoryCheck(bucketKey, config);
 }

--- a/src/lib/observability/redisClient.ts
+++ b/src/lib/observability/redisClient.ts
@@ -1,0 +1,26 @@
+import { createClient, type RedisClientType } from "redis";
+
+let client: RedisClientType | null = null;
+
+export async function getRedisClient(): Promise<RedisClientType | null> {
+  if (!process.env.REDIS_URL) return null;
+
+  if (client) return client;
+
+  client = createClient({ url: process.env.REDIS_URL }) as RedisClientType;
+
+  client.on("error", (err) => {
+    console.error("Redis client error:", err);
+    client = null;
+  });
+
+  await client.connect();
+  return client;
+}
+
+export async function closeRedisClient() {
+  if (client) {
+    await client.quit();
+    client = null;
+  }
+}

--- a/src/pages/profile/page.tsx
+++ b/src/pages/profile/page.tsx
@@ -27,6 +27,7 @@ import {
 import { Footer } from "@/components/footer";
 import { Navigation } from "@/components/navigation";
 import { WebhookSettings } from "@/components/WebhookSettings";
+import { PostVersionUpdate } from "@/components/PostVersionUpdate";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -471,6 +472,7 @@ function CreatedPromptCard({
   prompt,
   isBusy,
   priceDraft,
+  walletAddress,
   onDraftChange,
   onUpdatePrice,
   onToggleStatus,
@@ -478,10 +480,12 @@ function CreatedPromptCard({
   prompt: PromptRecord;
   isBusy: boolean;
   priceDraft: string;
+  walletAddress: string;
   onDraftChange: Handler<[string]>;
   onUpdatePrice: Handler<[bigint]>;
   onToggleStatus: Handler<[bigint, boolean]>;
 }) {
+  const [currentVersion, setCurrentVersion] = useState(1);
   const isActive = prompt.active;
 
   return (
@@ -575,6 +579,15 @@ function CreatedPromptCard({
               )}
               {isActive ? "Pause listing" : "Reactivate"}
             </Button>
+          </div>
+          <div className="mt-4">
+            <PostVersionUpdate
+              promptId={prompt.id.toString()}
+              promptTitle={prompt.title}
+              walletAddress={walletAddress}
+              currentVersion={currentVersion}
+              onSuccess={(v) => setCurrentVersion(v)}
+            />
           </div>
         </div>
       </div>
@@ -825,6 +838,7 @@ export default function ProfilePage() {
                           prompt={prompt}
                           isBusy={busyPromptId === prompt.id.toString()}
                           priceDraft={mergedDrafts[prompt.id.toString()]}
+                          walletAddress={address}
                           onDraftChange={(value) =>
                             setPriceDrafts((current) => ({
                               ...current,

--- a/src/pages/profile/page.tsx
+++ b/src/pages/profile/page.tsx
@@ -26,6 +26,7 @@ import {
 } from "lucide-react";
 import { Footer } from "@/components/footer";
 import { Navigation } from "@/components/navigation";
+import { WebhookSettings } from "@/components/WebhookSettings";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -838,6 +839,7 @@ export default function ProfilePage() {
                       ))}
                     </div>
                   )}
+                  <WebhookSettings walletAddress={address} />
                 </TabsContent>
               </Tabs>
             </section>


### PR DESCRIPTION
## Summary

- Adds `PromptVersion` collection storing per-version content with `versionIndex`, `changeNote`, and `createdBy`
- Adds `Purchase` collection that snapshots `versionIndex` at buy time so each buyer is always served the version they paid for
- Extends the `Prompt` model with `currentVersionIndex` (default `1`)
- Creators post new content via `POST /api/prompts/version`; unlock resolves the buyer's entitled version via `GET /api/prompts/version?promptId=&buyerWallet=`
- Express server routes mirrored under `/api/versions`
- Frontend adds a `PostVersionUpdate` collapsible panel inside each `CreatedPromptCard`

## Key files

- `server/src/models/PromptVersion.ts`
- `server/src/models/Purchase.ts`
- `server/src/controllers/versioningControllers.ts`
- `api/prompts/version.ts`
- `src/components/PostVersionUpdate.tsx`

## Test plan

- [ ] Create a prompt, confirm `currentVersionIndex` starts at `1`
- [ ] Post an update via the UI — confirm `currentVersionIndex` increments and a `PromptVersion` doc is created
- [ ] Record a purchase before the update — confirm `GET /api/prompts/version` returns v1 content for that buyer
- [ ] Record a purchase after the update — confirm they receive v2 content
- [ ] Confirm history endpoint returns metadata without content

closes #65

