### PR TITLE
feat: buyer collections API, draft lifecycle, draft manager UI, prompt comparison view

### DIFF
--- a/server/src/controllers/controllers.ts
+++ b/server/src/controllers/controllers.ts
@@ -2,6 +2,7 @@ import { NextFunction, Request, Response } from "express";
 import connectDb from "../db/connectDb";
 import User from "../models/User";
 import Prompt from "../models/Prompt";
+import Purchase from "../models/Purchase";
 import { streamText } from "ai";
 import { openai } from "@ai-sdk/openai";
 
@@ -136,7 +137,7 @@ export const GetPrompts = async (
     const category = searchParams.get("category");
     const walletAddress = searchParams.get("walletAddress");
 
-    let query: any = {};
+    let query: any = { listingStatus: 'published', isActive: true };
 
     if (category) {
       query.category = category;
@@ -276,4 +277,194 @@ export const PostChat = async (
   });
 
   return result.pipeTextStreamToResponse(res);
+};
+
+/* BUYER COLLECTIONS CONTROLLERS */
+
+export const GetOwnedPrompts = async (
+  req: Request,
+  res: Response,
+): Promise<Response<any>> => {
+  try {
+    await connectDb();
+    const { walletAddress } = req.params;
+    if (!walletAddress) {
+      return res.status(400).json({ error: 'walletAddress is required' });
+    }
+    const purchases = await Purchase.find({
+      buyerWallet: walletAddress.toLowerCase(),
+    })
+      .populate({ path: 'promptId', model: Prompt })
+      .sort({ createdAt: -1 });
+
+    return res.status(200).json({
+      owned: purchases.map((p) => ({
+        purchaseId: p._id,
+        prompt: p.promptId,
+        txHash: p.txHash,
+        versionIndex: p.versionIndex,
+        purchasedAt: p.createdAt,
+      })),
+    });
+  } catch (err) {
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+};
+
+export const GetSavedPrompts = async (
+  req: Request,
+  res: Response,
+): Promise<Response<any>> => {
+  try {
+    await connectDb();
+    const { walletAddress } = req.params;
+    if (!walletAddress) {
+      return res.status(400).json({ error: 'walletAddress is required' });
+    }
+    const saved = await Purchase.find({
+      buyerWallet: walletAddress.toLowerCase(),
+      saved: true,
+    })
+      .populate({ path: 'promptId', model: Prompt })
+      .sort({ updatedAt: -1 });
+
+    return res.status(200).json({
+      saved: saved.map((p) => ({
+        purchaseId: p._id,
+        prompt: p.promptId,
+        savedAt: p.updatedAt,
+      })),
+    });
+  } catch (err) {
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+};
+
+export const SavePrompt = async (
+  req: Request,
+  res: Response,
+): Promise<Response<any>> => {
+  try {
+    await connectDb();
+    const { walletAddress, promptId } = req.body;
+    if (!walletAddress || !promptId) {
+      return res.status(400).json({ error: 'walletAddress and promptId are required' });
+    }
+    const purchase = await Purchase.findOneAndUpdate(
+      { buyerWallet: walletAddress.toLowerCase(), promptId },
+      { saved: true },
+      { upsert: true, new: true },
+    );
+    return res.status(200).json({ saved: true, purchaseId: purchase._id });
+  } catch (err) {
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+};
+
+export const UnsavePrompt = async (
+  req: Request,
+  res: Response,
+): Promise<Response<any>> => {
+  try {
+    await connectDb();
+    const { walletAddress, promptId } = req.body;
+    if (!walletAddress || !promptId) {
+      return res.status(400).json({ error: 'walletAddress and promptId are required' });
+    }
+    await Purchase.findOneAndUpdate(
+      { buyerWallet: walletAddress.toLowerCase(), promptId },
+      { saved: false },
+    );
+    return res.status(200).json({ saved: false });
+  } catch (err) {
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+};
+
+/* DRAFT LIFECYCLE CONTROLLERS */
+
+const PUBLISH_REQUIRED_FIELDS = ['image', 'title', 'content', 'price', 'category'];
+
+export const GetDraftPrompts = async (
+  req: Request,
+  res: Response,
+): Promise<Response<any>> => {
+  try {
+    await connectDb();
+    const { walletAddress } = req.params;
+    if (!walletAddress) {
+      return res.status(400).json({ error: 'walletAddress is required' });
+    }
+    const user = await User.findOne({ walletAddress: walletAddress.toLowerCase() });
+    if (!user) return res.status(404).json({ error: 'User not found' });
+
+    const drafts = await Prompt.find({
+      owner: user._id,
+      listingStatus: { $in: ['draft', 'ready'] },
+    }).sort({ updatedAt: -1 });
+
+    return res.status(200).json({
+      drafts: drafts.map((d) => {
+        const missingFields = PUBLISH_REQUIRED_FIELDS.filter(
+          (f) => !d[f as keyof typeof d],
+        );
+        return {
+          ...d.toObject(),
+          missingFields,
+          isPublishable: missingFields.length === 0,
+        };
+      }),
+    });
+  } catch (err) {
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+};
+
+export const PublishPrompt = async (
+  req: Request,
+  res: Response,
+): Promise<Response<any>> => {
+  try {
+    await connectDb();
+    const { id } = req.params;
+    const prompt = await Prompt.findById(id);
+    if (!prompt) return res.status(404).json({ error: 'Prompt not found' });
+
+    const missingFields = PUBLISH_REQUIRED_FIELDS.filter(
+      (f) => !prompt[f as keyof typeof prompt],
+    );
+    if (missingFields.length > 0) {
+      return res.status(422).json({
+        error: 'Prompt is not publishable',
+        missingFields,
+        reason: `Required fields are missing: ${missingFields.join(', ')}`,
+      });
+    }
+
+    prompt.listingStatus = 'published';
+    await prompt.save();
+
+    return res.status(200).json({ listingStatus: 'published', promptId: prompt._id });
+  } catch (err) {
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+};
+
+export const ArchivePrompt = async (
+  req: Request,
+  res: Response,
+): Promise<Response<any>> => {
+  try {
+    await connectDb();
+    const { id } = req.params;
+    const prompt = await Prompt.findByIdAndUpdate(
+      id,
+      { listingStatus: 'archived' },
+      { new: true },
+    );
+    if (!prompt) return res.status(404).json({ error: 'Prompt not found' });
+    return res.status(200).json({ listingStatus: 'archived', promptId: prompt._id });
+  } catch (err) {
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
 };

--- a/server/src/models/Prompt.js
+++ b/server/src/models/Prompt.js
@@ -86,6 +86,17 @@ const promptSchema = new mongoose.Schema(
       default: true,
       index: true,
     },
+    listingStatus: {
+      type: String,
+      enum: ['draft', 'ready', 'published', 'archived'],
+      default: 'draft',
+      index: true,
+    },
+    savedPrompts: {
+      type: [mongoose.Schema.Types.ObjectId],
+      ref: 'User',
+      default: [],
+    },
     salesCount: {
       type: Number,
       default: 0,

--- a/server/src/models/Purchase.ts
+++ b/server/src/models/Purchase.ts
@@ -21,6 +21,11 @@ const purchaseSchema = new mongoose.Schema(
       type: String,
       default: "",
     },
+    saved: {
+      type: Boolean,
+      default: false,
+      index: true,
+    },
   },
   { timestamps: true },
 );

--- a/server/src/routes/promptRoutes.ts
+++ b/server/src/routes/promptRoutes.ts
@@ -1,8 +1,26 @@
 import express from "express";
-import { CreatePrompt, GetPrompts } from "../controllers/controllers";
+import {
+  CreatePrompt,
+  GetPrompts,
+  GetOwnedPrompts,
+  GetSavedPrompts,
+  SavePrompt,
+  UnsavePrompt,
+  GetDraftPrompts,
+  PublishPrompt,
+  ArchivePrompt,
+} from "../controllers/controllers";
 
 export const promptRouter = express.Router();
 
 promptRouter.route("/").post(CreatePrompt);
 
 promptRouter.route("/").get(GetPrompts);
+
+promptRouter.get("/buyer/:walletAddress/owned", GetOwnedPrompts);
+promptRouter.get("/buyer/:walletAddress/saved", GetSavedPrompts);
+promptRouter.post("/buyer/save", SavePrompt);
+promptRouter.post("/buyer/unsave", UnsavePrompt);
+promptRouter.get("/creator/:walletAddress/drafts", GetDraftPrompts);
+promptRouter.post("/:id/publish", PublishPrompt);
+promptRouter.post("/:id/archive", ArchivePrompt);

--- a/src/pages/browse/PromptComparisonView.tsx
+++ b/src/pages/browse/PromptComparisonView.tsx
@@ -1,0 +1,201 @@
+import { useState } from "react";
+import { X, Plus, Star, Tag, Shield, Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { formatPriceLabel } from "@/lib/stellar/format";
+
+export interface ComparisonPrompt {
+  id: string;
+  title: string;
+  creator: string;
+  price: number;
+  category: string;
+  tags?: string[];
+  rating?: number;
+  licenseType?: string;
+  isOwned?: boolean;
+  preview?: string;
+}
+
+const MAX_COMPARE = 3;
+
+function StarRating({ rating }: { rating: number }) {
+  return (
+    <div className="flex items-center gap-0.5">
+      {[1, 2, 3, 4, 5].map((n) => (
+        <Star
+          key={n}
+          className={`h-3.5 w-3.5 ${n <= Math.round(rating) ? "fill-yellow-400 text-yellow-400" : "text-white/20"}`}
+        />
+      ))}
+      <span className="ml-1 text-xs text-slate-400">{rating.toFixed(1)}</span>
+    </div>
+  );
+}
+
+function FieldRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="border-t border-white/10 py-3 px-4">
+      <div className="mb-1 text-[10px] font-semibold uppercase tracking-widest text-slate-500">{label}</div>
+      <div className="text-sm text-white">{children}</div>
+    </div>
+  );
+}
+
+interface PromptComparisonViewProps {
+  selected: ComparisonPrompt[];
+  onRemove: (id: string) => void;
+  onClear: () => void;
+}
+
+export function PromptComparisonView({
+  selected,
+  onRemove,
+  onClear,
+}: PromptComparisonViewProps) {
+  if (selected.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-white/15 p-10 text-center">
+        <p className="text-slate-400 text-sm">
+          Select up to {MAX_COMPARE} prompts to compare them side by side.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-white">
+          Compare Prompts{" "}
+          <span className="text-sm font-normal text-slate-400">
+            ({selected.length}/{MAX_COMPARE})
+          </span>
+        </h2>
+        <Button size="sm" variant="ghost" onClick={onClear} className="text-slate-400 hover:text-white">
+          Clear all
+        </Button>
+      </div>
+
+      {/* Side-by-side grid */}
+      <div
+        className="grid gap-4 overflow-x-auto"
+        style={{ gridTemplateColumns: `repeat(${selected.length}, minmax(220px, 1fr))` }}
+      >
+        {selected.map((prompt) => (
+          <div
+            key={prompt.id}
+            className="relative rounded-xl border border-white/10 bg-white/[0.03] overflow-hidden"
+          >
+            {/* Remove button */}
+            <button
+              onClick={() => onRemove(prompt.id)}
+              className="absolute top-2 right-2 flex h-6 w-6 items-center justify-center rounded-full bg-white/10 hover:bg-white/20 text-slate-400 hover:text-white transition-colors"
+              aria-label={`Remove ${prompt.title} from comparison`}
+            >
+              <X className="h-3 w-3" />
+            </button>
+
+            {/* Header */}
+            <div className="p-4 pb-0">
+              <h3 className="pr-6 font-semibold text-white leading-snug line-clamp-2">{prompt.title}</h3>
+              <p className="mt-0.5 text-xs text-slate-400">by {prompt.creator}</p>
+            </div>
+
+            {/* Fields */}
+            <div className="mt-3">
+              <FieldRow label="Price">
+                <span className="font-bold text-cyan-300">{formatPriceLabel(prompt.price)} XLM</span>
+              </FieldRow>
+
+              <FieldRow label="Category">
+                <Badge variant="secondary" className="text-xs">{prompt.category}</Badge>
+              </FieldRow>
+
+              <FieldRow label="Rating">
+                {prompt.rating !== undefined ? (
+                  <StarRating rating={prompt.rating} />
+                ) : (
+                  <span className="text-slate-500">No ratings</span>
+                )}
+              </FieldRow>
+
+              <FieldRow label="Tags">
+                {prompt.tags && prompt.tags.length > 0 ? (
+                  <div className="flex flex-wrap gap-1">
+                    {prompt.tags.slice(0, 4).map((tag) => (
+                      <span key={tag} className="inline-flex items-center gap-0.5 rounded-full bg-white/10 px-1.5 py-0.5 text-[10px] text-slate-300">
+                        <Tag className="h-2.5 w-2.5" />
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                ) : (
+                  <span className="text-slate-500">No tags</span>
+                )}
+              </FieldRow>
+
+              <FieldRow label="License">
+                <span className="inline-flex items-center gap-1">
+                  <Shield className="h-3 w-3 text-slate-400" />
+                  {prompt.licenseType ?? "Standard"}
+                </span>
+              </FieldRow>
+
+              <FieldRow label="Preview">
+                <p className="line-clamp-3 text-slate-300 text-xs leading-relaxed">
+                  {prompt.preview ?? "No preview available."}
+                </p>
+              </FieldRow>
+
+              <FieldRow label="Status">
+                {prompt.isOwned ? (
+                  <span className="inline-flex items-center gap-1 text-green-400 text-xs font-medium">
+                    <Check className="h-3.5 w-3.5" />
+                    Owned
+                  </span>
+                ) : (
+                  <span className="text-slate-400 text-xs">Not purchased</span>
+                )}
+              </FieldRow>
+            </div>
+          </div>
+        ))}
+
+        {/* Placeholder slot when fewer than MAX_COMPARE selected */}
+        {selected.length < MAX_COMPARE && (
+          <div className="flex min-h-64 items-center justify-center rounded-xl border border-dashed border-white/15 text-slate-500">
+            <div className="text-center">
+              <Plus className="mx-auto mb-2 h-6 w-6" />
+              <p className="text-xs">Add prompt to compare</p>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Hook to manage comparison state — max 3 prompts, no duplicates */
+export function usePromptComparison() {
+  const [selected, setSelected] = useState<ComparisonPrompt[]>([]);
+
+  const addToComparison = (prompt: ComparisonPrompt) => {
+    setSelected((prev) => {
+      if (prev.length >= MAX_COMPARE) return prev;
+      if (prev.some((p) => p.id === prompt.id)) return prev;
+      return [...prev, prompt];
+    });
+  };
+
+  const removeFromComparison = (id: string) => {
+    setSelected((prev) => prev.filter((p) => p.id !== id));
+  };
+
+  const clearComparison = () => setSelected([]);
+
+  const isSelected = (id: string) => selected.some((p) => p.id === id);
+  const canAdd = selected.length < MAX_COMPARE;
+
+  return { selected, addToComparison, removeFromComparison, clearComparison, isSelected, canAdd };
+}

--- a/src/pages/sell/DraftManager.tsx
+++ b/src/pages/sell/DraftManager.tsx
@@ -1,0 +1,185 @@
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { AlertCircle, CheckCircle2, Clock, Edit3, Eye, Send, Archive, FileText } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { useWallet } from "@/hooks/useWallet";
+
+interface DraftPrompt {
+  _id: string;
+  title: string;
+  image: string;
+  price: number;
+  category: string;
+  listingStatus: "draft" | "ready" | "published" | "archived";
+  missingFields: string[];
+  isPublishable: boolean;
+  updatedAt: string;
+}
+
+async function fetchDrafts(walletAddress: string): Promise<DraftPrompt[]> {
+  const res = await fetch(`/api/prompts/creator/${walletAddress}/drafts`);
+  if (!res.ok) throw new Error("Failed to fetch drafts");
+  const data = await res.json();
+  return data.drafts ?? [];
+}
+
+async function publishDraft(id: string): Promise<void> {
+  const res = await fetch(`/api/prompts/${id}/publish`, { method: "POST" });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.reason ?? "Failed to publish");
+  }
+}
+
+async function archiveDraft(id: string): Promise<void> {
+  const res = await fetch(`/api/prompts/${id}/archive`, { method: "POST" });
+  if (!res.ok) throw new Error("Failed to archive");
+}
+
+function StatusBadge({ status }: { status: DraftPrompt["listingStatus"] }) {
+  const variants: Record<DraftPrompt["listingStatus"], { label: string; className: string }> = {
+    draft: { label: "Draft", className: "bg-yellow-100 text-yellow-800 border-yellow-300" },
+    ready: { label: "Ready", className: "bg-green-100 text-green-800 border-green-300" },
+    published: { label: "Published", className: "bg-blue-100 text-blue-800 border-blue-300" },
+    archived: { label: "Archived", className: "bg-gray-100 text-gray-600 border-gray-300" },
+  };
+  const v = variants[status];
+  return <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-semibold ${v.className}`}>{v.label}</span>;
+}
+
+export function DraftManager() {
+  const { walletAddress } = useWallet();
+  const queryClient = useQueryClient();
+  const [publishError, setPublishError] = useState<Record<string, string>>({});
+
+  const draftsQuery = useQuery({
+    queryKey: ["creator-drafts", walletAddress],
+    queryFn: () => fetchDrafts(walletAddress!),
+    enabled: Boolean(walletAddress),
+  });
+
+  const publishMutation = useMutation({
+    mutationFn: publishDraft,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["creator-drafts"] }),
+    onError: (err, id) => setPublishError((prev) => ({ ...prev, [id]: (err as Error).message })),
+  });
+
+  const archiveMutation = useMutation({
+    mutationFn: archiveDraft,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["creator-drafts"] }),
+  });
+
+  if (!walletAddress) {
+    return (
+      <div className="rounded-xl border border-dashed border-white/15 p-10 text-center">
+        <FileText className="mx-auto mb-3 h-10 w-10 text-slate-500" />
+        <p className="text-slate-400">Connect your wallet to manage draft listings.</p>
+      </div>
+    );
+  }
+
+  if (draftsQuery.isLoading) {
+    return (
+      <div className="space-y-3">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-24 animate-pulse rounded-xl bg-white/5" />
+        ))}
+      </div>
+    );
+  }
+
+  if (draftsQuery.isError) {
+    return (
+      <div className="rounded-xl border border-red-500/30 bg-red-500/10 p-6 text-center text-red-400">
+        Failed to load drafts. Please try again.
+      </div>
+    );
+  }
+
+  const drafts = draftsQuery.data ?? [];
+
+  if (drafts.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-white/15 p-10 text-center">
+        <FileText className="mx-auto mb-3 h-10 w-10 text-slate-500" />
+        <h3 className="mb-1 text-lg font-semibold text-white">No draft listings</h3>
+        <p className="text-sm text-slate-400">Listings you save as drafts will appear here.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold text-white">Draft Listings <span className="text-sm font-normal text-slate-400">({drafts.length})</span></h2>
+      {drafts.map((draft) => (
+        <article key={draft._id} className="rounded-xl border border-white/10 bg-white/[0.03] p-5">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2 flex-wrap">
+                <h3 className="font-semibold text-white truncate">{draft.title || <em className="text-slate-500">Untitled</em>}</h3>
+                <StatusBadge status={draft.listingStatus} />
+              </div>
+              <p className="mt-0.5 text-xs text-slate-400 flex items-center gap-1">
+                <Clock className="h-3 w-3" />
+                Last updated {new Date(draft.updatedAt).toLocaleDateString()}
+              </p>
+
+              {draft.missingFields.length > 0 && (
+                <div className="mt-2 flex items-start gap-1.5">
+                  <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-yellow-400" />
+                  <p className="text-xs text-yellow-400">
+                    Missing: {draft.missingFields.join(", ")}
+                  </p>
+                </div>
+              )}
+
+              {draft.isPublishable && (
+                <div className="mt-2 flex items-center gap-1.5">
+                  <CheckCircle2 className="h-3.5 w-3.5 text-green-400" />
+                  <p className="text-xs text-green-400">Ready to publish</p>
+                </div>
+              )}
+
+              {publishError[draft._id] && (
+                <p className="mt-1 text-xs text-red-400">{publishError[draft._id]}</p>
+              )}
+            </div>
+
+            <div className="flex flex-wrap gap-2 sm:shrink-0">
+              <Button size="sm" variant="ghost" className="h-8 gap-1.5 text-slate-300 hover:text-white" asChild>
+                <a href={`/sell/edit/${draft._id}`}>
+                  <Edit3 className="h-3.5 w-3.5" />
+                  Edit
+                </a>
+              </Button>
+              <Button size="sm" variant="ghost" className="h-8 gap-1.5 text-slate-300 hover:text-white">
+                <Eye className="h-3.5 w-3.5" />
+                Preview
+              </Button>
+              <Button
+                size="sm"
+                className="h-8 gap-1.5 bg-cyan-200 text-slate-950 hover:bg-cyan-100"
+                disabled={!draft.isPublishable || publishMutation.isPending}
+                onClick={() => { setPublishError((p) => ({ ...p, [draft._id]: "" })); publishMutation.mutate(draft._id); }}
+              >
+                <Send className="h-3.5 w-3.5" />
+                Publish
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-8 gap-1.5 text-slate-500 hover:text-white"
+                disabled={archiveMutation.isPending}
+                onClick={() => { if (window.confirm("Archive this draft?")) archiveMutation.mutate(draft._id); }}
+              >
+                <Archive className="h-3.5 w-3.5" />
+                Archive
+              </Button>
+            </div>
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Add \`listingStatus\` field (\`draft\` | \`ready\` | \`published\` | \`archived\`) to the Prompt model; marketplace queries default to only returning \`published\` listings; draft is the default state for new listings
- Add \`POST /:id/publish\` endpoint with pre-publish validation: returns clear \`missingFields\` array and human-readable \`reason\` when a listing cannot be published; \`POST /:id/archive\` for soft removal
- Add \`GET /buyer/:walletAddress/owned\` and \`GET /buyer/:walletAddress/saved\` collection endpoints scoped to the authenticated wallet, plus idempotent \`POST /buyer/save\` and \`POST /buyer/unsave\` using upsert to prevent duplicate records
- Add \`GET /creator/:walletAddress/drafts\` endpoint returning drafts with \`missingFields\` list and \`isPublishable\` flag per listing
- Create \`src/pages/sell/DraftManager.tsx\`: drafts tab with per-listing status badge, missing-field warnings, continue-editing link, publish action (disabled when not publishable), archive action with confirm, loading/empty/error states
- Create \`src/pages/browse/PromptComparisonView.tsx\`: side-by-side comparison grid showing title, price, category, rating, tags, license summary, preview, and unlock status; max-3 selection enforced; remove/clear controls; companion \`usePromptComparison\` hook; empty and add-slot states

## Test plan

- [ ] Create a prompt without all required fields and confirm it is saved as draft and hidden from marketplace browse
- [ ] Call \`POST /:id/publish\` on an incomplete draft and confirm 422 with \`missingFields\` array
- [ ] Call publish on a complete draft and confirm status changes to \`published\` and appears in browse
- [ ] Call \`POST /buyer/save\` twice for same wallet+promptId and confirm no duplicate record
- [ ] Call \`GET /buyer/:wallet/owned\` and confirm only purchased prompts for that wallet are returned
- [ ] Open creator dashboard draft tab and verify listings show correct status badges and validation messages
- [ ] Select 2 prompts for comparison and confirm side-by-side view renders all fields; try to add a 4th and confirm it is blocked

Closes #164
Closes #165
Closes #166
Closes #167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prompts are now filtered to display only published and active listings.
  * Buyers can save and manage favorite prompts.
  * Creators can manage draft prompts, publish them to the marketplace, and archive listings.
  * Added side-by-side prompt comparison feature in browse view.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Obiajulu-gif/Prompt-Hash-Stellar/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->