### PR TITLE
Add saved listings, backend validation, and draft autosave

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,83 +1,244 @@
-# API Reference: Unlock Service
+# API Reference
 
-The Unlock Service is a gated delivery system that provides plaintext prompt content (or unwrapped encryption keys) only to users who have a verifiable purchase on the Stellar blockchain.
+This reference covers the marketplace and account endpoints used by the PromptHash frontend and the Express backend.
 
-## Authentication: Challenge-Response Protocol
+## Common Response Rules
 
-The service uses a cryptographic challenge-response flow to verify wallet ownership without requiring persistent sessions or passwords.
+- Successful requests return JSON.
+- Validation failures return `422` with a field-level error map when available.
+- Missing resources return `404`.
+- Auth or ownership failures return `403`.
 
-### 1. Request Challenge
-**Endpoint:** `POST /api/unlock/challenge`
+### Shared validation error shape
 
-Generates a short-lived challenge token that the user must sign with their Stellar wallet.
-
-**Request Body:**
 ```json
 {
-  "address": "G...",
-  "promptId": "123"
+  "error": "Invalid listing metadata",
+  "fields": {
+    "title": "Title is required.",
+    "price": "Price must be greater than zero."
+  }
 }
 ```
 
-**Response (200 OK):**
+## Marketplace Endpoints
+
+### List prompts
+
+`GET /api/prompts`
+
+Returns published, active marketplace prompts.
+
+Optional query parameters:
+
+- `category`
+- `walletAddress`
+
+Example response:
+
+```json
+[
+  {
+    "_id": "6650f1...",
+    "image": "https://example.com/cover.png",
+    "title": "Launch Strategy Pack",
+    "content": "Public preview text ...",
+    "owner": {
+      "username": "faithorji",
+      "walletAddress": "g..."
+    },
+    "price": 2.5,
+    "category": "Marketing",
+    "listingStatus": "published",
+    "isActive": true,
+    "salesCount": 12
+  }
+]
+```
+
+### Create a prompt
+
+`POST /api/prompts`
+
+Creates a creator listing after validating and normalizing the listing metadata.
+
+Request body:
+
 ```json
 {
-  "token": "base64payload.serverSignature",
-  "challenge": "prompt-hash unlock:G...:123:uuid:timestamp",
-  "expiresAt": 1714230000000
+  "image": "https://example.com/cover.png",
+  "title": "Launch Strategy Pack",
+  "content": "Long-form prompt content",
+  "walletAddress": "g...",
+  "price": 2.5,
+  "category": "marketing"
 }
 ```
 
-### 2. Verify and Unlock
-**Endpoint:** `POST /api/unlock/verify`
+Example response:
 
-Verifies the wallet signature and the challenge token. If the wallet has purchased the prompt (verified on-chain), it returns the decrypted content.
-
-**Request Body:**
 ```json
 {
-  "token": "base64payload.serverSignature",
-  "address": "G...",
-  "promptId": "123",
-  "signature": "base64_or_hex_signature"
+  "message": "Prompt created successfully",
+  "prompt": {
+    "_id": "6650f1...",
+    "title": "Launch Strategy Pack",
+    "price": 2.5,
+    "category": "Marketing"
+  }
 }
 ```
 
-**Response (200 OK):**
+### Publish a draft
+
+`POST /api/prompts/:id/publish`
+
+Publishes a draft prompt after validating required fields.
+
+Example error response:
+
 ```json
 {
-  "decryptedContent": "Act as a senior engineer...",
-  "contentHash": "..."
+  "error": "Prompt is not publishable",
+  "fields": {
+    "content": "Content is required."
+  }
 }
 ```
 
-**Error Responses:**
-- `401 Unauthorized`: Invalid signature or malformed token.
-- `403 Forbidden`: Wallet does not have access (no purchase recorded on-chain).
-- `410 Gone`: Challenge token has expired.
+### Archive a prompt
 
----
+`POST /api/prompts/:id/archive`
 
-## Client-Side Encryption Protocol
+Marks a prompt as archived and removes it from active workflow views.
 
-To ensure privacy, prompt content is encrypted before it ever reaches the blockchain.
+## Buyer Library Endpoints
 
-### 1. Encryption (Creator Side)
-1. Generate a random 256-bit AES key.
-2. Encrypt the prompt content using **AES-256-GCM**.
-3. Generate a content hash (SHA-256) of the plaintext.
-4. Wrap the AES key using the Unlock Service's public key (RSA-OAEP or ECIES).
-5. Submit the encrypted payload, wrapped key, and metadata to the Soroban contract.
+### Get owned prompts
 
-### 2. Decryption (Unlock Service Side)
-1. Verify the buyer's entitlement on the Soroban contract.
-2. Unwrap the AES key using the service's private key.
-3. Decrypt the ciphertext.
-4. Verify the integrity of the plaintext against the stored content hash.
-5. Return the plaintext to the authorized buyer.
+`GET /api/prompts/buyer/:walletAddress/owned`
 
-## Implementation Details
+Returns prompts tied to purchases for the buyer wallet.
 
-- **AES-GCM**: Used for symmetric encryption of the prompt body.
-- **Key Wrapping**: Prevents the server from reading content unless requested by an authorized buyer (assuming the server follows the protocol).
-- **On-Chain Verification**: The service calls the `has_access` method on the `PromptHash` Soroban contract.
+Example response:
+
+```json
+{
+  "owned": [
+    {
+      "purchaseId": "66a1...",
+      "prompt": {
+        "_id": "6650f1...",
+        "title": "Launch Strategy Pack",
+        "content": "Public preview text ...",
+        "category": "Marketing"
+      },
+      "txHash": "tx_123",
+      "versionIndex": 1,
+      "purchasedAt": "2026-05-28T10:15:30.000Z"
+    }
+  ]
+}
+```
+
+### Get saved prompts
+
+`GET /api/prompts/buyer/:walletAddress/saved`
+
+Returns the buyer's saved marketplace listings.
+
+Example response:
+
+```json
+{
+  "saved": [
+    {
+      "purchaseId": "66a1...",
+      "prompt": {
+        "_id": "6650f1...",
+        "title": "Launch Strategy Pack",
+        "content": "Preview text ...",
+        "price": 2.5,
+        "category": "Marketing",
+        "owner": {
+          "username": "faithorji"
+        }
+      },
+      "savedAt": "2026-05-28T10:15:30.000Z"
+    }
+  ]
+}
+```
+
+### Save a prompt
+
+`POST /api/prompts/buyer/save`
+
+Request body:
+
+```json
+{
+  "walletAddress": "g...",
+  "promptId": "6650f1..."
+}
+```
+
+Example response:
+
+```json
+{ "saved": true, "purchaseId": "66a1..." }
+```
+
+### Remove a saved prompt
+
+`POST /api/prompts/buyer/unsave`
+
+Request body:
+
+```json
+{
+  "walletAddress": "g...",
+  "promptId": "6650f1..."
+}
+```
+
+Example response:
+
+```json
+{ "saved": false }
+```
+
+## Creator Workspace Endpoints
+
+### Get draft prompts
+
+`GET /api/prompts/creator/:walletAddress/drafts`
+
+Returns draft and ready-to-publish prompts for the connected creator wallet.
+
+### Version updates
+
+`POST /api/prompts/version`
+
+Creates a new version for a prompt owned by the calling wallet.
+
+## Account And Auth Flow
+
+### Challenge token
+
+`POST /api/unlock/challenge`
+
+Issues a short-lived challenge token for wallet verification.
+
+### Unlock prompt
+
+`POST /api/unlock/verify`
+
+Verifies the wallet signature and on-chain entitlement before returning decrypted content.
+
+## Notes For Frontend Contributors
+
+- Listing metadata is normalized server-side before persistence.
+- Category casing is canonicalized so the frontend can send user-friendly values.
+- The buyer dashboard reads from `/api/prompts/buyer/:walletAddress/saved` and `/api/prompts/buyer/:walletAddress/owned` to populate separate library sections.
+- Save and unsave actions are intentionally idempotent from the UI perspective.

--- a/server/src/controllers/controllers.ts
+++ b/server/src/controllers/controllers.ts
@@ -5,6 +5,9 @@ import Prompt from "../models/Prompt";
 import Purchase from "../models/Purchase";
 import { streamText } from "ai";
 import { openai } from "@ai-sdk/openai";
+import {
+  validateListingMetadata,
+} from "../services/listingValidation";
 
 const API_BASE_URL = "https://secret-ai-gateway.onrender.com";
 
@@ -84,6 +87,21 @@ export const CreatePrompt = async (
       });
     }
 
+    const { normalized, errors } = validateListingMetadata({
+      image,
+      title,
+      content,
+      price,
+      category,
+    });
+
+    if (Object.keys(errors).length > 0) {
+      return res.status(422).json({
+        error: "Invalid listing metadata",
+        fields: errors,
+      });
+    }
+
     // Find the user by wallet address
     const user = await User.findOne({
       walletAddress: walletAddress.toLowerCase(),
@@ -96,12 +114,12 @@ export const CreatePrompt = async (
     }
 
     const newPrompt = new Prompt({
-      image,
-      title,
-      content,
+      image: normalized.image,
+      title: normalized.title,
+      content: normalized.content,
       owner: user._id, // Set the owner as the user's ObjectId
-      price,
-      category: category || "Other",
+      price: normalized.price,
+      category: normalized.category,
       rating: 3,
     });
 
@@ -352,7 +370,7 @@ export const SavePrompt = async (
     }
     const purchase = await Purchase.findOneAndUpdate(
       { buyerWallet: walletAddress.toLowerCase(), promptId },
-      { saved: true },
+      { saved: true, versionIndex: 1, txHash: "" },
       { upsert: true, new: true },
     );
     return res.status(200).json({ saved: true, purchaseId: purchase._id });
@@ -429,6 +447,21 @@ export const PublishPrompt = async (
     const { id } = req.params;
     const prompt = await Prompt.findById(id);
     if (!prompt) return res.status(404).json({ error: 'Prompt not found' });
+
+    const { errors } = validateListingMetadata({
+      image: prompt.image,
+      title: prompt.title,
+      content: prompt.content,
+      price: prompt.price,
+      category: prompt.category,
+    });
+
+    if (Object.keys(errors).length > 0) {
+      return res.status(422).json({
+        error: 'Prompt is not publishable',
+        fields: errors,
+      });
+    }
 
     const missingFields = PUBLISH_REQUIRED_FIELDS.filter(
       (f) => !prompt[f as keyof typeof prompt],

--- a/server/src/services/listingValidation.ts
+++ b/server/src/services/listingValidation.ts
@@ -1,0 +1,119 @@
+const CATEGORY_ALIASES: Record<string, string> = {
+  marketing: "Marketing",
+  "creative writing": "Creative Writing",
+  programming: "Programming",
+  music: "Music",
+  gaming: "Gaming",
+  other: "Other",
+};
+
+const LISTING_LIMITS = {
+  image: 512,
+  title: 100,
+  content: 50_000,
+  category: 40,
+};
+
+type ListingInput = {
+  image?: unknown;
+  title?: unknown;
+  content?: unknown;
+  price?: unknown;
+  category?: unknown;
+};
+
+export type ListingValidationErrors = Record<string, string>;
+
+export type NormalizedListing = {
+  image: string;
+  title: string;
+  content: string;
+  price: number;
+  category: string;
+};
+
+const asTrimmedString = (value: unknown) =>
+  typeof value === "string" ? value.trim() : "";
+
+const normalizeCategory = (value: unknown) => {
+  const trimmed = asTrimmedString(value);
+  if (!trimmed) return "Other";
+
+  const alias = CATEGORY_ALIASES[trimmed.toLowerCase()];
+  if (alias) return alias;
+
+  return trimmed
+    .split(/[\s_-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(" ");
+};
+
+export function normalizeListingMetadata(input: ListingInput): NormalizedListing {
+  const image = asTrimmedString(input.image);
+  const title = asTrimmedString(input.title).replace(/\s+/g, " ");
+  const content = asTrimmedString(input.content);
+  const category = normalizeCategory(input.category);
+  const parsedPrice =
+    typeof input.price === "number"
+      ? input.price
+      : typeof input.price === "string"
+        ? Number(input.price.trim())
+        : Number.NaN;
+
+  return {
+    image,
+    title,
+    content,
+    price: parsedPrice,
+    category,
+  };
+}
+
+export function validateListingMetadata(
+  input: ListingInput,
+): {
+  normalized: NormalizedListing;
+  errors: ListingValidationErrors;
+} {
+  const normalized = normalizeListingMetadata(input);
+  const errors: ListingValidationErrors = {};
+
+  if (!normalized.image) {
+    errors.image = "Image URL is required.";
+  } else if (normalized.image.length > LISTING_LIMITS.image) {
+    errors.image = `Image URL must be ${LISTING_LIMITS.image} characters or fewer.`;
+  } else if (!/^https?:\/\/.+/i.test(normalized.image)) {
+    errors.image = "Image URL must start with http:// or https://.";
+  }
+
+  if (!normalized.title) {
+    errors.title = "Title is required.";
+  } else if (normalized.title.length < 3) {
+    errors.title = "Title must be at least 3 characters long.";
+  } else if (normalized.title.length > LISTING_LIMITS.title) {
+    errors.title = `Title must be ${LISTING_LIMITS.title} characters or fewer.`;
+  }
+
+  if (!normalized.content) {
+    errors.content = "Content is required.";
+  } else if (normalized.content.length < 10) {
+    errors.content = "Content must be at least 10 characters long.";
+  } else if (normalized.content.length > LISTING_LIMITS.content) {
+    errors.content = `Content must be ${LISTING_LIMITS.content} characters or fewer.`;
+  }
+
+  if (!normalized.category) {
+    errors.category = "Category is required.";
+  } else if (normalized.category.length > LISTING_LIMITS.category) {
+    errors.category = `Category must be ${LISTING_LIMITS.category} characters or fewer.`;
+  }
+
+  if (!Number.isFinite(normalized.price)) {
+    errors.price = "Price must be a valid number.";
+  } else if (normalized.price <= 0) {
+    errors.price = "Price must be greater than zero.";
+  }
+
+  return { normalized, errors };
+}

--- a/src/hooks/useContractSync.ts
+++ b/src/hooks/useContractSync.ts
@@ -29,6 +29,7 @@ import { browserStellarConfig } from "@/lib/stellar/browserConfig";
  *   Any contract event → ["marketplace-prompts"]  (browse grid, prices, active flag)
  *   Any contract event → ["created-prompts"]       (creator inventory + sales count)
  *   Any contract event → ["purchased-prompts"]     (buyer's license list)
+ *   Any contract event → ["saved-prompts"]          (buyer saved listings)
  *   Any contract event → ["prompt-access"]         (per-prompt access checks)
  */
 
@@ -39,6 +40,7 @@ export function invalidateAllPromptQueries(queryClient: QueryClient) {
     queryClient.invalidateQueries({ queryKey: ["marketplace-prompts"] }),
     queryClient.invalidateQueries({ queryKey: ["created-prompts"] }),
     queryClient.invalidateQueries({ queryKey: ["purchased-prompts"] }),
+    queryClient.invalidateQueries({ queryKey: ["saved-prompts"] }),
     queryClient.invalidateQueries({ queryKey: ["prompt-access"] }),
   ]);
 }

--- a/src/lib/prompts/library.ts
+++ b/src/lib/prompts/library.ts
@@ -1,0 +1,114 @@
+export interface SavedPromptListing {
+  purchaseId: string;
+  promptId: string;
+  savedAt: string;
+  prompt: {
+    id: string;
+    image: string;
+    title: string;
+    content: string;
+    price: number;
+    category: string;
+    listingStatus?: string;
+    isActive?: boolean;
+    owner?: {
+      username?: string;
+      walletAddress?: string;
+    };
+  };
+}
+
+type SavedPromptApiResponse = {
+  purchaseId: string;
+  savedAt: string;
+  prompt: {
+    _id?: string;
+    id?: string;
+    image?: string;
+    title?: string;
+    content?: string;
+    price?: number;
+    category?: string;
+    listingStatus?: string;
+    isActive?: boolean;
+    owner?: {
+      username?: string;
+      walletAddress?: string;
+    };
+  } | null;
+};
+
+const toSavedPromptListing = (
+  record: SavedPromptApiResponse,
+): SavedPromptListing => {
+  const prompt = record.prompt ?? {};
+  const id = String(prompt._id ?? prompt.id ?? record.purchaseId);
+
+  return {
+    purchaseId: record.purchaseId,
+    promptId: id,
+    savedAt: record.savedAt,
+    prompt: {
+      id,
+      image: prompt.image ?? "",
+      title: prompt.title ?? "Untitled prompt",
+      content: prompt.content ?? "",
+      price: prompt.price ?? 0,
+      category: prompt.category ?? "Other",
+      listingStatus: prompt.listingStatus,
+      isActive: prompt.isActive,
+      owner: prompt.owner,
+    },
+  };
+};
+
+const parseJson = async <T>(response: Response): Promise<T> => {
+  const payload = await response.json().catch(() => null);
+  if (!response.ok) {
+    const message =
+      (payload && typeof payload === "object" && "error" in payload
+        ? String((payload as { error?: unknown }).error ?? "Request failed")
+        : "Request failed");
+    throw new Error(message);
+  }
+
+  return payload as T;
+};
+
+export async function fetchSavedPrompts(
+  walletAddress: string,
+): Promise<SavedPromptListing[]> {
+  const response = await fetch(`/api/prompts/buyer/${walletAddress}/saved`);
+  const payload = await parseJson<{ saved?: SavedPromptApiResponse[] }>(response);
+  return (payload.saved ?? []).map(toSavedPromptListing);
+}
+
+export async function savePromptListing(
+  walletAddress: string,
+  promptId: string,
+): Promise<void> {
+  const response = await fetch("/api/prompts/buyer/save", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ walletAddress, promptId }),
+  });
+
+  await parseJson<{ saved?: boolean }>(response);
+}
+
+export async function unsavePromptListing(
+  walletAddress: string,
+  promptId: string,
+): Promise<void> {
+  const response = await fetch("/api/prompts/buyer/unsave", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ walletAddress, promptId }),
+  });
+
+  await parseJson<{ saved?: boolean }>(response);
+}

--- a/src/pages/browse/FetchAllPrompts.tsx
+++ b/src/pages/browse/FetchAllPrompts.tsx
@@ -1,5 +1,10 @@
-import { useEffect, useMemo, useState, useRef, useCallback } from "react";
-import { useQueries, useQuery, useQueryClient, useInfiniteQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useState, useRef } from "react";
+import {
+  useQueries,
+  useQuery,
+  useQueryClient,
+  useMutation,
+} from "@tanstack/react-query";
 import {
   ChevronLeft,
   ChevronRight,
@@ -14,8 +19,12 @@ import {
   hasAccess,
   type PromptRecord,
 } from "@/lib/stellar/promptHashClient";
+import {
+  fetchSavedPrompts,
+  savePromptListing,
+  unsavePromptListing,
+} from "@/lib/prompts/library";
 import { stroopsToXlmString } from "@/lib/stellar/format";
-import { invalidateAllPromptQueries } from "@/hooks/useContractSync";
 import { PromptCard } from "./PromptCard";
 import { PromptModal } from "./PromptModal";
 
@@ -50,12 +59,42 @@ const FetchAllPrompts = ({
   );
   const [currentPage, setCurrentPage] = useState(1);
   const loadMoreRef = useRef<HTMLDivElement>(null);
+  const [savingPromptId, setSavingPromptId] = useState<string | null>(null);
 
   const promptsQuery = useQuery({
     queryKey: ["marketplace-prompts"],
     queryFn: async () => {
       if (!isMarketplaceConfigured) return [];
       return getAllPrompts(browserStellarConfig);
+    },
+  });
+
+  const savedPromptsQuery = useQuery({
+    queryKey: ["saved-prompts", address],
+    queryFn: async () => (address ? fetchSavedPrompts(address) : []),
+    enabled: Boolean(address),
+  });
+
+  const savePromptMutation = useMutation({
+    mutationFn: async ({
+      promptId,
+      saved,
+    }: {
+      promptId: string;
+      saved: boolean;
+    }) => {
+      if (!address) {
+        throw new Error("Connect your wallet before saving listings.");
+      }
+
+      if (saved) {
+        await unsavePromptListing(address, promptId);
+      } else {
+        await savePromptListing(address, promptId);
+      }
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["saved-prompts"] });
     },
   });
 
@@ -96,6 +135,27 @@ const FetchAllPrompts = ({
       ]),
     );
   }, [accessQueries, address, promptsQuery.data]);
+
+  const savedPromptIds = useMemo(() => {
+    return new Set((savedPromptsQuery.data ?? []).map((item) => item.promptId));
+  }, [savedPromptsQuery.data]);
+
+  const handleToggleSave = async (prompt: PromptRecord) => {
+    if (!address) {
+      return;
+    }
+
+    const promptId = prompt.id.toString();
+    setSavingPromptId(promptId);
+    try {
+      await savePromptMutation.mutateAsync({
+        promptId,
+        saved: savedPromptIds.has(promptId),
+      });
+    } finally {
+      setSavingPromptId(null);
+    }
+  };
 
   const filteredPrompts = useMemo(() => {
     const normalizedSearch = searchQuery.trim().toLowerCase();
@@ -210,6 +270,9 @@ const FetchAllPrompts = ({
                 prompt={prompt}
                 hasAccess={accessMap.get(prompt.id.toString()) ?? false}
                 openModal={setSelectedPrompt}
+                isSaved={savedPromptIds.has(prompt.id.toString())}
+                isSaving={savingPromptId === prompt.id.toString()}
+                onToggleSave={handleToggleSave}
               />
             ))}
           </div>

--- a/src/pages/browse/PromptCard.tsx
+++ b/src/pages/browse/PromptCard.tsx
@@ -1,5 +1,7 @@
 import {
   ArrowUpRight,
+  Bookmark,
+  BookmarkCheck,
   LockKeyhole,
   ShieldCheck,
   TrendingUp,
@@ -18,10 +20,16 @@ export const PromptCard = ({
   prompt,
   hasAccess,
   openModal,
+  isSaved,
+  isSaving,
+  onToggleSave,
 }: {
   prompt: PromptRecord;
   hasAccess: boolean;
   openModal: (prompt: PromptRecord) => void;
+  isSaved: boolean;
+  isSaving: boolean;
+  onToggleSave: (prompt: PromptRecord) => void;
 }) => {
   const isBestSeller = prompt.salesCount >= 10;
 
@@ -64,6 +72,25 @@ export const PromptCard = ({
               <TrendingUp className="h-3 w-3 mr-1" /> Best Seller
             </Badge>
           )}
+        </div>
+        <div className="absolute top-4 right-4">
+          <Button
+            size="sm"
+            variant="secondary"
+            className="h-8 rounded-full border border-white/10 bg-slate-950/75 px-3 text-xs text-white shadow-lg backdrop-blur-md hover:bg-slate-900"
+            disabled={isSaving}
+            onClick={(event) => {
+              event.stopPropagation();
+              onToggleSave(prompt);
+            }}
+          >
+            {isSaved ? (
+              <BookmarkCheck className="mr-1.5 h-3.5 w-3.5 text-emerald-300" />
+            ) : (
+              <Bookmark className="mr-1.5 h-3.5 w-3.5" />
+            )}
+            {isSaved ? "Saved" : "Save"}
+          </Button>
         </div>
       </div>
 

--- a/src/pages/profile/page.tsx
+++ b/src/pages/profile/page.tsx
@@ -5,6 +5,7 @@ import {
   ArrowUpRight,
   BadgeCheck,
   BookOpenCheck,
+  Bookmark,
   Boxes,
   CheckCircle2,
   CircleOff,
@@ -51,6 +52,12 @@ import {
   xlmToStroops,
 } from "@/lib/stellar/format";
 import { unlockPromptContent } from "@/lib/prompts/unlock";
+import {
+  fetchSavedPrompts,
+  savePromptListing,
+  unsavePromptListing,
+  type SavedPromptListing,
+} from "@/lib/prompts/library";
 import { shortenAddress } from "@/lib/utils";
 import { stellarNetwork } from "@/lib/env";
 import { connectWallet } from "@/util/wallet";
@@ -618,6 +625,97 @@ function CreatedPromptCard({
   );
 }
 
+function SavedPromptCard({
+  savedPrompt,
+  isBusy,
+  onToggleSaved,
+}: {
+  savedPrompt: SavedPromptListing;
+  isBusy: boolean;
+  onToggleSaved: Handler<[string, boolean]>;
+}) {
+  const { prompt } = savedPrompt;
+  const isActive = prompt.isActive ?? true;
+
+  return (
+    <article className="overflow-hidden rounded-xl border border-white/10 bg-[#0f1419] transition-colors hover:border-white/[0.18]">
+      <div className="grid lg:grid-cols-[10rem_1fr]">
+        <img
+          src={prompt.image || promptImageFallback}
+          alt={prompt.title}
+          className="h-48 w-full object-cover lg:h-full"
+        />
+        <div className="min-w-0 p-5 md:p-6">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge
+              className={
+                isActive
+                  ? "border-emerald-300/30 bg-emerald-300/10 text-emerald-100"
+                  : "border-amber-300/30 bg-amber-300/10 text-amber-100"
+              }
+            >
+              <Bookmark className="mr-1 h-3.5 w-3.5" />
+              {isActive ? "Saved listing" : "Paused listing"}
+            </Badge>
+            <Badge className="border-white/10 bg-white/[0.04] text-slate-300">
+              {prompt.category}
+            </Badge>
+            <Badge className="border-white/10 bg-white/[0.04] text-slate-300">
+              {new Date(savedPrompt.savedAt).toLocaleDateString()}
+            </Badge>
+          </div>
+
+          <div className="mt-4 grid gap-4 xl:grid-cols-[1fr_auto]">
+            <div className="min-w-0">
+              <h3 className="text-xl font-semibold text-white">{prompt.title}</h3>
+              <p className="mt-2 line-clamp-2 text-sm leading-7 text-slate-400">
+                {prompt.content}
+              </p>
+            </div>
+            <div className="flex gap-3 text-sm xl:w-60">
+              <div className="flex-1 rounded-lg border border-white/10 bg-white/[0.03] p-3">
+                <p className="text-xs uppercase tracking-[0.14em] text-slate-500">
+                  Price
+                </p>
+                <p className="mt-1.5 text-xl font-semibold text-white">
+                  {prompt.price.toLocaleString()} XLM
+                </p>
+              </div>
+              <div className="flex-1 rounded-lg border border-white/10 bg-white/[0.03] p-3">
+                <p className="text-xs uppercase tracking-[0.14em] text-slate-500">
+                  Owner
+                </p>
+                <p className="mt-1.5 text-xl font-semibold text-white">
+                  {prompt.owner?.username ?? "Creator"}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-5 flex flex-wrap items-center gap-3">
+            <Button
+              variant="outline"
+              className="h-10 shrink-0 border-white/15 bg-white/[0.03] text-white hover:bg-white/10 disabled:opacity-50"
+              onClick={() => onToggleSaved(savedPrompt.promptId, true)}
+              disabled={isBusy}
+            >
+              {isBusy ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Bookmark className="h-4 w-4" />
+              )}
+              Remove from saved
+            </Button>
+            <p className="font-mono text-xs text-slate-600">
+              {shortHash(savedPrompt.promptId)}
+            </p>
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}
+
 export default function ProfilePage() {
   const queryClient = useQueryClient();
   const [searchParams] = useSearchParams();
@@ -648,8 +746,15 @@ export default function ProfilePage() {
     enabled: Boolean(address),
   });
 
+  const savedQuery = useQuery({
+    queryKey: ["saved-prompts", address],
+    queryFn: async () => (address ? fetchSavedPrompts(address) : []),
+    enabled: Boolean(address),
+  });
+
   const createdPrompts = createdQuery.data ?? [];
   const purchasedPrompts = purchasedQuery.data ?? [];
+  const savedPrompts = savedQuery.data ?? [];
   const activeListingCount = createdPrompts.filter((p) => p.active).length;
 
   const mergedDrafts = useMemo(() => {
@@ -720,6 +825,28 @@ export default function ProfilePage() {
       updateError(
         error instanceof Error ? error.message : "Failed to update price.",
       );
+    } finally {
+      setBusyPromptId(null);
+    }
+  };
+
+  const handleToggleSaved = async (promptId: string, saved: boolean) => {
+    if (!address) {
+      updateError("Connect a wallet before saving listings.");
+      return;
+    }
+
+    setBusyPromptId(promptId);
+    try {
+      if (saved) {
+        await unsavePromptListing(address, promptId);
+      } else {
+        await savePromptListing(address, promptId);
+      }
+      updateStatus(saved ? "Listing removed from saved items." : "Listing saved.");
+      await queryClient.invalidateQueries({ queryKey: ["saved-prompts"] });
+    } catch (error) {
+      updateError(error instanceof Error ? error.message : "Failed to update saved listings.");
     } finally {
       setBusyPromptId(null);
     }
@@ -860,7 +987,7 @@ export default function ProfilePage() {
                     </p>
                   </div>
 
-                  <TabsList className="mb-6 grid h-auto w-full grid-cols-2 rounded-xl border border-white/10 bg-white/[0.03] p-1.5 sm:w-[34rem]">
+                  <TabsList className="mb-6 grid h-auto w-full grid-cols-3 rounded-xl border border-white/10 bg-white/[0.03] p-1.5 sm:w-[48rem]">
                     <TabsTrigger
                       value="purchased"
                       aria-label="Open my library tab"
@@ -881,6 +1008,17 @@ export default function ProfilePage() {
                       My Inventory
                       <span className="ml-1 rounded-full bg-slate-950/10 px-1.5 py-0.5 text-xs">
                         {createdPrompts.length}
+                      </span>
+                    </TabsTrigger>
+                    <TabsTrigger
+                      value="saved"
+                      aria-label="Open saved listings tab"
+                      className="flex items-center gap-2 rounded-lg px-4 py-2.5 text-slate-400 transition-all data-[state=active]:bg-emerald-300 data-[state=active]:text-slate-950 data-[state=active]:shadow-sm"
+                    >
+                      <Bookmark className="h-4 w-4" />
+                      Saved
+                      <span className="ml-1 rounded-full bg-slate-950/10 px-1.5 py-0.5 text-xs">
+                        {savedPrompts.length}
                       </span>
                     </TabsTrigger>
                   </TabsList>
@@ -955,6 +1093,37 @@ export default function ProfilePage() {
                       </div>
                     )}
                     <WebhookSettings walletAddress={address} />
+                  </TabsContent>
+
+                  <TabsContent value="saved" className="mt-0 space-y-4">
+                    {savedQuery.isLoading ? (
+                      <LoadingState label="Loading your saved listings..." />
+                    ) : savedPrompts.length === 0 ? (
+                      <EmptyState
+                        icon={Bookmark}
+                        title="No saved listings yet"
+                        body="Save marketplace prompts while browsing to keep a short list of listings you want to revisit or compare later."
+                        action={{
+                          label: "Browse marketplace",
+                          to: "/browse",
+                          icon: ShoppingBag,
+                        }}
+                        accent="cyan"
+                      />
+                    ) : (
+                      <div className="space-y-4">
+                        {savedPrompts.map((savedPrompt) => (
+                          <SavedPromptCard
+                            key={savedPrompt.promptId}
+                            savedPrompt={savedPrompt}
+                            isBusy={busyPromptId === savedPrompt.promptId}
+                            onToggleSaved={(promptId, saved) =>
+                              void handleToggleSaved(promptId, saved)
+                            }
+                          />
+                        ))}
+                      </div>
+                    )}
                   </TabsContent>
                 </Tabs>
               </section>

--- a/src/pages/sell/CreatePromptForm.tsx
+++ b/src/pages/sell/CreatePromptForm.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useMemo, useState } from "react";
+import { ChangeEvent, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AlertCircle, Loader2 } from "lucide-react";
 import {
@@ -48,22 +48,35 @@ interface FormData {
   priceXlm: string;
 }
 
-export function CreatePromptForm() {
+interface CreatePromptFormProps {
+  onCreated?: () => void;
+}
+
+const DRAFT_STORAGE_PREFIX = "prompt-hash:create-draft:";
+
+const createEmptyFormData = (): FormData => ({
+  imageUrl: "",
+  title: "",
+  category: "",
+  previewText: "",
+  fullPrompt: "",
+  priceXlm: "2",
+});
+
+export function CreatePromptForm({ onCreated }: CreatePromptFormProps) {
   const navigate = useNavigate();
   const { address, signTransaction } = useWallet();
-  const [formData, setFormData] = useState<FormData>({
-    imageUrl: "",
-    title: "",
-    category: "",
-    previewText: "",
-    fullPrompt: "",
-    priceXlm: "2",
-  });
+  const draftStorageKey = address ? `${DRAFT_STORAGE_PREFIX}${address}` : null;
+  const draftLoadRef = useRef<string | null>(null);
+  const skipNextAutosaveRef = useRef(false);
+  const [formData, setFormData] = useState<FormData>(createEmptyFormData);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [showChecklist, setShowChecklist] = useState(false);
+  const [draftRestored, setDraftRestored] = useState(false);
+  const [lastSavedAt, setLastSavedAt] = useState<string | null>(null);
 
   const isConfigured = useMemo(
     () =>
@@ -82,6 +95,79 @@ export function CreatePromptForm() {
   );
 
   const checklistHasFailures = checklistItems.some((i) => i.status === "fail");
+
+  const clearDraft = () => {
+    if (draftStorageKey) {
+      window.localStorage.removeItem(draftStorageKey);
+    }
+    skipNextAutosaveRef.current = true;
+    setDraftRestored(false);
+    setLastSavedAt(null);
+  };
+
+  useEffect(() => {
+    draftLoadRef.current = null;
+    setDraftRestored(false);
+    setLastSavedAt(null);
+
+    if (!draftStorageKey) {
+      setFormData(createEmptyFormData());
+      return;
+    }
+
+    const rawDraft = window.localStorage.getItem(draftStorageKey);
+    if (!rawDraft) {
+      skipNextAutosaveRef.current = true;
+      setFormData(createEmptyFormData());
+      draftLoadRef.current = draftStorageKey;
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(rawDraft) as {
+        formData?: Partial<FormData>;
+        savedAt?: string;
+      };
+
+      if (parsed.formData) {
+        setFormData((current) => ({
+          ...current,
+          ...parsed.formData,
+        }));
+        setDraftRestored(true);
+        setLastSavedAt(parsed.savedAt ?? null);
+      }
+    } catch {
+      window.localStorage.removeItem(draftStorageKey);
+    } finally {
+      draftLoadRef.current = draftStorageKey;
+    }
+  }, [draftStorageKey]);
+
+  useEffect(() => {
+    if (!draftStorageKey || draftLoadRef.current !== draftStorageKey || isSubmitting) {
+      return;
+    }
+
+    if (skipNextAutosaveRef.current) {
+      skipNextAutosaveRef.current = false;
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      const savedAt = new Date().toISOString();
+      window.localStorage.setItem(
+        draftStorageKey,
+        JSON.stringify({
+          savedAt,
+          formData,
+        }),
+      );
+      setLastSavedAt(savedAt);
+    }, 500);
+
+    return () => window.clearTimeout(timeout);
+  }, [draftStorageKey, formData, isSubmitting]);
 
   const handleChange = (
     event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -210,15 +296,13 @@ export function CreatePromptForm() {
       );
 
       setSuccessMessage(`Prompt #${promptId.toString()} created successfully.`);
-      setFormData({
-        imageUrl: "",
-        title: "",
-        category: "",
-        previewText: "",
-        fullPrompt: "",
-        priceXlm: "2",
-      });
-      navigate("/browse");
+      clearDraft();
+      setFormData(createEmptyFormData());
+      if (onCreated) {
+        onCreated();
+      } else {
+        navigate("/browse");
+      }
     } catch (error) {
       setSubmitError(
         error instanceof Error ? error.message : "Failed to create prompt.",
@@ -380,6 +464,35 @@ export function CreatePromptForm() {
 
       {showChecklist ? (
         <ListingQualityChecklist items={checklistItems} />
+      ) : null}
+
+      {(draftRestored || lastSavedAt) && !isSubmitting ? (
+        <div className="rounded-2xl border border-cyan-400/20 bg-cyan-500/10 px-4 py-3 text-sm text-cyan-100">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <p className="font-medium">
+                {draftRestored ? "Recovered local draft." : "Draft saved locally."}
+              </p>
+              <p className="text-xs text-cyan-100/80">
+                Stored only on this device and cleared after publish or discard.
+                {lastSavedAt ? ` Last saved ${new Date(lastSavedAt).toLocaleString()}.` : ""}
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              className="h-9 border-cyan-300/30 bg-cyan-500/10 text-cyan-50 hover:bg-cyan-500/20"
+              onClick={() => {
+                clearDraft();
+                setFormData(createEmptyFormData());
+                setErrors({});
+                setShowChecklist(false);
+              }}
+            >
+              Discard draft
+            </Button>
+          </div>
+        </div>
       ) : null}
 
       <Button


### PR DESCRIPTION
Implements the buyer saved-listings flow, adds backend listing validation/normalization, and adds creator draft autosave/recovery for the listing form.

Closes #168
Closes #169
Closes #170
Closes #171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now save and unsave prompts to their personal library using bookmark buttons on prompt cards.
  * New "Saved" tab added to the profile page to view, manage, and remove saved prompts.
  * Create form now auto-saves drafts per connected wallet and recovers them on return, with draft recovery status indicators.

* **Documentation**
  * Comprehensive API reference rewrite documenting unified marketplace, account, and library endpoints with standardized response formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Obiajulu-gif/Prompt-Hash-Stellar/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->