### PR TITLE
Issue 211

### DIFF
--- a/contracts/prompt-hash/src/contract.rs
+++ b/contracts/prompt-hash/src/contract.rs
@@ -1,6 +1,9 @@
 use super::events::Events;
 use super::storage::Storage;
-use super::types::{DataKey, Error, ListingConfig, ListingRevisionRecord, Prompt, PromptHashTrait, Split};
+use super::types::{
+    DataKey, DisputeReason, DisputeStatus, Error, ListingConfig, ListingRevisionRecord, Prompt,
+    PromptHashTrait, PurchaseDispute, Split,
+};
 use soroban_sdk::{contract, contractimpl, token, Address, Bytes, BytesN, Env, String, Vec};
 use stellar_access::ownable::{self as ownable, Ownable};
 use stellar_macros::{default_impl, only_owner};
@@ -20,6 +23,8 @@ const MAX_IV_LEN: u32 = 64;
 const LEASE_PRICE_BPS: u32 = 4_000;
 const MAX_ACCESS_EXPIRY: u64 = u64::MAX;
 const MAX_SPLITS: u32 = 10;
+const MAX_TAGS: u32 = 8;
+const MAX_TAG_LEN: u32 = 32;
 
 #[contract]
 pub struct PromptHashContract;
@@ -86,6 +91,7 @@ impl PromptHashTrait for PromptHashContract {
         validate_splits(&env, &listing.splits)?;
         validate_no_duplicate_recipients(&listing.splits)?;
         ensure(listing.splits.len() <= MAX_SPLITS, Error::TooManySplits)?;
+        validate_tags(&listing.tags)?;
 
         let prompt_id = Storage::get_prompt_counter(&env);
         let prompt = Prompt {
@@ -107,6 +113,7 @@ impl PromptHashTrait for PromptHashContract {
             expires_at: listing.expires_at,
             splits: listing.splits,
             revision: 0,
+            tags: listing.tags,
         };
 
         Storage::save_prompt(&env, &prompt)?;
@@ -433,8 +440,7 @@ impl PromptHashTrait for PromptHashContract {
     ) -> Result<ListingRevisionRecord, Error> {
         // Verify the listing exists before looking up the revision.
         Storage::require_prompt(&env, prompt_id)?;
-        Storage::get_listing_revision(&env, prompt_id, revision)
-            .ok_or(Error::PromptNotFound)
+        Storage::get_listing_revision(&env, prompt_id, revision).ok_or(Error::PromptNotFound)
     }
 
     fn update_splits(
@@ -472,6 +478,85 @@ impl PromptHashTrait for PromptHashContract {
         Ok(Storage::get_all_prompts(&env))
     }
 
+    fn get_prompts_by_category(env: Env, category: String) -> Result<Vec<Prompt>, Error> {
+        validate_len(&category, MAX_CATEGORY_LEN, Error::InvalidCategoryLength)?;
+        Ok(Storage::get_prompts_by_category(&env, &category))
+    }
+
+    fn get_prompts_by_tag(env: Env, tag: String) -> Result<Vec<Prompt>, Error> {
+        validate_len(&tag, MAX_TAG_LEN, Error::InvalidCategoryLength)?;
+        Ok(Storage::get_prompts_by_tag(&env, &tag))
+    }
+
+    fn open_dispute(
+        env: Env,
+        buyer: Address,
+        prompt_id: u128,
+        reason: DisputeReason,
+    ) -> Result<(), Error> {
+        buyer.require_auth();
+        ensure(!Storage::is_paused(&env), Error::ContractIsPaused)?;
+        let now = env.ledger().timestamp();
+        Storage::require_purchase(&env, prompt_id, &buyer)?;
+        if let Some(dispute) = Storage::get_dispute(&env, prompt_id, &buyer) {
+            ensure(
+                dispute.status != DisputeStatus::Open,
+                Error::DisputeAlreadyOpen,
+            )?;
+        }
+        let dispute = PurchaseDispute {
+            prompt_id,
+            buyer: buyer.clone(),
+            reason,
+            opened_at: now,
+            resolved_at: 0,
+            status: DisputeStatus::Open,
+        };
+        Storage::save_dispute(&env, &dispute);
+        Events::emit_dispute_opened(&env, prompt_id, buyer);
+        Ok(())
+    }
+
+    fn resolve_dispute(
+        env: Env,
+        admin: Address,
+        prompt_id: u128,
+        buyer: Address,
+        refund: bool,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let owner = ownable::get_owner(&env).ok_or(Error::Unauthorized)?;
+        ensure(owner == admin, Error::Unauthorized)?;
+        let prompt = Storage::require_prompt(&env, prompt_id)?;
+        let purchase = Storage::require_purchase(&env, prompt_id, &buyer)?;
+        let mut dispute = Storage::require_dispute(&env, prompt_id, &buyer)?;
+        ensure(
+            dispute.status == DisputeStatus::Open,
+            Error::DisputeResolved,
+        )?;
+        dispute.resolved_at = env.ledger().timestamp();
+        if refund {
+            let asset_client = token::StellarAssetClient::new(&env, &prompt.asset);
+            asset_client.transfer(
+                &env.current_contract_address(),
+                &buyer,
+                &purchase.original_price,
+            );
+            Storage::remove_purchase(&env, prompt_id, &buyer);
+            Storage::remove_prompt_from_buyer(&env, &buyer, prompt_id);
+            dispute.status = DisputeStatus::Refunded;
+        } else {
+            dispute.status = DisputeStatus::Rejected;
+        }
+        Storage::save_dispute(&env, &dispute);
+        Events::emit_dispute_resolved(&env, prompt_id, buyer, refund);
+        Ok(())
+    }
+
+    fn get_dispute(env: Env, prompt_id: u128, buyer: Address) -> Result<PurchaseDispute, Error> {
+        Storage::require_dispute(&env, prompt_id, &buyer)
+    }
+
     fn get_prompts_by_creator(env: Env, creator: Address) -> Result<Vec<Prompt>, Error> {
         Ok(Storage::get_prompts_by_creator(&env, &creator))
     }
@@ -505,13 +590,15 @@ impl PromptHashTrait for PromptHashContract {
 
     // New governance API: secure, bounded platform fee updates with cryptographic event logging.
     #[only_owner]
-    fn update_platform_fee(env: Env, new_fee: u32) -> Result<(), Error> {
+    fn update_platform_fee(env: Env, admin: Address, new_fee: u32) -> Result<(), Error> {
+        admin.require_auth();
+        let owner = ownable::get_owner(&env).ok_or(Error::Unauthorized)?;
+        ensure(owner == admin, Error::Unauthorized)?;
         ensure(new_fee <= MAX_PLATFORM_FEE, Error::FeeExceedsMaximum)?;
 
         let old_fee = Storage::get_fee_percentage(&env);
         Storage::set_fee_percentage(&env, &new_fee);
-        // Emit event with the invoker as admin for auditability
-        let admin = env.invoker();
+        // Emit event with the authenticated admin for auditability
         Events::emit_platform_fee_updated(&env, old_fee, new_fee, admin);
         Ok(())
     }
@@ -828,6 +915,18 @@ fn validate_prompt_fields(
         Error::InvalidWrappedKeyLength,
     )?;
     validate_len(encryption_iv, MAX_IV_LEN, Error::InvalidIvLength)?;
+    Ok(())
+}
+
+fn validate_tags(tags: &Vec<String>) -> Result<(), Error> {
+    ensure(tags.len() <= MAX_TAGS, Error::InvalidCategoryLength)?;
+    for i in 0..tags.len() {
+        let tag = tags.get(i).unwrap();
+        validate_len(&tag, MAX_TAG_LEN, Error::InvalidCategoryLength)?;
+        for j in (i + 1)..tags.len() {
+            ensure(tag != tags.get(j).unwrap(), Error::InvalidCategoryLength)?;
+        }
+    }
     Ok(())
 }
 

--- a/contracts/prompt-hash/src/events.rs
+++ b/contracts/prompt-hash/src/events.rs
@@ -113,6 +113,21 @@ struct SplitsUpdated {
     pub prompt_id: u128,
 }
 
+#[contractevent]
+struct DisputeOpened {
+    #[topic]
+    pub prompt_id: u128,
+    pub buyer: Address,
+}
+
+#[contractevent]
+struct DisputeResolved {
+    #[topic]
+    pub prompt_id: u128,
+    pub buyer: Address,
+    pub refunded: bool,
+}
+
 pub struct Events;
 
 impl Events {
@@ -226,7 +241,12 @@ impl Events {
     }
 
     pub fn emit_platform_fee_updated(env: &Env, old_fee: u32, new_fee: u32, admin: Address) {
-        PlatformFeeUpdated { old_fee, new_fee, admin }.publish(env);
+        PlatformFeeUpdated {
+            old_fee,
+            new_fee,
+            admin,
+        }
+        .publish(env);
     }
 
     pub fn emit_listing_extended(env: &Env, prompt_id: u128, new_expires_at: u64) {
@@ -247,5 +267,18 @@ impl Events {
 
     pub fn emit_splits_updated(env: &Env, prompt_id: u128) {
         SplitsUpdated { prompt_id }.publish(env);
+    }
+
+    pub fn emit_dispute_opened(env: &Env, prompt_id: u128, buyer: Address) {
+        DisputeOpened { prompt_id, buyer }.publish(env);
+    }
+
+    pub fn emit_dispute_resolved(env: &Env, prompt_id: u128, buyer: Address, refunded: bool) {
+        DisputeResolved {
+            prompt_id,
+            buyer,
+            refunded,
+        }
+        .publish(env);
     }
 }

--- a/contracts/prompt-hash/src/storage.rs
+++ b/contracts/prompt-hash/src/storage.rs
@@ -1,4 +1,4 @@
-use super::types::{DataKey, Error, ListingRevisionRecord, Prompt, Purchase};
+use super::types::{DataKey, Error, ListingRevisionRecord, Prompt, Purchase, PurchaseDispute};
 use soroban_sdk::{token, Address, BytesN, Env, Vec};
 
 pub const DAY_IN_LEDGERS: u32 = 17280;
@@ -78,6 +78,33 @@ impl Storage {
                 // Skip expired listings (expires_at == 0 means never expires)
                 if prompt.expires_at == 0 || prompt.expires_at >= now {
                     prompts.push_back(prompt);
+                }
+            }
+        }
+        prompts
+    }
+
+    pub fn get_prompts_by_category(env: &Env, category: &soroban_sdk::String) -> Vec<Prompt> {
+        let all = Self::get_all_prompts(env);
+        let mut prompts = Vec::new(env);
+        for index in 0..all.len() {
+            let prompt = all.get(index).unwrap();
+            if prompt.category == *category {
+                prompts.push_back(prompt);
+            }
+        }
+        prompts
+    }
+
+    pub fn get_prompts_by_tag(env: &Env, tag: &soroban_sdk::String) -> Vec<Prompt> {
+        let all = Self::get_all_prompts(env);
+        let mut prompts = Vec::new(env);
+        for index in 0..all.len() {
+            let prompt = all.get(index).unwrap();
+            for tag_index in 0..prompt.tags.len() {
+                if prompt.tags.get(tag_index).unwrap() == *tag {
+                    prompts.push_back(prompt.clone());
+                    break;
                 }
             }
         }
@@ -225,6 +252,29 @@ impl Storage {
         env.storage().persistent().set(&key, &purchase);
         Self::extend_key_ttl(env, &key);
         Self::add_prompt_to_buyer(env, buyer, prompt.id);
+    }
+
+    pub fn save_dispute(env: &Env, dispute: &PurchaseDispute) {
+        let key = DataKey::PurchaseDispute(dispute.prompt_id, dispute.buyer.clone());
+        env.storage().persistent().set(&key, dispute);
+        Self::extend_key_ttl(env, &key);
+    }
+
+    pub fn get_dispute(env: &Env, prompt_id: u128, buyer: &Address) -> Option<PurchaseDispute> {
+        let key = DataKey::PurchaseDispute(prompt_id, buyer.clone());
+        let dispute = env.storage().persistent().get(&key);
+        if env.storage().persistent().has(&key) {
+            Self::extend_key_ttl(env, &key);
+        }
+        dispute
+    }
+
+    pub fn require_dispute(
+        env: &Env,
+        prompt_id: u128,
+        buyer: &Address,
+    ) -> Result<PurchaseDispute, Error> {
+        Self::get_dispute(env, prompt_id, buyer).ok_or(Error::DisputeNotFound)
     }
 
     pub fn set_fee_percentage(env: &Env, fee_percentage: &u32) {

--- a/contracts/prompt-hash/src/test.rs
+++ b/contracts/prompt-hash/src/test.rs
@@ -3,7 +3,7 @@ use crate::mock_asset::FungibleTokenContract;
 use crate::types::{Error, ListingConfig, Split};
 extern crate std;
 use soroban_sdk::{
-    testutils::{Address as _, Ledger},
+    testutils::{Address as _, Events, Ledger},
     token, Address, Bytes, BytesN, Env, String, Vec,
 };
 
@@ -62,6 +62,7 @@ fn create_prompt(
             asset: asset.clone(),
             expires_at: 0,
             splits: Vec::new(env),
+            tags: Vec::new(&env),
         },
     )
 }
@@ -100,6 +101,7 @@ fn create_prompt_with_splits(
             asset: asset.clone(),
             expires_at: 0,
             splits,
+            tags: Vec::new(&env),
         },
     )
 }
@@ -411,7 +413,7 @@ fn test_admin_can_update_platform_fee_within_bounds() {
     let client = PromptHashContractClient::new(&env, &context.contract);
 
     // admin sets platform fee to 300 BPS (3%)
-    client.update_platform_fee(&300u32);
+    client.update_platform_fee(&context.admin, &300u32);
     assert_eq!(client.get_platform_fee(), 300u32);
 }
 
@@ -451,7 +453,7 @@ fn test_update_platform_fee_emits_event() {
 
     // Capture event count before
     let before = env.events().all().len();
-    client.update_platform_fee(&400u32);
+    client.update_platform_fee(&context.admin, &400u32);
     let after = env.events().all().len();
     assert!(after >= before + 1, "expected at least one new event");
 }
@@ -936,6 +938,7 @@ fn test_global_pause_blocks_mutations_but_not_reads() {
             asset: context.xlm.clone(),
             expires_at: 0,
             splits: Vec::new(&env),
+            tags: Vec::new(&env),
         },
     );
     match create_res {
@@ -1213,6 +1216,7 @@ fn test_create_prompt_blocked_when_paused() {
             asset: context.xlm.clone(),
             expires_at: 0,
             splits: Vec::new(&env),
+            tags: Vec::new(&env),
         },
     );
     match result {
@@ -1976,6 +1980,7 @@ fn test_create_prompt_with_expiry_stores_expires_at() {
             asset: context.xlm.clone(),
             expires_at,
             splits: Vec::new(&env),
+            tags: Vec::new(&env),
         },
     );
 
@@ -2009,6 +2014,7 @@ fn test_expired_listing_excluded_from_get_all_prompts() {
             asset: context.xlm.clone(),
             expires_at: 2_000,
             splits: Vec::new(&env),
+            tags: Vec::new(&env),
         },
     );
     let persistent = create_prompt(&env, &client, &creator, "Persistent", 5_000, &context.xlm);
@@ -2051,6 +2057,7 @@ fn test_buy_expired_listing_fails() {
             asset: context.xlm.clone(),
             expires_at: 2_000,
             splits: Vec::new(&env),
+            tags: Vec::new(&env),
         },
     );
 
@@ -2111,6 +2118,7 @@ fn test_extend_listing_pushes_expiry_and_allows_purchase() {
             asset: context.xlm.clone(),
             expires_at: 2_000, // expires at t=2000
             splits: Vec::new(&env),
+            tags: Vec::new(&env),
         },
     );
 
@@ -2187,6 +2195,7 @@ fn test_create_prompt_with_splits_stores_split_data() {
             asset: context.xlm.clone(),
             expires_at: 0,
             splits,
+            tags: Vec::new(&env),
         },
     );
 
@@ -2230,6 +2239,7 @@ fn test_buy_prompt_with_splits_distributes_correctly() {
             asset: context.xlm.clone(),
             expires_at: 0,
             splits,
+            tags: Vec::new(&env),
         },
     );
 
@@ -2291,6 +2301,7 @@ fn test_splits_exceeding_max_bps_minus_fee_rejected() {
             asset: context.xlm.clone(),
             expires_at: 0,
             splits,
+            tags: Vec::new(&env),
         },
     );
     match result {
@@ -2341,6 +2352,7 @@ fn test_multiple_splits_distribute_all_recipients() {
             asset: context.xlm.clone(),
             expires_at: 0,
             splits,
+            tags: Vec::new(&env),
         },
     );
 
@@ -2513,7 +2525,14 @@ fn test_revise_listing_increments_revision_and_snapshots_old_metadata() {
     let client = PromptHashContractClient::new(&env, &context.contract);
 
     let creator = Address::generate(&env);
-    let prompt_id = create_prompt(&env, &client, &creator, "Original Title", 1_000, &context.xlm);
+    let prompt_id = create_prompt(
+        &env,
+        &client,
+        &creator,
+        "Original Title",
+        1_000,
+        &context.xlm,
+    );
 
     // Revision starts at 0
     let prompt = client.get_prompt(&prompt_id);
@@ -2572,8 +2591,14 @@ fn test_revise_listing_multiple_times_each_revision_preserved() {
     );
 
     assert_eq!(client.get_prompt(&prompt_id).revision, 2);
-    assert_eq!(client.get_listing_revision(&prompt_id, &0).price_stroops, 100);
-    assert_eq!(client.get_listing_revision(&prompt_id, &1).price_stroops, 200);
+    assert_eq!(
+        client.get_listing_revision(&prompt_id, &0).price_stroops,
+        100
+    );
+    assert_eq!(
+        client.get_listing_revision(&prompt_id, &1).price_stroops,
+        200
+    );
 }
 
 #[test]
@@ -2649,7 +2674,13 @@ fn test_update_splits_replaces_existing_splits() {
     });
 
     let prompt_id = create_prompt_with_splits(
-        &env, &client, &creator, "Updatable Splits", price, &context.xlm, initial_splits,
+        &env,
+        &client,
+        &creator,
+        "Updatable Splits",
+        price,
+        &context.xlm,
+        initial_splits,
     );
     assert_eq!(client.get_prompt(&prompt_id).splits.len(), 1);
 
@@ -2683,7 +2714,10 @@ fn test_update_splits_replaces_existing_splits() {
 
     assert_eq!(xlm_client.balance(&co1), co1_start + expected_co1);
     assert_eq!(xlm_client.balance(&co2), co2_start + expected_co2);
-    assert_eq!(xlm_client.balance(&creator), creator_start + expected_creator);
+    assert_eq!(
+        xlm_client.balance(&creator),
+        creator_start + expected_creator
+    );
 }
 
 #[test]
@@ -2702,7 +2736,13 @@ fn test_update_splits_clears_all_splits() {
     });
 
     let prompt_id = create_prompt_with_splits(
-        &env, &client, &creator, "Clear Splits", 5_000, &context.xlm, initial_splits,
+        &env,
+        &client,
+        &creator,
+        "Clear Splits",
+        5_000,
+        &context.xlm,
+        initial_splits,
     );
 
     let empty_splits = Vec::<Split>::new(&env);
@@ -2724,7 +2764,10 @@ fn test_update_splits_rejects_unauthorized_caller() {
     let result = client.try_update_splits(&stranger, &prompt_id, &splits);
     match result {
         Err(Ok(Error::Unauthorized)) => {}
-        other => panic!("expected Unauthorized for stranger update_splits, got {:?}", other),
+        other => panic!(
+            "expected Unauthorized for stranger update_splits, got {:?}",
+            other
+        ),
     }
 }
 
@@ -2747,7 +2790,10 @@ fn test_update_splits_rejects_invalid_total_bps() {
     let result = client.try_update_splits(&creator, &prompt_id, &bad_splits);
     match result {
         Err(Ok(Error::InvalidSplits)) => {}
-        other => panic!("expected InvalidSplits for over-allocated update, got {:?}", other),
+        other => panic!(
+            "expected InvalidSplits for over-allocated update, got {:?}",
+            other
+        ),
     }
 }
 
@@ -2812,11 +2858,15 @@ fn test_create_prompt_rejects_duplicate_split_recipients() {
             asset: context.xlm.clone(),
             expires_at: 0,
             splits: dup_splits,
+            tags: Vec::new(&env),
         },
     );
     match result {
         Err(Ok(Error::DuplicateSplitRecipient)) => {}
-        other => panic!("expected DuplicateSplitRecipient on create, got {:?}", other),
+        other => panic!(
+            "expected DuplicateSplitRecipient on create, got {:?}",
+            other
+        ),
     }
 }
 
@@ -2833,6 +2883,134 @@ fn test_update_splits_blocked_when_paused() {
     let result = client.try_update_splits(&creator, &prompt_id, &Vec::new(&env));
     match result {
         Err(Ok(Error::ContractIsPaused)) => {}
-        other => panic!("expected ContractIsPaused for update_splits, got {:?}", other),
+        other => panic!(
+            "expected ContractIsPaused for update_splits, got {:?}",
+            other
+        ),
+    }
+}
+
+#[test]
+fn test_create_prompt_tags_and_category_filters() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let creator = Address::generate(&env);
+
+    let mut tags = Vec::new(&env);
+    tags.push_back(String::from_str(&env, "testing"));
+    tags.push_back(String::from_str(&env, "rust"));
+
+    let prompt_id = client.create_prompt(
+        &creator,
+        &String::from_str(&env, "https://example.com/prompt.png"),
+        &String::from_str(&env, "Tagged Prompt"),
+        &String::from_str(&env, "Software Development"),
+        &String::from_str(&env, "Generate tests."),
+        &String::from_str(&env, "ciphertext"),
+        &String::from_str(&env, "iv"),
+        &String::from_str(&env, "wrapped-key"),
+        &hash(&env, 91),
+        &ListingConfig {
+            price: 1_000,
+            asset: context.xlm.clone(),
+            expires_at: 0,
+            splits: Vec::new(&env),
+            tags,
+        },
+    );
+
+    let prompt = client.get_prompt(&prompt_id);
+    assert_eq!(prompt.tags.len(), 2);
+    assert_eq!(
+        prompt.tags.get(0).unwrap(),
+        String::from_str(&env, "testing")
+    );
+
+    let by_category =
+        client.get_prompts_by_category(&String::from_str(&env, "Software Development"));
+    assert_eq!(by_category.len(), 1);
+    assert_eq!(by_category.get(0).unwrap().id, prompt_id);
+
+    let by_tag = client.get_prompts_by_tag(&String::from_str(&env, "rust"));
+    assert_eq!(by_tag.len(), 1);
+    assert_eq!(by_tag.get(0).unwrap().id, prompt_id);
+}
+
+#[test]
+fn test_buyer_can_open_and_admin_can_resolve_refund_dispute() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let price = 10_000;
+    let prompt_id = create_prompt(&env, &client, &creator, "Refundable", price, &context.xlm);
+
+    fund_buyer(&xlm_client, &buyer, &context.contract, price);
+    client.buy_prompt(&buyer, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
+    xlm_client.mint(&context.contract, &price);
+
+    client.open_dispute(
+        &buyer,
+        &prompt_id,
+        &crate::types::DisputeReason::FailedIntegrityVerification,
+    );
+    let open = client.get_dispute(&prompt_id, &buyer);
+    assert_eq!(open.status, crate::types::DisputeStatus::Open);
+
+    let buyer_before = xlm_client.balance(&buyer);
+    client.resolve_dispute(&context.admin, &prompt_id, &buyer, &true);
+    let resolved = client.get_dispute(&prompt_id, &buyer);
+    assert_eq!(resolved.status, crate::types::DisputeStatus::Refunded);
+    assert_eq!(xlm_client.balance(&buyer), buyer_before + price);
+    assert!(!client.has_access(&buyer, &prompt_id));
+}
+
+#[test]
+fn test_invalid_dispute_requires_purchase() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let creator = Address::generate(&env);
+    let stranger = Address::generate(&env);
+    let prompt_id = create_prompt(&env, &client, &creator, "No Purchase", 10_000, &context.xlm);
+
+    let res = client.try_open_dispute(
+        &stranger,
+        &prompt_id,
+        &crate::types::DisputeReason::MissingMetadata,
+    );
+    match res {
+        Err(Ok(Error::LicenseNotFound)) => {}
+        other => panic!("expected LicenseNotFound, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_resolved_dispute_cannot_be_resolved_twice() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let price = 10_000;
+    let prompt_id = create_prompt(&env, &client, &creator, "Resolved", price, &context.xlm);
+
+    fund_buyer(&xlm_client, &buyer, &context.contract, price);
+    client.buy_prompt(&buyer, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
+    client.open_dispute(
+        &buyer,
+        &prompt_id,
+        &crate::types::DisputeReason::InvalidEncryptedPayload,
+    );
+    client.resolve_dispute(&context.admin, &prompt_id, &buyer, &false);
+
+    let res = client.try_resolve_dispute(&context.admin, &prompt_id, &buyer, &false);
+    match res {
+        Err(Ok(Error::DisputeResolved)) => {}
+        other => panic!("expected DisputeResolved, got {:?}", other),
     }
 }

--- a/contracts/prompt-hash/src/types.rs
+++ b/contracts/prompt-hash/src/types.rs
@@ -42,6 +42,9 @@ pub enum Error {
     DuplicateSplitRecipient = 32,
     TooManySplits = 33,
     FeeExceedsMaximum = 34,
+    DisputeAlreadyOpen = 35,
+    DisputeNotFound = 36,
+    DisputeResolved = 37,
 }
 
 #[contracttype]
@@ -62,6 +65,34 @@ pub enum DataKey {
     /// Snapshot of a listing taken before a revision (#226).
     /// Key: (prompt_id, revision_number_before_change)
     ListingRevision(u128, u32),
+    PurchaseDispute(u128, Address),
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DisputeStatus {
+    Open,
+    Refunded,
+    Rejected,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DisputeReason {
+    InvalidEncryptedPayload,
+    MissingMetadata,
+    FailedIntegrityVerification,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PurchaseDispute {
+    pub prompt_id: u128,
+    pub buyer: Address,
+    pub reason: DisputeReason,
+    pub opened_at: u64,
+    pub resolved_at: u64,
+    pub status: DisputeStatus,
 }
 
 #[contracttype]
@@ -107,6 +138,8 @@ pub struct ListingConfig {
     pub expires_at: u64,
     /// Optional co-creator revenue splits (empty Vec = no splits).
     pub splits: Vec<Split>,
+    /// Search tags used for marketplace discovery. Tags should be lowercase kebab-case.
+    pub tags: Vec<String>,
 }
 
 #[contracttype]
@@ -135,6 +168,8 @@ pub struct Prompt {
     /// Monotonically increasing revision counter. Starts at 0 on creation and
     /// increments by 1 on each successful `revise_listing` call (#226).
     pub revision: u32,
+    /// Search tags used for marketplace discovery. Tags should be lowercase kebab-case.
+    pub tags: Vec<String>,
 }
 
 /// Snapshot of the mutable listing fields captured before a revision (#226).
@@ -281,6 +316,22 @@ pub trait PromptHashTrait {
     fn has_access(env: Env, user: Address, prompt_id: u128) -> Result<bool, Error>;
     fn get_prompt(env: Env, prompt_id: u128) -> Result<Prompt, Error>;
     fn get_all_prompts(env: Env) -> Result<Vec<Prompt>, Error>;
+    fn get_prompts_by_category(env: Env, category: String) -> Result<Vec<Prompt>, Error>;
+    fn get_prompts_by_tag(env: Env, tag: String) -> Result<Vec<Prompt>, Error>;
+    fn open_dispute(
+        env: Env,
+        buyer: Address,
+        prompt_id: u128,
+        reason: DisputeReason,
+    ) -> Result<(), Error>;
+    fn resolve_dispute(
+        env: Env,
+        admin: Address,
+        prompt_id: u128,
+        buyer: Address,
+        refund: bool,
+    ) -> Result<(), Error>;
+    fn get_dispute(env: Env, prompt_id: u128, buyer: Address) -> Result<PurchaseDispute, Error>;
     fn get_prompts_by_creator(env: Env, creator: Address) -> Result<Vec<Prompt>, Error>;
     fn get_prompts_by_buyer(env: Env, buyer: Address) -> Result<Vec<Prompt>, Error>;
     fn set_fee_percentage(env: Env, new_fee_percentage: u32) -> Result<(), Error>;
@@ -290,7 +341,7 @@ pub trait PromptHashTrait {
     fn set_referral_percentage(env: Env, new_referral_percentage: u32) -> Result<(), Error>;
     fn get_referral_percentage(env: Env) -> u32;
     // New platform fee governance API
-    fn update_platform_fee(env: Env, new_fee: u32) -> Result<(), Error>;
+    fn update_platform_fee(env: Env, admin: Address, new_fee: u32) -> Result<(), Error>;
     fn get_platform_fee(env: Env) -> u32;
     fn set_pause_status(env: Env, paused: bool) -> Result<(), Error>;
     fn is_paused(env: Env) -> bool;

--- a/docs/prompt-categories-and-tags.md
+++ b/docs/prompt-categories-and-tags.md
@@ -1,0 +1,23 @@
+# Prompt categories and tags
+
+Prompt listings expose both a single `category` and zero or more `tags` for marketplace discovery.
+
+## Category format
+
+- Required string.
+- Maximum length: 40 bytes.
+- Use a human-readable marketplace label, such as `Software Development`, `Marketing`, `Education`, or `Design`.
+- Category matching in the contract is exact. Clients should normalize category choices before calling `create_prompt` or `get_prompts_by_category`.
+
+## Tag format
+
+- Optional list on `ListingConfig.tags`.
+- Maximum of 8 tags per prompt.
+- Each tag must be non-empty and no longer than 32 bytes.
+- Tags should use lowercase kebab-case, such as `unit-tests`, `copywriting`, or `lesson-plan`.
+- Duplicate tags are rejected.
+
+## Discovery methods
+
+- `get_prompts_by_category(category)` returns active, non-expired prompts with an exact category match.
+- `get_prompts_by_tag(tag)` returns active, non-expired prompts that contain the exact tag.


### PR DESCRIPTION
close #211 

Description
Add tag support to ListingConfig and store tags: Vec<String> on Prompt, with validations in create_prompt and a new validate_tags helper enforcing MAX_TAGS (8), MAX_TAG_LEN (32), non-empty and no-duplicates, and preserve tags through revisions.
Add storage helpers get_prompts_by_category and get_prompts_by_tag and persist/lookup helpers for disputes (save_dispute, get_dispute, require_dispute) in storage.rs and update types.rs with PurchaseDispute, DisputeStatus, and DisputeReason variants.
Add contract APIs get_prompts_by_category, get_prompts_by_tag, open_dispute, resolve_dispute, and get_dispute, implement buyer-authenticated dispute opening and owner-authorized resolution that supports refunding (which removes purchase access) or rejection, and update platform fee governance to require an authenticated admin argument and owner check.
Emit new events DisputeOpened and DisputeResolved, add unit tests covering tag/category discovery and the dispute flows, and add docs/prompt-categories-and-tags.md documenting formats and discovery methods.

Testing
Ran the contract test suite with cargo test -p prompt-hash --lib and all tests passed (78 passed; 0 failed).
Added unit tests test_create_prompt_tags_and_category_filters, test_buyer_can_open_and_admin_can_resolve_refund_dispute, test_invalid_dispute_requires_purchase, and test_resolved_dispute_cannot_be_resolved_twice which passed as part of the suite.
Existing tests were run to ensure backwards compatibility and passed successfully with the new changes.
