### PR TITLE
fix(contract): add global pause guard and leased access

### DIFF
--- a/contracts/prompt-hash/src/contract.rs
+++ b/contracts/prompt-hash/src/contract.rs
@@ -14,6 +14,8 @@ const MAX_ENCRYPTED_PROMPT_LEN: u32 = 4096;
 const MAX_WRAPPED_KEY_LEN: u32 = 256;
 const MAX_IMAGE_URL_LEN: u32 = 512;
 const MAX_IV_LEN: u32 = 64;
+const LEASE_PRICE_BPS: u32 = 4_000;
+const MAX_ACCESS_EXPIRY: u64 = u64::MAX;
 
 #[contract]
 pub struct PromptHashContract;
@@ -30,6 +32,7 @@ impl PromptHashTrait for PromptHashContract {
         Storage::set_fee_wallet(&env, &fee_wallet);
         Storage::set_fee_percentage(&env, &DEFAULT_FEE_BPS);
         Storage::set_xlm_address(&env, &xlm_sac);
+        Storage::set_pause_status(&env, false);
         env.storage().instance().extend_ttl(
             super::storage::PERSISTENT_LIFETIME_THRESHOLD,
             super::storage::PERSISTENT_BUMP_AMOUNT,
@@ -52,6 +55,7 @@ impl PromptHashTrait for PromptHashContract {
         price_stroops: i128,
     ) -> Result<u128, Error> {
         creator.require_auth();
+        require_not_paused(&env)?;
         validate_prompt_fields(
             &image_url,
             &title,
@@ -109,6 +113,7 @@ impl PromptHashTrait for PromptHashContract {
         price_stroops: i128,
     ) -> Result<(), Error> {
         creator.require_auth();
+        require_not_paused(&env)?;
         ensure(price_stroops > 0, Error::InvalidPrice)?;
 
         let mut prompt = Storage::require_prompt(&env, prompt_id)?;
@@ -122,11 +127,16 @@ impl PromptHashTrait for PromptHashContract {
 
     fn buy_prompt(env: Env, buyer: Address, prompt_id: u128) -> Result<(), Error> {
         buyer.require_auth();
+        require_not_paused(&env)?;
         let mut prompt = Storage::require_prompt(&env, prompt_id)?;
+        let now = env.ledger().timestamp();
 
         ensure(prompt.active, Error::PromptInactive)?;
         ensure(prompt.creator != buyer, Error::CreatorCannotBuy)?;
-        ensure(!Storage::has_purchase(&env, prompt_id, &buyer), Error::AlreadyPurchased)?;
+        ensure(
+            !Storage::has_active_purchase(&env, prompt_id, &buyer, now),
+            Error::AlreadyPurchased,
+        )?;
 
         Storage::set_reentrancy_guard(&env)?;
 
@@ -156,7 +166,7 @@ impl PromptHashTrait for PromptHashContract {
             .checked_add(1)
             .ok_or(Error::ArithmeticOverflow)?;
         Storage::update_prompt(&env, &prompt);
-        Storage::grant_purchase(&env, prompt_id, &buyer);
+        Storage::grant_purchase(&env, prompt_id, &buyer, MAX_ACCESS_EXPIRY);
         Storage::clear_reentrancy_guard(&env);
         Events::emit_prompt_purchased(
             &env,
@@ -168,9 +178,74 @@ impl PromptHashTrait for PromptHashContract {
         Ok(())
     }
 
+    fn lease_prompt(
+        env: Env,
+        buyer: Address,
+        prompt_id: u128,
+        lease_duration_secs: u64,
+    ) -> Result<(), Error> {
+        buyer.require_auth();
+        require_not_paused(&env)?;
+        let mut prompt = Storage::require_prompt(&env, prompt_id)?;
+        let now = env.ledger().timestamp();
+
+        ensure(prompt.active, Error::PromptInactive)?;
+        ensure(prompt.creator != buyer, Error::CreatorCannotBuy)?;
+        ensure(lease_duration_secs > 0, Error::InvalidPrice)?;
+        ensure(
+            !Storage::has_active_purchase(&env, prompt_id, &buyer, now),
+            Error::AlreadyPurchased,
+        )?;
+
+        Storage::set_reentrancy_guard(&env)?;
+
+        let fee_wallet = Storage::get_fee_wallet(&env).ok_or(Error::FeeWalletNotSet)?;
+        let this_contract = env.current_contract_address();
+        let fee_percentage = Storage::get_fee_percentage(&env);
+        ensure(fee_percentage <= MAX_BPS, Error::InvalidFeePercentage)?;
+
+        let lease_price = prompt
+            .price_stroops
+            .checked_mul(LEASE_PRICE_BPS as i128)
+            .ok_or(Error::ArithmeticOverflow)?
+            / MAX_BPS as i128;
+        ensure(lease_price > 0, Error::InvalidPrice)?;
+
+        let fee_amount = lease_price
+            .checked_mul(fee_percentage as i128)
+            .ok_or(Error::ArithmeticOverflow)?
+            / MAX_BPS as i128;
+        let seller_amount = lease_price
+            .checked_sub(fee_amount)
+            .ok_or(Error::ArithmeticOverflow)?;
+
+        let xlm = Storage::get_stellar_asset_contract(&env)?;
+        xlm.transfer_from(&this_contract, &buyer, &prompt.creator, &seller_amount);
+        if fee_amount > 0 {
+            xlm.transfer_from(&this_contract, &buyer, &fee_wallet, &fee_amount);
+        }
+
+        prompt.sales_count = prompt
+            .sales_count
+            .checked_add(1)
+            .ok_or(Error::ArithmeticOverflow)?;
+        let expires_at = now
+            .checked_add(lease_duration_secs)
+            .ok_or(Error::ArithmeticOverflow)?;
+        Storage::update_prompt(&env, &prompt);
+        Storage::grant_purchase(&env, prompt_id, &buyer, expires_at);
+        Storage::clear_reentrancy_guard(&env);
+        Events::emit_prompt_purchased(&env, prompt_id, buyer, prompt.creator, lease_price);
+        Ok(())
+    }
+
     fn has_access(env: Env, user: Address, prompt_id: u128) -> Result<bool, Error> {
         let prompt = Storage::require_prompt(&env, prompt_id)?;
-        Ok(prompt.creator == user || Storage::has_purchase(&env, prompt_id, &user))
+        let now = env.ledger().timestamp();
+        Ok(
+            prompt.creator == user
+                || Storage::has_active_purchase(&env, prompt_id, &user, now),
+        )
     }
 
     fn get_prompt(env: Env, prompt_id: u128) -> Result<Prompt, Error> {
@@ -214,6 +289,16 @@ impl PromptHashTrait for PromptHashContract {
 
     fn get_xlm_sac(env: Env) -> Option<Address> {
         Storage::get_xlm_address(&env)
+    }
+
+    #[only_owner]
+    fn set_pause_status(env: Env, is_paused: bool) -> Result<(), Error> {
+        Storage::set_pause_status(&env, is_paused);
+        Ok(())
+    }
+
+    fn get_pause_status(env: Env) -> bool {
+        Storage::get_pause_status(&env)
     }
 
     #[only_owner]
@@ -271,4 +356,8 @@ fn ensure(condition: bool, error: Error) -> Result<(), Error> {
     } else {
         Err(error)
     }
+}
+
+fn require_not_paused(env: &Env) -> Result<(), Error> {
+    ensure(!Storage::get_pause_status(env), Error::ContractPaused)
 }

--- a/contracts/prompt-hash/src/storage.rs
+++ b/contracts/prompt-hash/src/storage.rs
@@ -1,4 +1,4 @@
-use super::types::{DataKey, Error, Prompt};
+use super::types::{DataKey, Error, Prompt, Purchase};
 use soroban_sdk::{token, Address, Env, Vec};
 
 pub const DAY_IN_LEDGERS: u32 = 17280;
@@ -127,18 +127,25 @@ impl Storage {
         Self::extend_key_ttl(env, &key);
     }
 
-    pub fn has_purchase(env: &Env, prompt_id: u128, buyer: &Address) -> bool {
+    pub fn get_purchase(env: &Env, prompt_id: u128, buyer: &Address) -> Option<Purchase> {
         let key = DataKey::Purchase(prompt_id, buyer.clone());
-        let has = env.storage().persistent().get(&key).unwrap_or(false);
+        let purchase = env.storage().persistent().get(&key);
         if env.storage().persistent().has(&key) {
             Self::extend_key_ttl(env, &key);
         }
-        has
+        purchase
     }
 
-    pub fn grant_purchase(env: &Env, prompt_id: u128, buyer: &Address) {
+    pub fn has_active_purchase(env: &Env, prompt_id: u128, buyer: &Address, now: u64) -> bool {
+        Self::get_purchase(env, prompt_id, buyer)
+            .map(|purchase| purchase.expires_at >= now)
+            .unwrap_or(false)
+    }
+
+    pub fn grant_purchase(env: &Env, prompt_id: u128, buyer: &Address, expires_at: u64) {
         let key = DataKey::Purchase(prompt_id, buyer.clone());
-        env.storage().persistent().set(&key, &true);
+        let purchase = Purchase { expires_at };
+        env.storage().persistent().set(&key, &purchase);
         Self::extend_key_ttl(env, &key);
         Self::add_prompt_to_buyer(env, buyer, prompt_id);
     }
@@ -206,5 +213,20 @@ impl Storage {
         let key = DataKey::Reentrancy;
         env.storage().persistent().set(&key, &false);
         Self::extend_key_ttl(env, &key);
+    }
+
+    pub fn set_pause_status(env: &Env, is_paused: bool) {
+        let key = DataKey::PauseStatus;
+        env.storage().persistent().set(&key, &is_paused);
+        Self::extend_key_ttl(env, &key);
+    }
+
+    pub fn get_pause_status(env: &Env) -> bool {
+        let key = DataKey::PauseStatus;
+        let is_paused = env.storage().persistent().get(&key).unwrap_or(false);
+        if env.storage().persistent().has(&key) {
+            Self::extend_key_ttl(env, &key);
+        }
+        is_paused
     }
 }

--- a/contracts/prompt-hash/src/test.rs
+++ b/contracts/prompt-hash/src/test.rs
@@ -4,7 +4,7 @@ use crate::contract::{PromptHashContract, PromptHashContractClient};
 use crate::mock_asset::FungibleTokenContract;
 use crate::types::Error;
 extern crate std;
-use soroban_sdk::{testutils::Address as _, token, Address, BytesN, Env, String};
+use soroban_sdk::{testutils::{Address as _, Ledger}, token, Address, BytesN, Env, String};
 
 #[derive(Clone, Debug, PartialEq)]
 struct PromptHashContext {
@@ -364,4 +364,64 @@ fn test_arithmetic_safety_for_massive_prices() {
     
     assert_eq!(xlm_client.balance(&creator), expected_seller);
     assert_eq!(xlm_client.balance(&context.fee_wallet), expected_fee);
+}
+
+#[test]
+fn test_global_pause_blocks_mutations_but_not_reads() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let creator = Address::generate(&env);
+
+    client.set_pause_status(&true);
+    assert!(client.get_pause_status());
+
+    let create_res = client.try_create_prompt(
+        &creator,
+        &String::from_str(&env, "https://example.com/prompt.png"),
+        &String::from_str(&env, "Paused Create"),
+        &String::from_str(&env, "Software Development"),
+        &String::from_str(&env, "preview"),
+        &String::from_str(&env, "ciphertext"),
+        &String::from_str(&env, "iv"),
+        &String::from_str(&env, "wrapped-key"),
+        &hash(&env, 1),
+        &10_000,
+    );
+    match create_res {
+        Err(Ok(Error::ContractPaused)) => {}
+        other => panic!("expected ContractPaused for create_prompt, got {:?}", other),
+    }
+
+    client.set_pause_status(&false);
+    let prompt_id = create_prompt(&env, &client, &creator, "Readable Prompt", 10_000);
+    client.set_pause_status(&true);
+
+    assert!(client.get_prompt(&prompt_id).id == prompt_id);
+    assert!(client.has_access(&creator, &prompt_id));
+}
+
+#[test]
+fn test_lease_prompt_grants_temporary_access_and_expires() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+
+    env.ledger().with_mut(|ledger| {
+        ledger.timestamp = 1_000;
+    });
+
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let prompt_id = create_prompt(&env, &client, &creator, "Lease Prompt", 10_000);
+    fund_buyer(&xlm_client, &buyer, &context.contract, 100_000);
+
+    client.lease_prompt(&buyer, &prompt_id, &600);
+    assert!(client.has_access(&buyer, &prompt_id));
+
+    env.ledger().with_mut(|ledger| {
+        ledger.timestamp = 1_700;
+    });
+    assert!(!client.has_access(&buyer, &prompt_id));
 }

--- a/contracts/prompt-hash/src/types.rs
+++ b/contracts/prompt-hash/src/types.rs
@@ -22,6 +22,7 @@ pub enum Error {
     XlmAddressNotSet = 16,
     ArithmeticOverflow = 17,
     ReentrancyGuard = 18,
+    ContractPaused = 19,
 }
 
 #[contracttype]
@@ -35,9 +36,15 @@ pub enum DataKey {
     CreatorPrompts(Address),
     BuyerPrompts(Address),
     Purchase(u128, Address),
+    PauseStatus,
     Reentrancy,
 }
 
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Purchase {
+    pub expires_at: u64,
+}
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -95,6 +102,12 @@ pub trait PromptHashTrait {
     ) -> Result<(), Error>;
 
     fn buy_prompt(env: Env, buyer: Address, prompt_id: u128) -> Result<(), Error>;
+    fn lease_prompt(
+        env: Env,
+        buyer: Address,
+        prompt_id: u128,
+        lease_duration_secs: u64,
+    ) -> Result<(), Error>;
     fn has_access(env: Env, user: Address, prompt_id: u128) -> Result<bool, Error>;
     fn get_prompt(env: Env, prompt_id: u128) -> Result<Prompt, Error>;
     fn get_all_prompts(env: Env) -> Result<Vec<Prompt>, Error>;
@@ -105,6 +118,8 @@ pub trait PromptHashTrait {
     fn get_fee_percentage(env: Env) -> u32;
     fn get_fee_wallet(env: Env) -> Option<Address>;
     fn get_xlm_sac(env: Env) -> Option<Address>;
+    fn set_pause_status(env: Env, is_paused: bool) -> Result<(), Error>;
+    fn get_pause_status(env: Env) -> bool;
     fn upgrade(env: Env, new_wasm_hash: BytesN<32>) -> Result<(), Error>;
     fn extend_ttl(env: Env, key: DataKey) -> Result<(), Error>;
 }


### PR DESCRIPTION
Closes #120
Closes #122
Closes #123
Closes #124

## Changes
- added global pause state with owner-only pause toggling
- blocked create, price update, buy, and lease mutating calls when paused
- introduced timed purchase storage (expires_at) and active-access checks
- added lease_prompt with separate lease pricing tier and lease duration
- updated access logic to enforce expiry windows
- added tests for global pause behavior and lease expiration

## Testing
- not run (per request)