### PR TITLE
Feat/issues 28 49 50 51

### DIFF
--- a/contracts/prompt-hash/src/contract.rs
+++ b/contracts/prompt-hash/src/contract.rs
@@ -1,6 +1,6 @@
 use super::events::Events;
 use super::storage::Storage;
-use super::types::{DataKey, Error, PricingConfig, Prompt, PromptHashTrait};
+use super::types::{DataKey, Error, ListingConfig, Prompt, PromptHashTrait, Split};
 use soroban_sdk::{contract, contractimpl, token, Address, Bytes, BytesN, Env, String, Vec};
 use stellar_access::ownable::{self as ownable, Ownable};
 use stellar_macros::{default_impl, only_owner};
@@ -52,7 +52,7 @@ impl PromptHashTrait for PromptHashContract {
         encryption_iv: String,
         wrapped_key: String,
         content_hash: BytesN<32>,
-        pricing: PricingConfig,
+        listing: ListingConfig,
     ) -> Result<u128, Error> {
         creator.require_auth();
         ensure(!Storage::is_paused(&env), Error::ContractIsPaused)?;
@@ -64,11 +64,19 @@ impl PromptHashTrait for PromptHashContract {
             &encrypted_prompt,
             &encryption_iv,
             &wrapped_key,
-            pricing.price,
+            listing.price,
         )?;
 
         // Validate that the asset address implements the token interface
-        token::Client::new(&env, &pricing.asset).decimals();
+        token::Client::new(&env, &listing.asset).decimals();
+
+        // #49: optional listing expiry must be in the future when provided
+        if listing.expires_at != 0 {
+            ensure(listing.expires_at > env.ledger().timestamp(), Error::InvalidPrice)?;
+        }
+
+        // #50: validate revenue splits
+        validate_splits(&env, &listing.splits)?;
 
         let prompt_id = Storage::get_prompt_counter(&env);
         let prompt = Prompt {
@@ -82,16 +90,18 @@ impl PromptHashTrait for PromptHashContract {
             encryption_iv,
             wrapped_key,
             content_hash,
-            price_stroops: pricing.price,
-            asset: pricing.asset.clone(),
+            price_stroops: listing.price,
+            asset: listing.asset.clone(),
             active: true,
             sales_count: 0,
             max_supply: 0,
+            expires_at: listing.expires_at,
+            splits: listing.splits,
         };
 
         Storage::save_prompt(&env, &prompt)?;
         Storage::add_prompt_to_creator(&env, &creator, prompt_id);
-        Events::emit_prompt_created(&env, prompt_id, creator, pricing.price, pricing.asset);
+        Events::emit_prompt_created(&env, prompt_id, creator, listing.price, listing.asset);
         Ok(prompt_id)
     }
 
@@ -156,126 +166,14 @@ impl PromptHashTrait for PromptHashContract {
     ) -> Result<(), Error> {
         buyer.require_auth();
         ensure(!Storage::is_paused(&env), Error::ContractIsPaused)?;
-        let mut prompt = Storage::require_prompt(&env, prompt_id)?;
-        let now = env.ledger().timestamp();
-
-        ensure(prompt.active, Error::PromptInactive)?;
-        ensure(prompt.creator != buyer, Error::CreatorCannotBuy)?;
-        ensure(
-            !Storage::has_active_purchase(&env, prompt_id, &buyer, now),
-            Error::AlreadyPurchased,
-        )?;
-
-        // Enforce max supply (0 = unlimited)
-        if prompt.max_supply > 0 {
-            ensure(
-                prompt.sales_count < prompt.max_supply,
-                Error::MaxSupplyReached,
-            )?;
-        }
-
-        // Apply voucher discount if provided
-        let mut required_price = prompt.price_stroops;
-        if let Some(code) = voucher {
-            let hashed_raw = env.crypto().sha256(&code);
-            let hashed = BytesN::from_array(&env, &hashed_raw.to_array());
-            if let Some(discount_bps) = Storage::get_voucher(&env, prompt_id, &hashed) {
-                let discount_amount = required_price
-                    .checked_mul(discount_bps as i128)
-                    .ok_or(Error::ArithmeticOverflow)?
-                    / MAX_BPS as i128;
-                required_price = required_price
-                    .checked_sub(discount_amount)
-                    .ok_or(Error::ArithmeticOverflow)?;
-                Storage::remove_voucher(&env, prompt_id, &hashed);
-            } else {
-                return Err(Error::InvalidVoucher);
-            }
-        }
-
-        ensure(
-            payment_amount_stroops >= required_price,
-            Error::InvalidPaymentAmount,
-        )?;
-
-        if let Some(ref r) = referrer {
-            ensure(
-                r != &buyer && r != &prompt.creator,
-                Error::ReferrerCannotBeBuyerOrCreator,
-            )?;
-        }
-
-        Storage::set_reentrancy_guard(&env)?;
-
-        let fee_wallet = Storage::get_fee_wallet(&env).ok_or(Error::FeeWalletNotSet)?;
-        let this_contract = env.current_contract_address();
-
-        let fee_percentage = Storage::get_fee_percentage(&env);
-        ensure(fee_percentage <= MAX_BPS, Error::InvalidFeePercentage)?;
-
-        let fee_amount = payment_amount_stroops
-            .checked_mul(fee_percentage as i128)
-            .ok_or(Error::ArithmeticOverflow)?
-            / MAX_BPS as i128;
-
-        let referral_percentage = Storage::get_referral_percentage(&env);
-        let referral_amount = if referrer.is_some() {
-            payment_amount_stroops
-                .checked_mul(referral_percentage as i128)
-                .ok_or(Error::ArithmeticOverflow)?
-                / MAX_BPS as i128
-        } else {
-            0
-        };
-
-        let deductions = fee_amount
-            .checked_add(referral_amount)
-            .ok_or(Error::ArithmeticOverflow)?;
-        let creator_amount = payment_amount_stroops
-            .checked_sub(deductions)
-            .ok_or(Error::ArithmeticOverflow)?;
-
-        let asset_client = token::StellarAssetClient::new(&env, &prompt.asset);
-
-        asset_client.transfer_from(&this_contract, &buyer, &prompt.creator, &creator_amount);
-
-        if fee_amount > 0 {
-            asset_client.transfer_from(&this_contract, &buyer, &fee_wallet, &fee_amount);
-        }
-
-        if let Some(ref r) = referrer {
-            if referral_amount > 0 {
-                asset_client.transfer_from(&this_contract, &buyer, r, &referral_amount);
-            }
-        }
-
-        prompt.sales_count = prompt
-            .sales_count
-            .checked_add(1)
-            .ok_or(Error::ArithmeticOverflow)?;
-        Storage::update_prompt(&env, &prompt);
-        Storage::grant_purchase(&env, prompt_id, &buyer, MAX_ACCESS_EXPIRY);
-        Storage::clear_reentrancy_guard(&env);
-
-        Events::emit_prompt_purchased(
+        execute_buy(
             &env,
+            &buyer,
             prompt_id,
-            buyer.clone(),
-            prompt.creator,
+            &referrer,
             payment_amount_stroops,
-            referrer,
-        );
-
-        if payment_amount_stroops > required_price {
-            Events::emit_prompt_tipped(
-                &env,
-                prompt_id,
-                buyer,
-                payment_amount_stroops - required_price,
-            );
-        }
-
-        Ok(())
+            voucher,
+        )
     }
 
     fn lease_prompt(
@@ -296,6 +194,11 @@ impl PromptHashTrait for PromptHashContract {
             !Storage::has_active_purchase(&env, prompt_id, &buyer, now),
             Error::AlreadyPurchased,
         )?;
+
+        // #49: block purchase on expired listing
+        if prompt.expires_at != 0 {
+            ensure(prompt.expires_at >= now, Error::ListingExpired)?;
+        }
 
         Storage::set_reentrancy_guard(&env)?;
 
@@ -336,6 +239,49 @@ impl PromptHashTrait for PromptHashContract {
         Storage::grant_purchase(&env, prompt_id, &buyer, expires_at);
         Storage::clear_reentrancy_guard(&env);
         Events::emit_prompt_purchased(&env, prompt_id, buyer, prompt.creator, lease_price, None);
+        Ok(())
+    }
+
+    // ─── Issue #49: Time-Bound Listing Expiry ────────────────────────────────
+
+    fn extend_listing(
+        env: Env,
+        creator: Address,
+        prompt_id: u128,
+        new_expires_at: u64,
+    ) -> Result<(), Error> {
+        creator.require_auth();
+        ensure(!Storage::is_paused(&env), Error::ContractIsPaused)?;
+        let mut prompt = Storage::require_prompt(&env, prompt_id)?;
+        ensure(prompt.creator == creator, Error::Unauthorized)?;
+
+        let now = env.ledger().timestamp();
+        ensure(new_expires_at > now, Error::InvalidPrice)?;
+
+        prompt.expires_at = new_expires_at;
+        Storage::update_prompt(&env, &prompt);
+        Events::emit_listing_extended(&env, prompt_id, new_expires_at);
+        Ok(())
+    }
+
+    // ─── Issue #51: Bulk Purchase ────────────────────────────────────────────
+
+    fn buy_prompts_bulk(
+        env: Env,
+        buyer: Address,
+        prompt_ids: Vec<u128>,
+        payment_amounts: Vec<i128>,
+        referrer: Option<Address>,
+    ) -> Result<(), Error> {
+        buyer.require_auth();
+        ensure(!Storage::is_paused(&env), Error::ContractIsPaused)?;
+        ensure(prompt_ids.len() == payment_amounts.len(), Error::InvalidPrice)?;
+
+        for i in 0..prompt_ids.len() {
+            let prompt_id = prompt_ids.get(i).unwrap();
+            let payment_amount = payment_amounts.get(i).unwrap();
+            execute_buy(&env, &buyer, prompt_id, &referrer, payment_amount, None)?;
+        }
         Ok(())
     }
 
@@ -464,6 +410,205 @@ impl PromptHashTrait for PromptHashContract {
 #[default_impl]
 #[contractimpl]
 impl Ownable for PromptHashContract {}
+
+// ─── Core buy logic (shared by buy_prompt and buy_prompts_bulk) ──────────────
+
+fn execute_buy(
+    env: &Env,
+    buyer: &Address,
+    prompt_id: u128,
+    referrer: &Option<Address>,
+    payment_amount_stroops: i128,
+    voucher: Option<Bytes>,
+) -> Result<(), Error> {
+    let mut prompt = Storage::require_prompt(env, prompt_id)?;
+    let now = env.ledger().timestamp();
+
+    ensure(prompt.active, Error::PromptInactive)?;
+    ensure(prompt.creator != *buyer, Error::CreatorCannotBuy)?;
+    ensure(
+        !Storage::has_active_purchase(env, prompt_id, buyer, now),
+        Error::AlreadyPurchased,
+    )?;
+
+    // #49: block purchase on an expired listing
+    if prompt.expires_at != 0 {
+        ensure(prompt.expires_at >= now, Error::ListingExpired)?;
+    }
+
+    // Enforce max supply (0 = unlimited)
+    if prompt.max_supply > 0 {
+        ensure(
+            prompt.sales_count < prompt.max_supply,
+            Error::MaxSupplyReached,
+        )?;
+    }
+
+    // Apply voucher discount if provided
+    let mut required_price = prompt.price_stroops;
+    if let Some(code) = voucher {
+        let hashed_raw = env.crypto().sha256(&code);
+        let hashed = BytesN::from_array(env, &hashed_raw.to_array());
+        if let Some(discount_bps) = Storage::get_voucher(env, prompt_id, &hashed) {
+            let discount_amount = required_price
+                .checked_mul(discount_bps as i128)
+                .ok_or(Error::ArithmeticOverflow)?
+                / MAX_BPS as i128;
+            required_price = required_price
+                .checked_sub(discount_amount)
+                .ok_or(Error::ArithmeticOverflow)?;
+            Storage::remove_voucher(env, prompt_id, &hashed);
+        } else {
+            return Err(Error::InvalidVoucher);
+        }
+    }
+
+    ensure(
+        payment_amount_stroops >= required_price,
+        Error::InvalidPaymentAmount,
+    )?;
+
+    if let Some(ref r) = referrer {
+        ensure(
+            r != buyer && r != &prompt.creator,
+            Error::ReferrerCannotBeBuyerOrCreator,
+        )?;
+    }
+
+    Storage::set_reentrancy_guard(env)?;
+
+    let fee_wallet = Storage::get_fee_wallet(env).ok_or(Error::FeeWalletNotSet)?;
+    let this_contract = env.current_contract_address();
+
+    let fee_percentage = Storage::get_fee_percentage(env);
+    ensure(fee_percentage <= MAX_BPS, Error::InvalidFeePercentage)?;
+
+    let fee_amount = payment_amount_stroops
+        .checked_mul(fee_percentage as i128)
+        .ok_or(Error::ArithmeticOverflow)?
+        / MAX_BPS as i128;
+
+    let referral_percentage = Storage::get_referral_percentage(env);
+    let referral_amount = if referrer.is_some() {
+        payment_amount_stroops
+            .checked_mul(referral_percentage as i128)
+            .ok_or(Error::ArithmeticOverflow)?
+            / MAX_BPS as i128
+    } else {
+        0
+    };
+
+    let deductions = fee_amount
+        .checked_add(referral_amount)
+        .ok_or(Error::ArithmeticOverflow)?;
+
+    // #50: accumulate split amounts (each split is a share of the full payment)
+    let mut split_total: i128 = 0;
+    for i in 0..prompt.splits.len() {
+        let split = prompt.splits.get(i).unwrap();
+        let split_amount = payment_amount_stroops
+            .checked_mul(split.bps as i128)
+            .ok_or(Error::ArithmeticOverflow)?
+            / MAX_BPS as i128;
+        split_total = split_total
+            .checked_add(split_amount)
+            .ok_or(Error::ArithmeticOverflow)?;
+    }
+
+    let total_deductions = deductions
+        .checked_add(split_total)
+        .ok_or(Error::ArithmeticOverflow)?;
+    let creator_amount = payment_amount_stroops
+        .checked_sub(total_deductions)
+        .ok_or(Error::ArithmeticOverflow)?;
+
+    // Guard against misconfigured splits (e.g. fee raised after creation)
+    ensure(creator_amount >= 0, Error::InvalidSplits)?;
+
+    let asset_client = token::StellarAssetClient::new(env, &prompt.asset);
+
+    if creator_amount > 0 {
+        asset_client.transfer_from(&this_contract, buyer, &prompt.creator, &creator_amount);
+    }
+
+    if fee_amount > 0 {
+        asset_client.transfer_from(&this_contract, buyer, &fee_wallet, &fee_amount);
+    }
+
+    if let Some(ref r) = referrer {
+        if referral_amount > 0 {
+            asset_client.transfer_from(&this_contract, buyer, r, &referral_amount);
+        }
+    }
+
+    // #50: distribute co-creator splits
+    for i in 0..prompt.splits.len() {
+        let split = prompt.splits.get(i).unwrap();
+        let split_amount = payment_amount_stroops
+            .checked_mul(split.bps as i128)
+            .ok_or(Error::ArithmeticOverflow)?
+            / MAX_BPS as i128;
+        if split_amount > 0 {
+            asset_client.transfer_from(
+                &this_contract,
+                buyer,
+                &split.recipient,
+                &split_amount,
+            );
+        }
+    }
+
+    prompt.sales_count = prompt
+        .sales_count
+        .checked_add(1)
+        .ok_or(Error::ArithmeticOverflow)?;
+    Storage::update_prompt(env, &prompt);
+    Storage::grant_purchase(env, prompt_id, buyer, MAX_ACCESS_EXPIRY);
+    Storage::clear_reentrancy_guard(env);
+
+    Events::emit_prompt_purchased(
+        env,
+        prompt_id,
+        buyer.clone(),
+        prompt.creator,
+        payment_amount_stroops,
+        referrer.clone(),
+    );
+
+    if payment_amount_stroops > required_price {
+        Events::emit_prompt_tipped(
+            env,
+            prompt_id,
+            buyer.clone(),
+            payment_amount_stroops - required_price,
+        );
+    }
+
+    Ok(())
+}
+
+// ─── Validation helpers ───────────────────────────────────────────────────────
+
+/// Validate that the sum of all split basis-points does not exceed
+/// MAX_BPS minus the current platform fee, ensuring the creator always
+/// receives a non-negative payout.
+fn validate_splits(env: &Env, splits: &Vec<Split>) -> Result<(), Error> {
+    let fee_percentage = Storage::get_fee_percentage(env);
+    let mut total_bps: u32 = 0;
+    for i in 0..splits.len() {
+        let split = splits.get(i).unwrap();
+        ensure(split.bps > 0, Error::InvalidSplits)?;
+        total_bps = total_bps
+            .checked_add(split.bps)
+            .ok_or(Error::ArithmeticOverflow)?;
+    }
+    // total_bps + fee must not exceed MAX_BPS so creator always gets ≥ 0
+    let total = total_bps
+        .checked_add(fee_percentage)
+        .ok_or(Error::ArithmeticOverflow)?;
+    ensure(total <= MAX_BPS, Error::InvalidSplits)?;
+    Ok(())
+}
 
 #[allow(clippy::too_many_arguments)]
 fn validate_prompt_fields(

--- a/contracts/prompt-hash/src/events.rs
+++ b/contracts/prompt-hash/src/events.rs
@@ -73,6 +73,13 @@ struct FeeWalletUpdated {
     pub new_fee_wallet: Address,
 }
 
+#[contractevent]
+struct ListingExtended {
+    #[topic]
+    pub prompt_id: u128,
+    pub new_expires_at: u64,
+}
+
 pub struct Events;
 
 impl Events {
@@ -163,5 +170,13 @@ impl Events {
 
     pub fn emit_fee_wallet_updated(env: &Env, new_fee_wallet: Address) {
         FeeWalletUpdated { new_fee_wallet }.publish(env);
+    }
+
+    pub fn emit_listing_extended(env: &Env, prompt_id: u128, new_expires_at: u64) {
+        ListingExtended {
+            prompt_id,
+            new_expires_at,
+        }
+        .publish(env);
     }
 }

--- a/contracts/prompt-hash/src/storage.rs
+++ b/contracts/prompt-hash/src/storage.rs
@@ -71,10 +71,14 @@ impl Storage {
 
     pub fn get_all_prompts(env: &Env) -> Vec<Prompt> {
         let prompt_count = Self::get_prompt_counter(env);
+        let now = env.ledger().timestamp();
         let mut prompts = Vec::new(env);
         for prompt_id in 0..prompt_count {
             if let Some(prompt) = Self::get_prompt(env, prompt_id) {
-                prompts.push_back(prompt);
+                // Skip expired listings (expires_at == 0 means never expires)
+                if prompt.expires_at == 0 || prompt.expires_at >= now {
+                    prompts.push_back(prompt);
+                }
             }
         }
         prompts

--- a/contracts/prompt-hash/src/test.rs
+++ b/contracts/prompt-hash/src/test.rs
@@ -1,10 +1,10 @@
 use crate::contract::{PromptHashContract, PromptHashContractClient};
 use crate::mock_asset::FungibleTokenContract;
-use crate::types::{Error, PricingConfig};
+use crate::types::{Error, ListingConfig, Split};
 extern crate std;
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
-    token, Address, Bytes, BytesN, Env, String,
+    token, Address, Bytes, BytesN, Env, String, Vec,
 };
 
 #[derive(Clone, Debug, PartialEq)]
@@ -38,6 +38,7 @@ fn hash(env: &Env, byte: u8) -> BytesN<32> {
     BytesN::from_array(env, &[byte; 32])
 }
 
+/// Convenience helper: creates a prompt with no expiry and no splits.
 fn create_prompt(
     env: &Env,
     client: &PromptHashContractClient,
@@ -56,9 +57,11 @@ fn create_prompt(
         &String::from_str(env, "iv"),
         &String::from_str(env, "wrapped-key"),
         &hash(env, 7),
-        &PricingConfig {
+        &ListingConfig {
             price: price_stroops,
             asset: asset.clone(),
+            expires_at: 0,
+            splits: Vec::new(env),
         },
     )
 }
@@ -105,6 +108,8 @@ fn test_create_prompt_stores_encrypted_fields() {
     assert_eq!(prompt.content_hash, hash(&env, 7));
     assert!(prompt.active);
     assert_eq!(prompt.sales_count, 0);
+    assert_eq!(prompt.expires_at, 0);
+    assert_eq!(prompt.splits.len(), 0);
 
     let all_prompts = client.get_all_prompts();
     assert_eq!(all_prompts.len(), 1);
@@ -532,9 +537,11 @@ fn test_global_pause_blocks_mutations_but_not_reads() {
         &String::from_str(&env, "iv"),
         &String::from_str(&env, "wrapped-key"),
         &hash(&env, 1),
-        &PricingConfig {
+        &ListingConfig {
             price: 10_000,
             asset: context.xlm.clone(),
+            expires_at: 0,
+            splits: Vec::new(&env),
         },
     );
     match create_res {
@@ -807,9 +814,11 @@ fn test_create_prompt_blocked_when_paused() {
         &String::from_str(&env, "iv"),
         &String::from_str(&env, "wrapped-key"),
         &hash(&env, 1),
-        &PricingConfig {
+        &ListingConfig {
             price: 5_000,
             asset: context.xlm.clone(),
+            expires_at: 0,
+            splits: Vec::new(&env),
         },
     );
     match result {
@@ -935,6 +944,68 @@ fn test_unpause_restores_operations() {
     fund_buyer(&xlm_client, &buyer, &context.contract, price);
     client.buy_prompt(&buyer, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
     assert!(client.has_access(&buyer, &prompt_id));
+}
+
+// ─── Issue #28: Emergency Pause – additional coverage ─────────────────────────
+
+/// Verifies that set_pause_status is restricted to the owner. The #[only_owner]
+/// macro enforces this at the auth level; here we confirm the happy path works
+/// and that extend_listing is also blocked while paused.
+#[test]
+fn test_extend_listing_blocked_when_paused() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+
+    let creator = Address::generate(&env);
+    let prompt_id = create_prompt(
+        &env,
+        &client,
+        &creator,
+        "Pause Extend Prompt",
+        5_000,
+        &context.xlm,
+    );
+
+    client.set_pause_status(&true);
+
+    let result = client.try_extend_listing(&creator, &prompt_id, &2_000u64);
+    match result {
+        Err(Ok(Error::ContractIsPaused)) => {}
+        other => panic!(
+            "expected ContractIsPaused for extend_listing while paused, got {:?}",
+            other
+        ),
+    }
+}
+
+#[test]
+fn test_bulk_purchase_blocked_when_paused() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let prompt_id = create_prompt(&env, &client, &creator, "Bulk Pause", 1_000, &context.xlm);
+
+    client.set_pause_status(&true);
+
+    let mut ids = Vec::new(&env);
+    ids.push_back(prompt_id);
+    let mut amounts = Vec::new(&env);
+    amounts.push_back(1_000i128);
+
+    let result = client.try_buy_prompts_bulk(&buyer, &ids, &amounts, &None::<Address>);
+    match result {
+        Err(Ok(Error::ContractIsPaused)) => {}
+        other => panic!(
+            "expected ContractIsPaused for buy_prompts_bulk while paused, got {:?}",
+            other
+        ),
+    }
 }
 
 // ─── Issue #108: Prompt Tipping and Bonus Payments ────────────────────────────
@@ -1481,4 +1552,555 @@ fn test_lease_prompt_with_non_xlm_asset() {
         ledger.timestamp = 1_700;
     });
     assert!(!client.has_access(&buyer, &prompt_id));
+}
+
+// ─── Issue #49: Time-Bound Listing Expiry ────────────────────────────────────
+
+#[test]
+fn test_create_prompt_with_expiry_stores_expires_at() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+
+    let creator = Address::generate(&env);
+    let expires_at: u64 = 10_000;
+
+    let prompt_id = client.create_prompt(
+        &creator,
+        &String::from_str(&env, "https://example.com/img.png"),
+        &String::from_str(&env, "Expiring Prompt"),
+        &String::from_str(&env, "Software Development"),
+        &String::from_str(&env, "preview"),
+        &String::from_str(&env, "ciphertext"),
+        &String::from_str(&env, "iv"),
+        &String::from_str(&env, "wrapped-key"),
+        &hash(&env, 2),
+        &ListingConfig {
+            price: 5_000,
+            asset: context.xlm.clone(),
+            expires_at,
+            splits: Vec::new(&env),
+        },
+    );
+
+    let prompt = client.get_prompt(&prompt_id);
+    assert_eq!(prompt.expires_at, expires_at);
+}
+
+#[test]
+fn test_expired_listing_excluded_from_get_all_prompts() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+
+    let creator = Address::generate(&env);
+
+    // Create one prompt that expires at t=2000 and one that never expires
+    let _expiring = client.create_prompt(
+        &creator,
+        &String::from_str(&env, "https://example.com/img.png"),
+        &String::from_str(&env, "Expiring"),
+        &String::from_str(&env, "Software Development"),
+        &String::from_str(&env, "preview"),
+        &String::from_str(&env, "ciphertext"),
+        &String::from_str(&env, "iv"),
+        &String::from_str(&env, "wrapped-key"),
+        &hash(&env, 3),
+        &ListingConfig {
+            price: 5_000,
+            asset: context.xlm.clone(),
+            expires_at: 2_000,
+            splits: Vec::new(&env),
+        },
+    );
+    let persistent = create_prompt(&env, &client, &creator, "Persistent", 5_000, &context.xlm);
+
+    // Both visible before expiry
+    assert_eq!(client.get_all_prompts().len(), 2);
+
+    // Advance time past the first prompt's expiry
+    env.ledger().with_mut(|l| l.timestamp = 3_000);
+
+    let visible = client.get_all_prompts();
+    assert_eq!(visible.len(), 1);
+    assert_eq!(visible.get(0).unwrap().id, persistent);
+}
+
+#[test]
+fn test_buy_expired_listing_fails() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+
+    let prompt_id = client.create_prompt(
+        &creator,
+        &String::from_str(&env, "https://example.com/img.png"),
+        &String::from_str(&env, "Short-lived Prompt"),
+        &String::from_str(&env, "Software Development"),
+        &String::from_str(&env, "preview"),
+        &String::from_str(&env, "ciphertext"),
+        &String::from_str(&env, "iv"),
+        &String::from_str(&env, "wrapped-key"),
+        &hash(&env, 4),
+        &ListingConfig {
+            price: 5_000,
+            asset: context.xlm.clone(),
+            expires_at: 2_000,
+            splits: Vec::new(&env),
+        },
+    );
+
+    fund_buyer(&xlm_client, &buyer, &context.contract, 10_000);
+
+    // Purchase before expiry succeeds
+    client.buy_prompt(
+        &buyer,
+        &prompt_id,
+        &None::<Address>,
+        &5_000i128,
+        &None::<Bytes>,
+    );
+    assert!(client.has_access(&buyer, &prompt_id));
+
+    // After expiry a new buyer is rejected
+    env.ledger().with_mut(|l| l.timestamp = 3_000);
+    let buyer2 = Address::generate(&env);
+    fund_buyer(&xlm_client, &buyer2, &context.contract, 10_000);
+
+    let result = client.try_buy_prompt(
+        &buyer2,
+        &prompt_id,
+        &None::<Address>,
+        &5_000i128,
+        &None::<Bytes>,
+    );
+    match result {
+        Err(Ok(Error::ListingExpired)) => {}
+        other => panic!("expected ListingExpired, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_extend_listing_pushes_expiry_and_allows_purchase() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+
+    let prompt_id = client.create_prompt(
+        &creator,
+        &String::from_str(&env, "https://example.com/img.png"),
+        &String::from_str(&env, "Extend Me"),
+        &String::from_str(&env, "Software Development"),
+        &String::from_str(&env, "preview"),
+        &String::from_str(&env, "ciphertext"),
+        &String::from_str(&env, "iv"),
+        &String::from_str(&env, "wrapped-key"),
+        &hash(&env, 5),
+        &ListingConfig {
+            price: 5_000,
+            asset: context.xlm.clone(),
+            expires_at: 2_000, // expires at t=2000
+            splits: Vec::new(&env),
+        },
+    );
+
+    // Advance past original expiry
+    env.ledger().with_mut(|l| l.timestamp = 2_500);
+
+    // Extend to t=5000
+    client.extend_listing(&creator, &prompt_id, &5_000u64);
+    assert_eq!(client.get_prompt(&prompt_id).expires_at, 5_000);
+
+    // Purchase now succeeds
+    fund_buyer(&xlm_client, &buyer, &context.contract, 10_000);
+    client.buy_prompt(
+        &buyer,
+        &prompt_id,
+        &None::<Address>,
+        &5_000i128,
+        &None::<Bytes>,
+    );
+    assert!(client.has_access(&buyer, &prompt_id));
+}
+
+#[test]
+fn test_only_creator_can_extend_listing() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+
+    let creator = Address::generate(&env);
+    let stranger = Address::generate(&env);
+    let prompt_id = create_prompt(&env, &client, &creator, "Auth Extend", 5_000, &context.xlm);
+
+    let result = client.try_extend_listing(&stranger, &prompt_id, &9_000u64);
+    match result {
+        Err(Ok(Error::Unauthorized)) => {}
+        other => panic!("expected Unauthorized for stranger extend_listing, got {:?}", other),
+    }
+}
+
+// ─── Issue #50: Seller Revenue Sharing (Splits) ───────────────────────────────
+
+#[test]
+fn test_create_prompt_with_splits_stores_split_data() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+
+    let creator = Address::generate(&env);
+    let co_creator = Address::generate(&env);
+
+    let mut splits = Vec::<Split>::new(&env);
+    splits.push_back(Split {
+        recipient: co_creator.clone(),
+        bps: 2_000, // 20%
+    });
+
+    let prompt_id = client.create_prompt(
+        &creator,
+        &String::from_str(&env, "https://example.com/img.png"),
+        &String::from_str(&env, "Split Prompt"),
+        &String::from_str(&env, "Software Development"),
+        &String::from_str(&env, "preview"),
+        &String::from_str(&env, "ciphertext"),
+        &String::from_str(&env, "iv"),
+        &String::from_str(&env, "wrapped-key"),
+        &hash(&env, 6),
+        &ListingConfig {
+            price: 10_000,
+            asset: context.xlm.clone(),
+            expires_at: 0,
+            splits,
+        },
+    );
+
+    let prompt = client.get_prompt(&prompt_id);
+    assert_eq!(prompt.splits.len(), 1);
+    assert_eq!(prompt.splits.get(0).unwrap().bps, 2_000);
+}
+
+#[test]
+fn test_buy_prompt_with_splits_distributes_correctly() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+
+    let creator = Address::generate(&env);
+    let co_creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let price: i128 = 10_000;
+
+    // Platform fee = 500 BPS (5%), split = 2000 BPS (20%)
+    // creator receives 10_000 - 500 - 2_000 = 7_500 (75%)
+    let mut splits = Vec::<Split>::new(&env);
+    splits.push_back(Split {
+        recipient: co_creator.clone(),
+        bps: 2_000,
+    });
+
+    let prompt_id = client.create_prompt(
+        &creator,
+        &String::from_str(&env, "https://example.com/img.png"),
+        &String::from_str(&env, "Split Buy Prompt"),
+        &String::from_str(&env, "Software Development"),
+        &String::from_str(&env, "preview"),
+        &String::from_str(&env, "ciphertext"),
+        &String::from_str(&env, "iv"),
+        &String::from_str(&env, "wrapped-key"),
+        &hash(&env, 8),
+        &ListingConfig {
+            price,
+            asset: context.xlm.clone(),
+            expires_at: 0,
+            splits,
+        },
+    );
+
+    fund_buyer(&xlm_client, &buyer, &context.contract, price);
+
+    let creator_start = xlm_client.balance(&creator);
+    let co_creator_start = xlm_client.balance(&co_creator);
+    let fee_start = xlm_client.balance(&context.fee_wallet);
+
+    client.buy_prompt(&buyer, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
+
+    let expected_fee = price * 500 / 10_000;       // 500
+    let expected_split = price * 2_000 / 10_000;   // 2_000
+    let expected_creator = price - expected_fee - expected_split; // 7_500
+
+    assert_eq!(
+        xlm_client.balance(&creator),
+        creator_start + expected_creator
+    );
+    assert_eq!(
+        xlm_client.balance(&co_creator),
+        co_creator_start + expected_split
+    );
+    assert_eq!(
+        xlm_client.balance(&context.fee_wallet),
+        fee_start + expected_fee
+    );
+    assert!(client.has_access(&buyer, &prompt_id));
+}
+
+#[test]
+fn test_splits_exceeding_max_bps_minus_fee_rejected() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+
+    let creator = Address::generate(&env);
+    let co1 = Address::generate(&env);
+
+    // Platform fee = 500 BPS; split = 9_600 BPS → total = 10_100 > MAX_BPS
+    let mut splits = Vec::<Split>::new(&env);
+    splits.push_back(Split {
+        recipient: co1.clone(),
+        bps: 9_600,
+    });
+
+    let result = client.try_create_prompt(
+        &creator,
+        &String::from_str(&env, "https://example.com/img.png"),
+        &String::from_str(&env, "Bad Splits"),
+        &String::from_str(&env, "Software Development"),
+        &String::from_str(&env, "preview"),
+        &String::from_str(&env, "ciphertext"),
+        &String::from_str(&env, "iv"),
+        &String::from_str(&env, "wrapped-key"),
+        &hash(&env, 9),
+        &ListingConfig {
+            price: 5_000,
+            asset: context.xlm.clone(),
+            expires_at: 0,
+            splits,
+        },
+    );
+    match result {
+        Err(Ok(Error::InvalidSplits)) => {}
+        other => panic!("expected InvalidSplits for over-allocated splits, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_multiple_splits_distribute_all_recipients() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+
+    let creator = Address::generate(&env);
+    let co1 = Address::generate(&env);
+    let co2 = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let price: i128 = 10_000;
+
+    // fee=500, co1=1000, co2=1500 → total=3000, creator gets 7000
+    let mut splits = Vec::<Split>::new(&env);
+    splits.push_back(Split {
+        recipient: co1.clone(),
+        bps: 1_000,
+    });
+    splits.push_back(Split {
+        recipient: co2.clone(),
+        bps: 1_500,
+    });
+
+    let prompt_id = client.create_prompt(
+        &creator,
+        &String::from_str(&env, "https://example.com/img.png"),
+        &String::from_str(&env, "Multi Split"),
+        &String::from_str(&env, "Software Development"),
+        &String::from_str(&env, "preview"),
+        &String::from_str(&env, "ciphertext"),
+        &String::from_str(&env, "iv"),
+        &String::from_str(&env, "wrapped-key"),
+        &hash(&env, 10),
+        &ListingConfig {
+            price,
+            asset: context.xlm.clone(),
+            expires_at: 0,
+            splits,
+        },
+    );
+
+    fund_buyer(&xlm_client, &buyer, &context.contract, price);
+
+    let creator_start = xlm_client.balance(&creator);
+    let co1_start = xlm_client.balance(&co1);
+    let co2_start = xlm_client.balance(&co2);
+
+    client.buy_prompt(&buyer, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
+
+    assert_eq!(
+        xlm_client.balance(&creator),
+        creator_start + price * (10_000 - 500 - 1_000 - 1_500) / 10_000
+    );
+    assert_eq!(xlm_client.balance(&co1), co1_start + price * 1_000 / 10_000);
+    assert_eq!(xlm_client.balance(&co2), co2_start + price * 1_500 / 10_000);
+}
+
+// ─── Issue #51: Bulk Purchase ─────────────────────────────────────────────────
+
+#[test]
+fn test_buy_prompts_bulk_purchases_all_and_grants_access() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+
+    let price_a: i128 = 5_000;
+    let price_b: i128 = 8_000;
+
+    let prompt_a = create_prompt(&env, &client, &creator, "Bulk A", price_a, &context.xlm);
+    let prompt_b = create_prompt(&env, &client, &creator, "Bulk B", price_b, &context.xlm);
+
+    let total = price_a + price_b;
+    fund_buyer(&xlm_client, &buyer, &context.contract, total);
+
+    let mut ids = Vec::new(&env);
+    ids.push_back(prompt_a);
+    ids.push_back(prompt_b);
+
+    let mut amounts = Vec::new(&env);
+    amounts.push_back(price_a);
+    amounts.push_back(price_b);
+
+    client.buy_prompts_bulk(&buyer, &ids, &amounts, &None::<Address>);
+
+    assert!(client.has_access(&buyer, &prompt_a));
+    assert!(client.has_access(&buyer, &prompt_b));
+
+    let fee_bps = 500i128;
+    let expected_creator =
+        (price_a - price_a * fee_bps / 10_000) + (price_b - price_b * fee_bps / 10_000);
+    let expected_fee =
+        price_a * fee_bps / 10_000 + price_b * fee_bps / 10_000;
+    assert_eq!(xlm_client.balance(&creator), expected_creator);
+    assert_eq!(xlm_client.balance(&context.fee_wallet), expected_fee);
+}
+
+#[test]
+fn test_buy_prompts_bulk_atomicity_one_failure_reverts_all() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+
+    let price: i128 = 5_000;
+    let prompt_a = create_prompt(&env, &client, &creator, "Bulk Ok", price, &context.xlm);
+    // prompt 999_999 does not exist
+
+    fund_buyer(&xlm_client, &buyer, &context.contract, price);
+
+    let mut ids = Vec::new(&env);
+    ids.push_back(prompt_a);
+    ids.push_back(999_999u128); // non-existent
+
+    let mut amounts = Vec::new(&env);
+    amounts.push_back(price);
+    amounts.push_back(price);
+
+    let result = client.try_buy_prompts_bulk(&buyer, &ids, &amounts, &None::<Address>);
+    match result {
+        Err(Ok(Error::PromptNotFound)) => {}
+        other => panic!(
+            "expected PromptNotFound for bulk with bad ID, got {:?}",
+            other
+        ),
+    }
+
+    // First prompt must not have been purchased (whole tx reverted)
+    assert!(!client.has_access(&buyer, &prompt_a));
+}
+
+#[test]
+fn test_buy_prompts_bulk_mismatched_lengths_fails() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let prompt_a = create_prompt(&env, &client, &creator, "Mismatch", 5_000, &context.xlm);
+
+    let mut ids = Vec::new(&env);
+    ids.push_back(prompt_a);
+
+    let amounts: Vec<i128> = Vec::new(&env); // empty — mismatch
+
+    let result = client.try_buy_prompts_bulk(&buyer, &ids, &amounts, &None::<Address>);
+    match result {
+        Err(Ok(Error::InvalidPrice)) => {}
+        other => panic!(
+            "expected InvalidPrice for mismatched bulk lengths, got {:?}",
+            other
+        ),
+    }
+}
+
+#[test]
+fn test_buy_prompts_bulk_with_referrer() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+
+    client.set_referral_percentage(&500); // 5%
+
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let referrer = Address::generate(&env);
+
+    let price: i128 = 10_000;
+    let prompt_a = create_prompt(&env, &client, &creator, "Bulk Ref A", price, &context.xlm);
+    let prompt_b = create_prompt(&env, &client, &creator, "Bulk Ref B", price, &context.xlm);
+
+    fund_buyer(&xlm_client, &buyer, &context.contract, price * 2);
+
+    let mut ids = Vec::new(&env);
+    ids.push_back(prompt_a);
+    ids.push_back(prompt_b);
+
+    let mut amounts = Vec::new(&env);
+    amounts.push_back(price);
+    amounts.push_back(price);
+
+    let referrer_start = xlm_client.balance(&referrer);
+    client.buy_prompts_bulk(&buyer, &ids, &amounts, &Some(referrer.clone()));
+
+    // referral = 10_000 * 500 / 10_000 = 500 per prompt × 2
+    let expected_referral = price * 500 / 10_000 * 2;
+    assert_eq!(
+        xlm_client.balance(&referrer),
+        referrer_start + expected_referral
+    );
+    assert!(client.has_access(&buyer, &prompt_a));
+    assert!(client.has_access(&buyer, &prompt_b));
 }

--- a/contracts/prompt-hash/src/types.rs
+++ b/contracts/prompt-hash/src/types.rs
@@ -30,6 +30,10 @@ pub enum Error {
     InvalidDiscountPercentage = 24,
     MaxSupplyReached = 25,
     InvalidAsset = 26,
+    // #50 – revenue splits
+    InvalidSplits = 27,
+    // #49 – time-bound listing expiry
+    ListingExpired = 28,
 }
 
 #[contracttype]
@@ -62,6 +66,31 @@ pub struct PricingConfig {
     pub asset: Address,
 }
 
+/// A single revenue-split entry stored inside a prompt.
+/// `bps` is the share of the full payment (in basis points) paid to `recipient`
+/// before the creator receives the remainder.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Split {
+    pub recipient: Address,
+    pub bps: u32,
+}
+
+/// Full listing configuration passed to create_prompt.
+/// Bundles pricing, optional expiry, and optional revenue splits into a single
+/// parameter so the function stays within Soroban's 10-parameter limit.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ListingConfig {
+    pub price: i128,
+    pub asset: Address,
+    /// Unix timestamp after which the listing can no longer be purchased.
+    /// `0` means the listing never expires.
+    pub expires_at: u64,
+    /// Optional co-creator revenue splits (empty Vec = no splits).
+    pub splits: Vec<Split>,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Prompt {
@@ -79,7 +108,12 @@ pub struct Prompt {
     pub asset: Address,
     pub active: bool,
     pub sales_count: u64,
-    pub max_supply: u64, // 0 = unlimited
+    pub max_supply: u64,
+    /// Unix timestamp after which the listing can no longer be purchased.
+    /// `0` means the listing never expires.
+    pub expires_at: u64,
+    /// Optional co-creator revenue splits applied against the full payment.
+    pub splits: Vec<Split>,
 }
 
 pub trait PromptHashTrait {
@@ -102,7 +136,7 @@ pub trait PromptHashTrait {
         encryption_iv: String,
         wrapped_key: String,
         content_hash: BytesN<32>,
-        pricing: PricingConfig,
+        listing: ListingConfig,
     ) -> Result<u128, Error>;
 
     fn set_prompt_sale_status(
@@ -140,6 +174,27 @@ pub trait PromptHashTrait {
         buyer: Address,
         prompt_id: u128,
         lease_duration_secs: u64,
+    ) -> Result<(), Error>;
+
+    /// Push the expiry date of a listing forward. `new_expires_at` must be
+    /// strictly greater than the current ledger timestamp.
+    fn extend_listing(
+        env: Env,
+        creator: Address,
+        prompt_id: u128,
+        new_expires_at: u64,
+    ) -> Result<(), Error>;
+
+    /// Purchase multiple prompts atomically in a single transaction.
+    /// `prompt_ids` and `payment_amounts` must have equal length.
+    /// An optional `referrer` applies to every prompt in the batch.
+    /// If any individual purchase fails the entire transaction reverts.
+    fn buy_prompts_bulk(
+        env: Env,
+        buyer: Address,
+        prompt_ids: Vec<u128>,
+        payment_amounts: Vec<i128>,
+        referrer: Option<Address>,
     ) -> Result<(), Error>;
 
     fn has_access(env: Env, user: Address, prompt_id: u128) -> Result<bool, Error>;


### PR DESCRIPTION
# [contracts] Emergency Pause, Listing Expiry, Revenue Splits, Bulk Purchase

Closes #28 
Closes #49 
Closes #50 
Closes #51 

---

## Summary

This PR extends the `prompt-hash` Soroban smart contract with four related features:

- **#28** – Emergency pause controls (documentation + coverage for new methods)
- **#49** – Time-bound listing expiry with `extend_listing`
- **#50** – Seller revenue sharing (splits) paid at purchase time
- **#51** – Bulk purchase in a single atomic transaction

---

## Implemented approach

### #28 – Emergency Pause Controls

The pause mechanism (`set_pause_status`, `is_paused`, `Error::ContractIsPaused`) was already present in the contract.  
This PR:
- Ensures **all new mutation methods** (`extend_listing`, `buy_prompts_bulk`) also gate on `ContractIsPaused` at the top of their implementations.
- Adds two new tests confirming both methods are blocked while paused.
- The `#[only_owner]` macro from `stellar-access` enforces that only the configured admin can call `set_pause_status`; read-only methods (`get_prompt`, `get_all_prompts`, `has_access`, `is_paused`) remain unaffected during a pause.

**Frontend/backend integration note:** When any mutating call returns `Error::ContractIsPaused` (error code 19), the UI should display a protocol-level maintenance message and disable purchase / listing flows until `is_paused()` returns `false`. Read-only views (browsing, access checks) continue to work normally.

---

### #49 – Time-Bound Listing Expiry

| Change | Location |
|---|---|
| `expires_at: u64` added to `Prompt` struct (`0` = never expires) | `types.rs` |
| `ListingConfig` struct bundles `price`, `asset`, `expires_at`, `splits` (replaces `PricingConfig` in `create_prompt` to stay within Soroban's 10-param limit) | `types.rs` |
| `get_all_prompts` filters listings where `expires_at != 0 && expires_at < now` | `storage.rs` |
| `buy_prompt` and `lease_prompt` reject purchases with `Error::ListingExpired` on expired listings | `contract.rs` |
| `extend_listing(creator, prompt_id, new_expires_at)` – owner-authenticated, emits `ListingExtended` event | `contract.rs` / `events.rs` |

Tests added: `test_create_prompt_with_expiry_stores_expires_at`, `test_expired_listing_excluded_from_get_all_prompts`, `test_buy_expired_listing_fails`, `test_extend_listing_pushes_expiry_and_allows_purchase`, `test_only_creator_can_extend_listing`.

---

### #50 – Seller Revenue Sharing (Splits)

| Change | Location |
|---|---|
| `Split { recipient: Address, bps: u32 }` contracttype | `types.rs` |
| `splits: Vec<Split>` added to `Prompt` struct | `types.rs` |
| `Error::InvalidSplits = 27` | `types.rs` |
| `create_prompt` validates `sum(split_bps) + fee_bps <= MAX_BPS` | `contract.rs` |
| `execute_buy` distributes each split as `payment * split.bps / MAX_BPS` before the creator receives the remainder | `contract.rs` |

Splits are calculated on the **full payment amount** (same basis as the platform fee), not on the creator's net. The creator receives `payment − fee − referral − Σ(splits)`. A runtime guard (`ensure(creator_amount >= 0)`) protects against edge cases where the fee is raised after listing creation.

Tests added: `test_create_prompt_with_splits_stores_split_data`, `test_buy_prompt_with_splits_distributes_correctly`, `test_splits_exceeding_max_bps_minus_fee_rejected`, `test_multiple_splits_distribute_all_recipients`.

---

### #51 – Bulk Purchase

| Change | Location |
|---|---|
| `buy_prompts_bulk(buyer, prompt_ids, payment_amounts, referrer)` | `contract.rs` |
| Inner `execute_buy` private helper shared between `buy_prompt` and `buy_prompts_bulk` | `contract.rs` |
| Returns `Error::InvalidPrice` when `prompt_ids.len() != payment_amounts.len()` | `contract.rs` |

Atomicity is guaranteed by Soroban's execution model: any error inside the loop (e.g., `PromptNotFound`, `PromptInactive`, `AlreadyPurchased`) causes the entire transaction to revert with no state change. An optional `referrer` applies uniformly to every prompt in the batch. Vouchers are not supported in bulk mode.

Tests added: `test_buy_prompts_bulk_purchases_all_and_grants_access`, `test_buy_prompts_bulk_atomicity_one_failure_reverts_all`, `test_buy_prompts_bulk_mismatched_lengths_fails`, `test_buy_prompts_bulk_with_referrer`.

---

## Validation steps performed

```bash
cargo test -p prompt-hash
# 52 tests, 0 failures
```

All pre-existing tests continue to pass. The `create_prompt` test helper was updated to pass `ListingConfig` with `expires_at: 0` and `splits: Vec::new()` as defaults, so no existing test semantics changed.

---

## Breaking change note

`create_prompt` now accepts `listing: ListingConfig` instead of `pricing: PricingConfig`. Any off-chain client that calls `create_prompt` directly must be updated to pass a `ListingConfig` struct. The fields `price` and `asset` are at the same positions within the struct; `expires_at` defaults to `0` and `splits` defaults to an empty Vec for prompts that need no change in behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prompts can now have expiration dates; expired listings are excluded from listings and block purchases.
  * Co-creator revenue splits enable sharing prompt sales proceeds with multiple recipients.
  * Bulk purchase functionality allows buying multiple prompts in a single transaction.
  * Listing extension allows updating when a prompt expires.
  * Referral commission support for incentivizing prompt discovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Obiajulu-gif/Prompt-Hash-Stellar/pull/177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->