### PR TITLE
Pull Request: Marketplace UX Improvements (#237 #238 #240 #241)

### DIFF
--- a/src/components/FeaturedCreators.tsx
+++ b/src/components/FeaturedCreators.tsx
@@ -1,0 +1,141 @@
+import { Link } from "react-router-dom";
+import { ArrowUpRight, Star, Users } from "lucide-react";
+
+interface FeaturedCreator {
+  address: string;
+  displayName: string;
+  specialty: string;
+  avatarUrl?: string;
+  listingCount: number;
+  totalSales: number;
+  tagline: string;
+}
+
+const FEATURED_CREATORS: FeaturedCreator[] = [
+  {
+    address: "GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV2KXPBDQJW",
+    displayName: "CodeGuru",
+    specialty: "Software Development",
+    avatarUrl: "/images/codeguru.png",
+    listingCount: 12,
+    totalSales: 84,
+    tagline: "Architecture reviews, code audits, and system design prompts for engineering teams.",
+  },
+  {
+    address: "GBQNZKAQLWFAZS6RCQZFN2ESOVP4LJZULMZUOWXFTPKZXS6YXMMLDQJ",
+    displayName: "MarketMind",
+    specialty: "Marketing & Growth",
+    avatarUrl: "/browse/campaign.png",
+    listingCount: 8,
+    totalSales: 61,
+    tagline: "Campaign frameworks and multi-channel launch playbooks that convert.",
+  },
+  {
+    address: "GD3DCFB4COYEELFNZPZM7TQXKCMFCNRNTBFHKJ4CWIQNZS7Q3BVQKC2",
+    displayName: "FinanceCraft",
+    specialty: "Finance & Analysis",
+    avatarUrl: "/browse/finance.png",
+    listingCount: 6,
+    totalSales: 45,
+    tagline: "Financial modeling, risk analysis, and investor communication templates.",
+  },
+];
+
+function CreatorCard({ creator }: { creator: FeaturedCreator }) {
+  return (
+    <Link
+      to={`/sellers/${encodeURIComponent(creator.address)}`}
+      className="group flex flex-col rounded-[20px] border border-white/8 bg-white/[0.02] p-5 transition-all duration-300 hover:bg-white/[0.05] hover:-translate-y-1 hover:border-emerald-500/20"
+    >
+      {/* Avatar + name row */}
+      <div className="flex items-center gap-3 mb-4">
+        <div className="h-12 w-12 shrink-0 overflow-hidden rounded-full border border-white/10 bg-slate-800">
+          {creator.avatarUrl ? (
+            <img
+              src={creator.avatarUrl}
+              alt={creator.displayName}
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center text-lg font-bold text-slate-300">
+              {creator.displayName.slice(0, 1)}
+            </div>
+          )}
+        </div>
+        <div className="min-w-0">
+          <p className="font-bold text-white group-hover:text-emerald-300 transition-colors truncate">
+            {creator.displayName}
+          </p>
+          <p className="text-xs text-slate-500 truncate">
+            {creator.address.slice(0, 8)}…{creator.address.slice(-4)}
+          </p>
+        </div>
+        <ArrowUpRight className="ml-auto h-4 w-4 shrink-0 text-slate-600 group-hover:text-emerald-400 transition-colors" />
+      </div>
+
+      {/* Specialty badge */}
+      <span className="mb-3 inline-flex self-start rounded-full border border-amber-500/20 bg-amber-500/10 px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-amber-400">
+        {creator.specialty}
+      </span>
+
+      {/* Tagline */}
+      <p className="text-sm leading-6 text-slate-400 flex-1 line-clamp-2">{creator.tagline}</p>
+
+      {/* Stats row */}
+      <div className="mt-4 flex items-center gap-4 border-t border-white/5 pt-4 text-xs text-slate-500">
+        <span className="flex items-center gap-1">
+          <Star className="h-3 w-3 text-emerald-400" />
+          {creator.listingCount} listings
+        </span>
+        <span className="flex items-center gap-1">
+          <Users className="h-3 w-3 text-cyan-400" />
+          {creator.totalSales} sales
+        </span>
+      </div>
+    </Link>
+  );
+}
+
+export function FeaturedCreators() {
+  if (FEATURED_CREATORS.length === 0) {
+    return (
+      <section className="mx-auto max-w-7xl px-6 py-10">
+        <div className="rounded-3xl border border-white/10 bg-white/[0.02] px-8 py-14 text-center">
+          <Users className="mx-auto mb-4 h-10 w-10 text-slate-600" />
+          <p className="text-base font-semibold text-white">No featured creators yet</p>
+          <p className="mt-1 text-sm text-slate-400">
+            Check back soon as the community grows.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="mx-auto max-w-7xl px-6 py-10">
+      <div className="mb-6 flex items-end justify-between gap-4">
+        <div>
+          <p className="text-xs font-bold uppercase tracking-[0.28em] text-emerald-400 mb-1">
+            Community
+          </p>
+          <h2 className="text-2xl font-bold text-white sm:text-3xl">Featured Creators</h2>
+          <p className="mt-1 text-sm text-slate-400">
+            Discover active prompt authors trusted by the marketplace.
+          </p>
+        </div>
+        <Link
+          to="/browse"
+          className="shrink-0 text-xs font-semibold text-slate-400 hover:text-emerald-300 transition-colors"
+        >
+          Browse all →
+        </Link>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {FEATURED_CREATORS.map((creator) => (
+          <CreatorCard key={creator.address} creator={creator} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,6 +3,7 @@ import { ArrowRight, LockKeyhole, ShoppingBag, Sparkles } from "lucide-react";
 import { Navigation } from "@/components/navigation";
 import { Footer } from "@/components/footer";
 import { FeaturedPrompts } from "@/components/featured-prompts";
+import { FeaturedCreators } from "@/components/FeaturedCreators";
 import { Button } from "@/components/ui/button";
 import { MarketplaceAnalyticsCards } from "@/components/analytics/MarketplaceAnalyticsCards";
 import { usePageMeta } from "@/lib/seo/usePageMeta";
@@ -121,6 +122,8 @@ export default function Home() {
             </div>
           </div>
         </section>
+
+        <FeaturedCreators />
 
         <FeaturedPrompts />
       </main>

--- a/src/pages/browse/PromptCard.tsx
+++ b/src/pages/browse/PromptCard.tsx
@@ -171,18 +171,28 @@ export const PromptCard = ({
             {prompt.previewText}
           </p>
 
-          {/* Rating Display */}
-          {reviewStats && reviewStats.total > 0 && (
-            <div className="pt-2">
-              <StarRating
-                rating={reviewStats.averageRating}
-                readonly
-                size="sm"
-                showCount
-                reviewCount={reviewStats.total}
-              />
-            </div>
-          )}
+          {/* Quality Score Display */}
+          <div className="pt-2">
+            {reviewStats && reviewStats.total > 0 ? (
+              <div className="flex items-center gap-2">
+                <StarRating
+                  rating={reviewStats.averageRating}
+                  readonly
+                  size="sm"
+                  showCount
+                  reviewCount={reviewStats.total}
+                />
+                <span
+                  className="rounded-full border border-amber-500/20 bg-amber-500/10 px-2 py-0.5 text-[10px] font-bold text-amber-400"
+                  title="Average quality score based on buyer reviews"
+                >
+                  {reviewStats.averageRating.toFixed(1)}
+                </span>
+              </div>
+            ) : (
+              <span className="text-[11px] text-slate-500 italic">No ratings yet</span>
+            )}
+          </div>
         </div>
 
         {/* Purchase Info Row */}

--- a/src/pages/browse/PromptModal.tsx
+++ b/src/pages/browse/PromptModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useContext, useEffect, useRef } from "react";
+import { Link } from "react-router-dom";
 import { WalletContext } from "../../providers/WalletProvider";
 import { useAsyncTransaction } from "../../components/useAsyncTransaction";
 import { PromptHashClient } from "../../lib/stellar/promptHashClient";
@@ -23,6 +24,29 @@ import {
   ShoppingBag,
   Hash,
 } from "lucide-react";
+
+// Small inline copy button used in the receipt reference details
+const CopyField: React.FC<{ value: string; label: string }> = ({ value, label }) => {
+  const [copied, setCopied] = React.useState(false);
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1800);
+    } catch {
+      // silent
+    }
+  };
+  return (
+    <button
+      onClick={handleCopy}
+      title={`Copy ${label}`}
+      className="shrink-0 rounded-lg border border-white/10 bg-white/5 p-1.5 text-slate-400 hover:text-white hover:bg-white/10 transition-colors"
+    >
+      {copied ? <Check className="h-3.5 w-3.5 text-emerald-400" /> : <Copy className="h-3.5 w-3.5" />}
+    </button>
+  );
+};
 import { ReviewForm } from "../../components/prompts/ReviewForm";
 import { ReviewList } from "../../components/prompts/ReviewList";
 import { StarRating } from "../../components/prompts/StarRating";
@@ -60,6 +84,13 @@ const PromptMetadataSection: React.FC<{ itemId: string; status: BuyerStatus }> =
     enabled: !!itemId,
   });
 
+  const { data: reviewStats, isLoading: reviewStatsLoading } = useQuery({
+    queryKey: ["review-stats", itemId],
+    queryFn: () => ReviewClient.getReviewStats(itemId),
+    enabled: !!itemId,
+    staleTime: 60_000,
+  });
+
   if (isLoading) {
     return (
       <div className="mb-6 space-y-3">
@@ -80,6 +111,30 @@ const PromptMetadataSection: React.FC<{ itemId: string; status: BuyerStatus }> =
       <div className="p-4 rounded-xl bg-white/5 border border-white/5">
         <p className="text-xs uppercase tracking-wider text-slate-400 mb-2">Preview</p>
         <p className="text-sm text-slate-300 leading-relaxed">{prompt.previewText}</p>
+      </div>
+
+      {/* Quality Score */}
+      <div className="p-3 rounded-lg bg-white/5 border border-white/5">
+        <div className="flex items-center justify-between">
+          <p className="text-xs text-slate-400 uppercase tracking-wider">Quality Score</p>
+          {!reviewStatsLoading && reviewStats && reviewStats.total > 0 && (
+            <span className="rounded-full border border-amber-500/20 bg-amber-500/10 px-2 py-0.5 text-[10px] font-bold text-amber-400">
+              {reviewStats.averageRating.toFixed(1)} / 5
+            </span>
+          )}
+        </div>
+        {reviewStatsLoading ? (
+          <Skeleton className="mt-2 h-4 w-32" />
+        ) : reviewStats && reviewStats.total > 0 ? (
+          <div className="mt-2 flex items-center gap-3">
+            <StarRating rating={reviewStats.averageRating} readonly size="sm" />
+            <span className="text-xs text-slate-400">
+              {reviewStats.total} {reviewStats.total === 1 ? "review" : "reviews"}
+            </span>
+          </div>
+        ) : (
+          <p className="mt-2 text-xs italic text-slate-500">No ratings yet — be the first to review.</p>
+        )}
       </div>
 
       {/* Metadata Grid */}
@@ -163,6 +218,13 @@ export const PromptModal: React.FC<PromptModalProps> = ({
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const modalRef = useRef<HTMLDivElement>(null);
   const lastActiveElementRef = useRef<HTMLElement | null>(null);
+
+  // Fetch prompt details (used by receipt view and metadata section)
+  const { data: promptDetail } = useQuery({
+    queryKey: ["prompt-detail", itemId],
+    queryFn: async () => PromptHashClient.getPrompt(browserStellarConfig, BigInt(itemId)),
+    enabled: isOpen && !!itemId,
+  });
 
   // Fetch reviews for this prompt
   const { data: reviewData, isLoading: reviewsLoading } = useQuery({
@@ -460,20 +522,85 @@ export const PromptModal: React.FC<PromptModalProps> = ({
               )}
 
               {status === "SUCCESS" && (
-                <div className="animate-in fade-in zoom-in duration-300">
-                  <div className="flex items-center gap-2 text-emerald-400 font-bold mb-4">
-                    <CheckCircle className="h-5 w-5" /> Access Granted
+                <div className="animate-in fade-in zoom-in duration-300 space-y-4">
+                  {/* Receipt header */}
+                  <div className="rounded-2xl border border-emerald-500/20 bg-emerald-500/10 p-4">
+                    <div className="flex items-center gap-2 text-emerald-400 font-bold mb-3">
+                      <CheckCircle className="h-5 w-5" /> Purchase Receipt
+                    </div>
+                    <div className="grid grid-cols-2 gap-3 text-xs">
+                      <div>
+                        <p className="text-slate-400 uppercase tracking-wider mb-1">Prompt</p>
+                        <p className="font-semibold text-white truncate">
+                          {promptDetail?.title ?? `#${itemId}`}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-slate-400 uppercase tracking-wider mb-1">Price paid</p>
+                        <p className="font-semibold text-emerald-300">
+                          {promptDetail ? `${stroopsToXlmString(promptDetail.priceStroops)} XLM` : "—"}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-slate-400 uppercase tracking-wider mb-1">Buyer status</p>
+                        <span className="inline-flex items-center gap-1 rounded-full border border-blue-500/20 bg-blue-500/10 px-2 py-0.5 text-[10px] font-bold text-blue-400">
+                          Licensed
+                        </span>
+                      </div>
+                      <div>
+                        <p className="text-slate-400 uppercase tracking-wider mb-1">Buyer</p>
+                        <p className="font-mono text-white truncate">
+                          {wallet?.address
+                            ? `${wallet.address.slice(0, 6)}…${wallet.address.slice(-4)}`
+                            : "—"}
+                        </p>
+                      </div>
+                    </div>
                   </div>
+
+                  {/* Reference details — copyable */}
+                  <div className="rounded-xl border border-white/10 bg-white/5 p-3 space-y-2">
+                    <p className="text-[10px] uppercase tracking-wider text-slate-500 mb-2">Reference details</p>
+                    <div className="flex items-center justify-between gap-2">
+                      <div className="min-w-0">
+                        <p className="text-[10px] text-slate-500">Prompt ID</p>
+                        <p className="font-mono text-xs text-slate-300">#{itemId}</p>
+                      </div>
+                      <CopyField value={itemId} label="prompt ID" />
+                    </div>
+                    {txHash && (
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="min-w-0">
+                          <p className="text-[10px] text-slate-500">Transaction ref</p>
+                          <p className="font-mono text-xs text-slate-300 truncate">{txHash}</p>
+                        </div>
+                        <CopyField value={txHash} label="tx ref" />
+                      </div>
+                    )}
+                    {promptDetail?.contentHash && (
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="min-w-0">
+                          <p className="text-[10px] text-slate-500">Content hash</p>
+                          <p className="font-mono text-xs text-slate-300 truncate">
+                            {promptDetail.contentHash.slice(0, 16)}…
+                          </p>
+                        </div>
+                        <CopyField value={promptDetail.contentHash} label="content hash" />
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Unlocked content */}
                   <div className="relative group">
                     <div className="absolute -inset-1 bg-gradient-to-r from-emerald-500 to-blue-500 rounded-2xl blur opacity-20 group-hover:opacity-30 transition" />
-                    <div className="relative bg-black border border-white/5 rounded-xl p-6 max-h-[300px] overflow-y-auto">
+                    <div className="relative bg-black border border-white/5 rounded-xl p-6 max-h-[240px] overflow-y-auto">
                       <pre className="text-sm text-slate-300 whitespace-pre-wrap font-mono leading-relaxed">
                         {secretContent}
                       </pre>
                     </div>
                   </div>
 
-                  <div className="mt-4 flex gap-3">
+                  <div className="flex gap-3">
                     <button
                       onClick={handleCopyContent}
                       className="flex-1 flex items-center justify-center gap-2 h-12 bg-emerald-500/20 hover:bg-emerald-500/30 text-emerald-400 font-semibold rounded-xl transition-all border border-emerald-500/30"
@@ -487,27 +614,27 @@ export const PromptModal: React.FC<PromptModalProps> = ({
                       ) : (
                         <>
                           <Copy className="h-4 w-4" />
-                          Copy
+                          Copy content
                         </>
                       )}
                     </button>
                   </div>
 
                   {copyFeedback.visible && !copyFeedback.success && (
-                    <div className="mt-3 p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-xs text-red-400">
+                    <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-xs text-red-400">
                       {copyFeedback.message}
                     </div>
                   )}
 
-                  <div className="mt-4 p-4 bg-blue-500/10 border border-blue-500/20 rounded-xl">
+                  <div className="p-3 bg-blue-500/10 border border-blue-500/20 rounded-xl">
                     <p className="text-xs text-blue-300 leading-relaxed">
-                      Please store your purchased prompt content securely. Do not share this content publicly or with unauthorized users.
+                      Store this prompt securely. Do not share it publicly or with unauthorised users.
                     </p>
                   </div>
 
                   {/* Review Section */}
                   {wallet?.address && (
-                    <div className="mt-6 pt-6 border-t border-white/10">
+                    <div className="pt-4 border-t border-white/10">
                       {!showReviewForm ? (
                         <button
                           onClick={() => setShowReviewForm(true)}
@@ -539,12 +666,22 @@ export const PromptModal: React.FC<PromptModalProps> = ({
                     </div>
                   )}
 
-                  <button
-                    onClick={onClose}
-                    className="w-full mt-6 h-12 bg-white/5 hover:bg-white/10 text-white font-bold rounded-xl transition-all"
-                  >
-                    Back to Marketplace
-                  </button>
+                  <div className="flex gap-3 pt-2">
+                    <Link
+                      to="/purchases"
+                      className="flex-1 flex items-center justify-center gap-2 h-12 bg-emerald-500 hover:bg-emerald-400 text-slate-950 font-bold rounded-xl transition-all"
+                      onClick={onClose}
+                    >
+                      <ShoppingBag className="h-4 w-4" />
+                      Go to my library
+                    </Link>
+                    <button
+                      onClick={onClose}
+                      className="flex-1 h-12 bg-white/5 hover:bg-white/10 text-white font-bold rounded-xl transition-all"
+                    >
+                      Back to marketplace
+                    </button>
+                  </div>
                 </div>
               )}
             </div>

--- a/src/pages/sell/MyPrompts.tsx
+++ b/src/pages/sell/MyPrompts.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Eye, Loader2, LockKeyhole } from "lucide-react";
+import { Eye, Loader2, LockKeyhole, PackagePlus, ShoppingBag, ToggleLeft, ToggleRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -16,18 +17,11 @@ import {
 import { formatPriceLabel, stroopsToXlmString, xlmToStroops } from "@/lib/stellar/format";
 import { unlockPromptContent } from "@/lib/prompts/unlock";
 
-const emptyState = (
-  <div className="rounded-3xl border border-white/10 bg-white/5 p-8 text-sm text-slate-300">
-    No prompts found yet.
-  </div>
-);
-
 interface MyPromptsProps {
   onCreateNew?: () => void;
 }
 
-const MyPrompts = ({ onCreateNew: _onCreateNew }: MyPromptsProps) => {
-  void _onCreateNew;
+const MyPrompts = ({ onCreateNew }: MyPromptsProps) => {
 
   const queryClient = useQueryClient();
   const { address, signMessage, signTransaction } = useWallet();
@@ -209,7 +203,23 @@ const MyPrompts = ({ onCreateNew: _onCreateNew }: MyPromptsProps) => {
             Loading created prompts...
           </div>
         ) : createdPrompts.length === 0 ? (
-          emptyState
+          <div className="flex flex-col items-center justify-center gap-4 rounded-3xl border border-white/10 bg-white/5 px-8 py-14 text-center">
+            <PackagePlus className="h-10 w-10 text-slate-500" />
+            <div>
+              <p className="text-base font-semibold text-white">No listings yet</p>
+              <p className="mt-1 text-sm text-slate-400">
+                Publish your first prompt to start earning license fees.
+              </p>
+            </div>
+            {onCreateNew && (
+              <Button
+                className="mt-2 bg-emerald-400 text-slate-950 hover:bg-emerald-300"
+                onClick={onCreateNew}
+              >
+                Create a listing
+              </Button>
+            )}
+          </div>
         ) : (
           <div className="grid gap-6 xl:grid-cols-2">
             {createdPrompts.map((prompt) => (
@@ -225,14 +235,28 @@ const MyPrompts = ({ onCreateNew: _onCreateNew }: MyPromptsProps) => {
                   />
                 </div>
                 <CardContent className="space-y-4 p-5">
-                  <div>
-                    <p className="text-xs uppercase tracking-[0.25em] text-slate-500">
-                      {prompt.category}
-                    </p>
-                    <h3 className="mt-2 text-xl font-semibold">{prompt.title}</h3>
-                    <p className="mt-3 text-sm leading-6 text-slate-300">
-                      {prompt.previewText}
-                    </p>
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="text-xs uppercase tracking-[0.25em] text-slate-500">
+                        {prompt.category}
+                      </p>
+                      <h3 className="mt-2 text-xl font-semibold">{prompt.title}</h3>
+                      <p className="mt-3 text-sm leading-6 text-slate-300">
+                        {prompt.previewText}
+                      </p>
+                    </div>
+                    {/* Status badge */}
+                    {prompt.active ? (
+                      <span className="mt-1 inline-flex shrink-0 items-center gap-1.5 rounded-full border border-emerald-500/25 bg-emerald-500/10 px-2.5 py-1 text-xs font-semibold text-emerald-400">
+                        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-400" />
+                        Active
+                      </span>
+                    ) : (
+                      <span className="mt-1 inline-flex shrink-0 items-center gap-1.5 rounded-full border border-slate-500/25 bg-slate-500/10 px-2.5 py-1 text-xs font-semibold text-slate-400">
+                        <span className="h-1.5 w-1.5 rounded-full bg-slate-400" />
+                        Inactive
+                      </span>
+                    )}
                   </div>
                   <div className="grid grid-cols-2 gap-3 rounded-2xl border border-white/10 bg-white/5 p-4 text-sm">
                     <div>
@@ -245,10 +269,10 @@ const MyPrompts = ({ onCreateNew: _onCreateNew }: MyPromptsProps) => {
                     </div>
                     <div>
                       <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
-                        Status
+                        Current price
                       </p>
                       <p className="mt-2 font-medium text-slate-100">
-                        {prompt.active ? "Active" : "Inactive"}
+                        {formatPriceLabel(prompt.priceStroops)}
                       </p>
                     </div>
                   </div>
@@ -273,22 +297,25 @@ const MyPrompts = ({ onCreateNew: _onCreateNew }: MyPromptsProps) => {
                     </Button>
                   </div>
                 </CardContent>
-                <CardFooter className="flex items-center justify-between p-5 pt-0">
-                  <div>
-                    <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
-                      Current price
-                    </p>
-                    <p className="mt-2 text-lg font-semibold text-slate-100">
-                      {formatPriceLabel(prompt.priceStroops)}
-                    </p>
-                  </div>
+                <CardFooter className="p-5 pt-0">
                   <Button
                     variant="outline"
-                    className="border-white/10 bg-white/5 text-slate-100 hover:bg-white/10"
+                    className={`w-full gap-2 border-white/10 text-slate-100 hover:bg-white/10 ${
+                      prompt.active
+                        ? "bg-white/5 hover:border-red-400/30 hover:text-red-300"
+                        : "bg-emerald-500/10 border-emerald-500/20 hover:border-emerald-400/40 text-emerald-400"
+                    }`}
                     onClick={() => void handleToggleSaleStatus(prompt.id, prompt.active)}
                     disabled={busyPromptId === prompt.id.toString()}
                   >
-                    {prompt.active ? "Set inactive" : "Reactivate"}
+                    {busyPromptId === prompt.id.toString() ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : prompt.active ? (
+                      <ToggleRight className="h-4 w-4" />
+                    ) : (
+                      <ToggleLeft className="h-4 w-4" />
+                    )}
+                    {prompt.active ? "Deactivate listing" : "Reactivate listing"}
                   </Button>
                 </CardFooter>
               </Card>
@@ -310,7 +337,18 @@ const MyPrompts = ({ onCreateNew: _onCreateNew }: MyPromptsProps) => {
             Loading purchased prompts...
           </div>
         ) : purchasedPrompts.length === 0 ? (
-          emptyState
+          <div className="flex flex-col items-center justify-center gap-4 rounded-3xl border border-white/10 bg-white/5 px-8 py-14 text-center">
+            <ShoppingBag className="h-10 w-10 text-slate-500" />
+            <div>
+              <p className="text-base font-semibold text-white">No purchases yet</p>
+              <p className="mt-1 text-sm text-slate-400">
+                Browse the marketplace to find and unlock prompt licenses.
+              </p>
+            </div>
+            <Button asChild className="mt-2 bg-white/10 text-slate-100 hover:bg-white/15">
+              <Link to="/browse">Browse marketplace</Link>
+            </Button>
+          </div>
         ) : (
           <div className="grid gap-6 xl:grid-cols-2">
             {purchasedPrompts.map((prompt) => (


### PR DESCRIPTION


## Summary

This PR delivers four independent feature improvements to the PromptHash marketplace frontend. Each change targets a distinct user journey — seller management, buyer discovery, purchase confirmation, and creator showcasing.

closes #238 
closes #237 
closes #240 
closes #241
---

## Changes by issue

### #238 — Improve seller listing management (`src/pages/sell/MyPrompts.tsx`)

- **Status badges**: each created-prompt card now shows a colored Active (emerald, animated pulse) or Inactive (slate) badge instead of plain "Active"/"Inactive" text, making listing state instantly scannable.
- **Section-specific empty states**: the generic "No prompts found yet" message is replaced with two distinct empty states:
  - *Created prompts*: icon + copy + CTA button calling `onCreateNew` (prop is now wired up; previously voided).
  - *Purchased prompts*: icon + copy + `Link` to `/browse` so buyers can start shopping immediately.
- **Toggle button redesign**: the status toggle now spans the full card footer width, changes color based on active state (red tint for deactivate, emerald for reactivate), and shows a spinner while the transaction is in flight.
- **Stats grid cleanup**: "Current price" replaces the old duplicate status cell; status is now only shown via the badge.

### #237 — Add prompt quality score display (`src/pages/browse/PromptCard.tsx`, `src/pages/browse/PromptModal.tsx`)

**Prompt cards** (`PromptCard.tsx`):
- Always renders a quality score row beneath the description.
- When reviews exist: shows `StarRating` + an amber score badge (e.g. `4.3`).
- When no reviews exist: shows italic "No ratings yet" placeholder so the row is never empty.

**Prompt detail modal** (`PromptModal.tsx`):
- New dedicated **Quality Score** panel in `PromptMetadataSection`, above the metadata grid.
- Shows `StarRating` + review count when reviews exist; "No ratings yet — be the first to review." fallback when they don't.
- Score badge shows `x.x / 5` for quick reference.
- Shares the same `review-stats` React Query cache used by the card.

### #240 — Improve purchase receipt view (`src/pages/browse/PromptModal.tsx`)

The `SUCCESS` state in `PromptModal` is now a proper receipt rather than just a content dump:

- **Receipt header**: emerald-tinted block showing prompt title, price paid (in XLM), buyer wallet (abbreviated), and a "Licensed" status badge.
- **Reference details panel**: copyable prompt ID, transaction reference, and content hash — each with an inline copy button that shows a check icon on success.
- **Library link**: primary CTA "Go to my library" routes to `/purchases`; secondary "Back to marketplace" closes the modal.
- A `CopyField` helper component handles the clipboard interaction and success feedback inline.
- A `promptDetail` React Query is hoisted to the `PromptModal` scope so receipt data is available without an additional fetch.

### #241 — Add featured creator section (`src/components/FeaturedCreators.tsx`, `src/pages/Home.tsx`)

- New `FeaturedCreators` component with a static list of featured creators, each with: Stellar address, display name, specialty badge, tagline, avatar, listing count, total sales.
- Each card links to `/sellers/:address` for full seller profile discovery.
- Fallback empty state with icon and message when `FEATURED_CREATORS` is empty.
- Responsive layout: 1 column on mobile → 2 on sm → 3 on lg.
- Section added to `Home.tsx` above `<FeaturedPrompts />` with a "Browse all →" link.

---

## Test plan

- [ ] Seller dashboard: create a listing, confirm Active badge is visible; deactivate it, confirm Inactive badge appears and button turns red-tinted.
- [ ] Seller dashboard: with no listings, confirm "No listings yet" empty state and CTA button appear.
- [ ] Seller dashboard: with no purchases, confirm "No purchases yet" empty state and "Browse marketplace" link appear.
- [ ] Browse page: open a prompt card with reviews — confirm star rating and amber score badge appear.
- [ ] Browse page: open a prompt card with no reviews — confirm "No ratings yet" text appears.
- [ ] Prompt modal (detail): open a prompt — confirm Quality Score panel appears above metadata grid with fallback text when unrated.
- [ ] Prompt modal (purchase): complete a purchase flow — confirm receipt shows title, price, buyer address, Licensed badge, copyable reference IDs, and both action buttons.
- [ ] Prompt modal (receipt): click "Go to my library" — confirm navigation to `/purchases`.
- [ ] Home page: confirm Featured Creators section appears with three creator cards, each linking to the correct `/sellers/` path.
- [ ] All layouts: verify no overflow or broken alignment on mobile (375 px) and wide desktop (1440 px).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Featured Creators” section on the home page with creator cards, stats, and seller links.
  * Added a purchase receipt view with copyable reference details and quick links to your library and the marketplace.
  * Added clearer prompt management actions for creating listings, browsing purchases, and toggling listing status.
* **Improvements**
  * Updated prompt cards and purchase flows to show quality scores, better empty states, and clearer pricing/status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->