### PR TITLE
Implement secondary license royalties

### DIFF
--- a/contracts/prompt-hash/src/contract.rs
+++ b/contracts/prompt-hash/src/contract.rs
@@ -6,6 +6,7 @@ use stellar_access::ownable::{self as ownable, Ownable};
 use stellar_macros::{default_impl, only_owner};
 
 const DEFAULT_FEE_BPS: u32 = 500;
+const ROYALTY_BPS: u32 = 500;
 const MAX_BPS: u32 = 10_000;
 const MAX_TITLE_LEN: u32 = 120;
 const MAX_CATEGORY_LEN: u32 = 40;
@@ -72,7 +73,10 @@ impl PromptHashTrait for PromptHashContract {
 
         // #49: optional listing expiry must be in the future when provided
         if listing.expires_at != 0 {
-            ensure(listing.expires_at > env.ledger().timestamp(), Error::InvalidPrice)?;
+            ensure(
+                listing.expires_at > env.ledger().timestamp(),
+                Error::InvalidPrice,
+            )?;
         }
 
         // #50: validate revenue splits
@@ -236,7 +240,7 @@ impl PromptHashTrait for PromptHashContract {
             .checked_add(lease_duration_secs)
             .ok_or(Error::ArithmeticOverflow)?;
         Storage::update_prompt(&env, &prompt);
-        Storage::grant_purchase(&env, prompt_id, &buyer, expires_at);
+        Storage::grant_purchase(&env, &prompt, &buyer, lease_price, expires_at);
         Storage::clear_reentrancy_guard(&env);
         Events::emit_prompt_purchased(&env, prompt_id, buyer, prompt.creator, lease_price, None);
         Ok(())
@@ -275,13 +279,88 @@ impl PromptHashTrait for PromptHashContract {
     ) -> Result<(), Error> {
         buyer.require_auth();
         ensure(!Storage::is_paused(&env), Error::ContractIsPaused)?;
-        ensure(prompt_ids.len() == payment_amounts.len(), Error::InvalidPrice)?;
+        ensure(
+            prompt_ids.len() == payment_amounts.len(),
+            Error::InvalidPrice,
+        )?;
 
         for i in 0..prompt_ids.len() {
             let prompt_id = prompt_ids.get(i).unwrap();
             let payment_amount = payment_amounts.get(i).unwrap();
             execute_buy(&env, &buyer, prompt_id, &referrer, payment_amount, None)?;
         }
+        Ok(())
+    }
+
+    fn transfer_license(
+        env: Env,
+        seller: Address,
+        prompt_id: u128,
+        new_buyer: Address,
+        resale_price: i128,
+    ) -> Result<(), Error> {
+        seller.require_auth();
+        ensure(!Storage::is_paused(&env), Error::ContractIsPaused)?;
+        ensure(resale_price > 0, Error::InvalidPaymentAmount)?;
+        ensure(seller != new_buyer, Error::InvalidLicenseTransfer)?;
+        new_buyer.require_auth();
+
+        let prompt = Storage::require_prompt(&env, prompt_id)?;
+        let now = env.ledger().timestamp();
+        let mut purchase = Storage::require_purchase(&env, prompt_id, &seller)?;
+        ensure(purchase.owner == seller, Error::Unauthorized)?;
+        ensure(purchase.expires_at >= now, Error::LicenseNotFound)?;
+        ensure(
+            !Storage::has_active_purchase(&env, prompt_id, &new_buyer, now),
+            Error::AlreadyPurchased,
+        )?;
+
+        Storage::set_reentrancy_guard(&env)?;
+
+        let this_contract = env.current_contract_address();
+        let asset_client = token::StellarAssetClient::new(&env, &prompt.asset);
+        let royalty_amount = resale_price
+            .checked_mul(ROYALTY_BPS as i128)
+            .ok_or(Error::ArithmeticOverflow)?
+            / MAX_BPS as i128;
+        let seller_amount = resale_price
+            .checked_sub(royalty_amount)
+            .ok_or(Error::ArithmeticOverflow)?;
+
+        if royalty_amount > 0 {
+            asset_client.transfer_from(
+                &this_contract,
+                &new_buyer,
+                &purchase.original_creator,
+                &royalty_amount,
+            );
+        }
+        if seller_amount > 0 {
+            asset_client.transfer_from(&this_contract, &new_buyer, &seller, &seller_amount);
+        }
+
+        Storage::remove_purchase(&env, prompt_id, &seller);
+        Storage::remove_prompt_from_buyer(&env, &seller, prompt_id);
+        purchase.owner = new_buyer.clone();
+        purchase.last_transfer_price = resale_price;
+        purchase.transfer_count = purchase
+            .transfer_count
+            .checked_add(1)
+            .ok_or(Error::ArithmeticOverflow)?;
+        purchase.last_transferred_at = now;
+        Storage::save_purchase(&env, &purchase);
+        Storage::add_prompt_to_buyer(&env, &new_buyer, prompt_id);
+        Storage::clear_reentrancy_guard(&env);
+
+        Events::emit_license_transferred(
+            &env,
+            prompt_id,
+            seller,
+            new_buyer,
+            purchase.original_creator,
+            resale_price,
+            royalty_amount,
+        );
         Ok(())
     }
 
@@ -549,12 +628,7 @@ fn execute_buy(
             .ok_or(Error::ArithmeticOverflow)?
             / MAX_BPS as i128;
         if split_amount > 0 {
-            asset_client.transfer_from(
-                &this_contract,
-                buyer,
-                &split.recipient,
-                &split_amount,
-            );
+            asset_client.transfer_from(&this_contract, buyer, &split.recipient, &split_amount);
         }
     }
 
@@ -563,7 +637,13 @@ fn execute_buy(
         .checked_add(1)
         .ok_or(Error::ArithmeticOverflow)?;
     Storage::update_prompt(env, &prompt);
-    Storage::grant_purchase(env, prompt_id, buyer, MAX_ACCESS_EXPIRY);
+    Storage::grant_purchase(
+        env,
+        &prompt,
+        buyer,
+        payment_amount_stroops,
+        MAX_ACCESS_EXPIRY,
+    );
     Storage::clear_reentrancy_guard(env);
 
     Events::emit_prompt_purchased(

--- a/contracts/prompt-hash/src/events.rs
+++ b/contracts/prompt-hash/src/events.rs
@@ -34,6 +34,17 @@ struct PromptPurchased {
 }
 
 #[contractevent]
+struct LicenseTransferred {
+    #[topic]
+    pub prompt_id: u128,
+    pub seller: Address,
+    pub buyer: Address,
+    pub creator: Address,
+    pub resale_price: i128,
+    pub royalty_amount: i128,
+}
+
+#[contractevent]
 struct PromptTipped {
     #[topic]
     pub prompt_id: u128,
@@ -125,6 +136,26 @@ impl Events {
             creator,
             price_stroops,
             referrer,
+        }
+        .publish(env);
+    }
+
+    pub fn emit_license_transferred(
+        env: &Env,
+        prompt_id: u128,
+        seller: Address,
+        buyer: Address,
+        creator: Address,
+        resale_price: i128,
+        royalty_amount: i128,
+    ) {
+        LicenseTransferred {
+            prompt_id,
+            seller,
+            buyer,
+            creator,
+            resale_price,
+            royalty_amount,
         }
         .publish(env);
     }

--- a/contracts/prompt-hash/src/storage.rs
+++ b/contracts/prompt-hash/src/storage.rs
@@ -140,7 +140,32 @@ impl Storage {
             .persistent()
             .get(&key)
             .unwrap_or_else(|| Vec::new(env));
+        for index in 0..ids.len() {
+            if ids.get(index).unwrap() == prompt_id {
+                Self::extend_key_ttl(env, &key);
+                return;
+            }
+        }
         ids.push_back(prompt_id);
+        env.storage().persistent().set(&key, &ids);
+        Self::extend_key_ttl(env, &key);
+    }
+
+    pub fn remove_prompt_from_buyer(env: &Env, buyer: &Address, prompt_id: u128) {
+        let key = DataKey::BuyerPrompts(buyer.clone());
+        let mut ids: Vec<u128> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| Vec::new(env));
+        let mut index = 0;
+        while index < ids.len() {
+            if ids.get(index).unwrap() == prompt_id {
+                ids.remove(index);
+            } else {
+                index += 1;
+            }
+        }
         env.storage().persistent().set(&key, &ids);
         Self::extend_key_ttl(env, &key);
     }
@@ -160,12 +185,46 @@ impl Storage {
             .unwrap_or(false)
     }
 
-    pub fn grant_purchase(env: &Env, prompt_id: u128, buyer: &Address, expires_at: u64) {
-        let key = DataKey::Purchase(prompt_id, buyer.clone());
-        let purchase = Purchase { expires_at };
+    pub fn save_purchase(env: &Env, purchase: &Purchase) {
+        let key = DataKey::Purchase(purchase.prompt_id, purchase.owner.clone());
+        env.storage().persistent().set(&key, purchase);
+        Self::extend_key_ttl(env, &key);
+    }
+
+    pub fn remove_purchase(env: &Env, prompt_id: u128, owner: &Address) {
+        let key = DataKey::Purchase(prompt_id, owner.clone());
+        env.storage().persistent().remove(&key);
+    }
+
+    pub fn require_purchase(
+        env: &Env,
+        prompt_id: u128,
+        owner: &Address,
+    ) -> Result<Purchase, Error> {
+        Self::get_purchase(env, prompt_id, owner).ok_or(Error::LicenseNotFound)
+    }
+
+    pub fn grant_purchase(
+        env: &Env,
+        prompt: &Prompt,
+        buyer: &Address,
+        paid_price: i128,
+        expires_at: u64,
+    ) {
+        let key = DataKey::Purchase(prompt.id, buyer.clone());
+        let purchase = Purchase {
+            prompt_id: prompt.id,
+            original_creator: prompt.creator.clone(),
+            owner: buyer.clone(),
+            original_price: paid_price,
+            last_transfer_price: 0,
+            transfer_count: 0,
+            last_transferred_at: 0,
+            expires_at,
+        };
         env.storage().persistent().set(&key, &purchase);
         Self::extend_key_ttl(env, &key);
-        Self::add_prompt_to_buyer(env, buyer, prompt_id);
+        Self::add_prompt_to_buyer(env, buyer, prompt.id);
     }
 
     pub fn set_fee_percentage(env: &Env, fee_percentage: &u32) {

--- a/contracts/prompt-hash/src/test.rs
+++ b/contracts/prompt-hash/src/test.rs
@@ -260,6 +260,142 @@ fn test_get_prompts_by_creator_and_buyer() {
 }
 
 #[test]
+fn test_license_owner_can_transfer_and_creator_receives_royalty() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+
+    let creator = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let prompt_id = create_prompt(
+        &env,
+        &client,
+        &creator,
+        "Transferable Prompt",
+        10_000,
+        &context.xlm,
+    );
+
+    fund_buyer(&xlm_client, &seller, &context.contract, 100_000);
+    client.buy_prompt(
+        &seller,
+        &prompt_id,
+        &None::<Address>,
+        &10_000i128,
+        &None::<Bytes>,
+    );
+
+    fund_buyer(&xlm_client, &buyer, &context.contract, 100_000);
+    let creator_before = xlm_client.balance(&creator);
+    let seller_before = xlm_client.balance(&seller);
+    let buyer_before = xlm_client.balance(&buyer);
+    let resale_price = 20_000i128;
+
+    client.transfer_license(&seller, &prompt_id, &buyer, &resale_price);
+
+    let royalty = resale_price * 500 / 10_000;
+    let seller_proceeds = resale_price - royalty;
+    assert_eq!(xlm_client.balance(&creator), creator_before + royalty);
+    assert_eq!(xlm_client.balance(&seller), seller_before + seller_proceeds);
+    assert_eq!(xlm_client.balance(&buyer), buyer_before - resale_price);
+    assert!(!client.has_access(&seller, &prompt_id));
+    assert!(client.has_access(&buyer, &prompt_id));
+    assert_eq!(client.get_prompts_by_buyer(&seller).len(), 0);
+    assert_eq!(client.get_prompts_by_buyer(&buyer).len(), 1);
+}
+
+#[test]
+fn test_non_owner_cannot_transfer_license() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+
+    let creator = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let stranger = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let prompt_id = create_prompt(
+        &env,
+        &client,
+        &creator,
+        "Protected Transfer Prompt",
+        10_000,
+        &context.xlm,
+    );
+
+    fund_buyer(&xlm_client, &owner, &context.contract, 100_000);
+    fund_buyer(&xlm_client, &buyer, &context.contract, 100_000);
+    client.buy_prompt(
+        &owner,
+        &prompt_id,
+        &None::<Address>,
+        &10_000i128,
+        &None::<Bytes>,
+    );
+
+    let result = client.try_transfer_license(&stranger, &prompt_id, &buyer, &20_000i128);
+    match result {
+        Err(Ok(Error::LicenseNotFound)) => {}
+        other => panic!(
+            "expected LicenseNotFound for non-owner transfer, got {:?}",
+            other
+        ),
+    }
+    assert!(client.has_access(&owner, &prompt_id));
+    assert!(!client.has_access(&buyer, &prompt_id));
+}
+
+#[test]
+fn test_transfer_license_rejects_zero_price_and_self_transfer() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+
+    let creator = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let prompt_id = create_prompt(
+        &env,
+        &client,
+        &creator,
+        "Invalid Transfer Prompt",
+        10_000,
+        &context.xlm,
+    );
+
+    fund_buyer(&xlm_client, &owner, &context.contract, 100_000);
+    client.buy_prompt(
+        &owner,
+        &prompt_id,
+        &None::<Address>,
+        &10_000i128,
+        &None::<Bytes>,
+    );
+
+    let zero_price = client.try_transfer_license(&owner, &prompt_id, &buyer, &0i128);
+    match zero_price {
+        Err(Ok(Error::InvalidPaymentAmount)) => {}
+        other => panic!(
+            "expected InvalidPaymentAmount for zero resale, got {:?}",
+            other
+        ),
+    }
+
+    let self_transfer = client.try_transfer_license(&owner, &prompt_id, &owner, &20_000i128);
+    match self_transfer {
+        Err(Ok(Error::InvalidLicenseTransfer)) => {}
+        other => panic!(
+            "expected InvalidLicenseTransfer for self transfer, got {:?}",
+            other
+        ),
+    }
+}
+
+#[test]
 fn test_duplicate_purchase_returns_typed_error() {
     let env: Env = Default::default();
     let context = setup(&env);
@@ -1754,7 +1890,10 @@ fn test_only_creator_can_extend_listing() {
     let result = client.try_extend_listing(&stranger, &prompt_id, &9_000u64);
     match result {
         Err(Ok(Error::Unauthorized)) => {}
-        other => panic!("expected Unauthorized for stranger extend_listing, got {:?}", other),
+        other => panic!(
+            "expected Unauthorized for stranger extend_listing, got {:?}",
+            other
+        ),
     }
 }
 
@@ -1844,8 +1983,8 @@ fn test_buy_prompt_with_splits_distributes_correctly() {
 
     client.buy_prompt(&buyer, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
 
-    let expected_fee = price * 500 / 10_000;       // 500
-    let expected_split = price * 2_000 / 10_000;   // 2_000
+    let expected_fee = price * 500 / 10_000; // 500
+    let expected_split = price * 2_000 / 10_000; // 2_000
     let expected_creator = price - expected_fee - expected_split; // 7_500
 
     assert_eq!(
@@ -1898,7 +2037,10 @@ fn test_splits_exceeding_max_bps_minus_fee_rejected() {
     );
     match result {
         Err(Ok(Error::InvalidSplits)) => {}
-        other => panic!("expected InvalidSplits for over-allocated splits, got {:?}", other),
+        other => panic!(
+            "expected InvalidSplits for over-allocated splits, got {:?}",
+            other
+        ),
     }
 }
 
@@ -1997,8 +2139,7 @@ fn test_buy_prompts_bulk_purchases_all_and_grants_access() {
     let fee_bps = 500i128;
     let expected_creator =
         (price_a - price_a * fee_bps / 10_000) + (price_b - price_b * fee_bps / 10_000);
-    let expected_fee =
-        price_a * fee_bps / 10_000 + price_b * fee_bps / 10_000;
+    let expected_fee = price_a * fee_bps / 10_000 + price_b * fee_bps / 10_000;
     assert_eq!(xlm_client.balance(&creator), expected_creator);
     assert_eq!(xlm_client.balance(&context.fee_wallet), expected_fee);
 }

--- a/contracts/prompt-hash/src/types.rs
+++ b/contracts/prompt-hash/src/types.rs
@@ -34,6 +34,8 @@ pub enum Error {
     InvalidSplits = 27,
     // #49 – time-bound listing expiry
     ListingExpired = 28,
+    LicenseNotFound = 29,
+    InvalidLicenseTransfer = 30,
 }
 
 #[contracttype]
@@ -56,6 +58,13 @@ pub enum DataKey {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Purchase {
+    pub prompt_id: u128,
+    pub original_creator: Address,
+    pub owner: Address,
+    pub original_price: i128,
+    pub last_transfer_price: i128,
+    pub transfer_count: u32,
+    pub last_transferred_at: u64,
     pub expires_at: u64,
 }
 
@@ -195,6 +204,14 @@ pub trait PromptHashTrait {
         prompt_ids: Vec<u128>,
         payment_amounts: Vec<i128>,
         referrer: Option<Address>,
+    ) -> Result<(), Error>;
+
+    fn transfer_license(
+        env: Env,
+        seller: Address,
+        prompt_id: u128,
+        new_buyer: Address,
+        resale_price: i128,
     ) -> Result<(), Error>;
 
     fn has_access(env: Env, user: Address, prompt_id: u128) -> Result<bool, Error>;


### PR DESCRIPTION
close #128 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled prompt license resale functionality, allowing current license holders to transfer prompts to new buyers
  * Implemented automatic royalty distribution to original creators on all resale transactions
  * Enhanced purchase records with complete transfer history, including transfer count and timestamps
  * Added validation to prevent self-transfers and duplicate active purchases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->