### PR TITLE
feat(#239): add prompt category landing pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,8 @@ const MyPurchasesPage = lazy(
 );
 const StatusPage = lazy(() => import("./pages/status/page.tsx"));
 const SellerPage = lazy(() => import("./pages/sellers/page.tsx"));
+const CategoryPage = lazy(() => import("./pages/category/page.tsx"));
+const PromptDetailPage = lazy(() => import("./pages/prompts/[id].tsx"));
 
 const AppLayout = () => (
   <main className="min-h-screen bg-slate-950 text-white">
@@ -37,6 +39,8 @@ function App() {
           <Route path="/purchases" element={<MyPurchasesPage />} />
           <Route path="/status" element={<StatusPage />} />
           <Route path="/sellers/:sellerId" element={<SellerPage />} />
+          <Route path="/category/:categoryName" element={<CategoryPage />} />
+          <Route path="/prompts/:id" element={<PromptDetailPage />} />
           <Route path="*" element={<Home />} />
         </Route>
       </Routes>

--- a/src/components/category-showcase.jsx
+++ b/src/components/category-showcase.jsx
@@ -1,27 +1,11 @@
 import { Button } from "./ui/button";
-// import Link from "next/link";
 import { Link } from "react-router-dom";
 
-const categories = [
-  {
-    id: 1,
-    name: "Image Generation",
-    count: 1243,
-    image: "/images/image-generator.png",
-  },
-  {
-    id: 2,
-    name: "Text & Writing",
-    count: 876,
-    image: "/images/text&writing.png",
-  },
-  {
-    id: 3,
-    name: "Code & Development",
-    count: 542,
-    image: "/images/code&dev.png",
-  },
-  { id: 4, name: "Marketing", count: 321, image: "/images/marketing.png" },
+const showcaseCategories = [
+  { name: "Software Development", slug: "software-development", count: 42, image: "/images/code&dev.png" },
+  { name: "Marketing", slug: "marketing", count: 38, image: "/images/marketing.png" },
+  { name: "Creative", slug: "creative", count: 27, image: "/images/text&writing.png" },
+  { name: "Sales", slug: "sales", count: 19, image: "/images/sales.png" },
 ];
 
 export function CategoryShowcase() {
@@ -29,11 +13,11 @@ export function CategoryShowcase() {
     <section className="py-16 px-6 bg-gray-950">
       <div className="mx-auto max-w-7xl">
         <h2 className="text-2xl font-bold tracking-tight text-white mb-8">
-          Explore the App Store
+          Explore Categories
         </h2>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-          {categories.map((category) => (
-            <Link to={`/category/${category.id}`} key={category.id}>
+          {showcaseCategories.map((category) => (
+            <Link to={`/category/${category.slug}`} key={category.slug}>
               <div className="relative group overflow-hidden rounded-lg">
                 <div className="aspect-[4/3] overflow-hidden">
                   <img

--- a/src/data/categoryMetadata.ts
+++ b/src/data/categoryMetadata.ts
@@ -1,0 +1,93 @@
+export interface CategoryMeta {
+  name: string;
+  slug: string;
+  description: string;
+  count?: number;
+}
+
+export const categoryMetadata: Record<string, CategoryMeta> = {
+  "Software Development": {
+    name: "Software Development",
+    slug: "software-development",
+    description:
+      "Prompts for architects, engineers, and developers to streamline coding, architecture review, and technical planning workflows.",
+  },
+  Marketing: {
+    name: "Marketing",
+    slug: "marketing",
+    description:
+      "Campaign strategies, copywriting frameworks, and multi-channel launch templates for marketing professionals.",
+  },
+  Sales: {
+    name: "Sales",
+    slug: "sales",
+    description:
+      "Discovery call scripts, objection handling, and closing sequences crafted for high-performance sales teams.",
+  },
+  "Customer Support": {
+    name: "Customer Support",
+    slug: "customer-support",
+    description:
+      "Escalation recovery scripts, troubleshooting sequences, and empathy-driven support templates.",
+  },
+  Finance: {
+    name: "Finance",
+    slug: "finance",
+    description:
+      "Financial scenario planning, budgeting memos, and decision-oriented analysis prompts for finance teams.",
+  },
+  "Product Management": {
+    name: "Product Management",
+    slug: "product-management",
+    description:
+      "PRD templates, launch checklists, and product strategy prompts for effective product management.",
+  },
+  "User Experience": {
+    name: "User Experience",
+    slug: "user-experience",
+    description:
+      "UX research synthesis, design critiques, and user testing frameworks for experience designers.",
+  },
+  Recruitment: {
+    name: "Recruitment",
+    slug: "recruitment",
+    description:
+      "Structured hiring scorecards, interview loops, and calibrated feedback prompts for recruiting teams.",
+  },
+  Operations: {
+    name: "Operations",
+    slug: "operations",
+    description:
+      "Playbook generators, process documentation, and workflow optimization prompts for operations managers.",
+  },
+  "Public Relations": {
+    name: "Public Relations",
+    slug: "public-relations",
+    description:
+      "Crisis communication briefs, media response plans, and stakeholder messaging templates for PR professionals.",
+  },
+  Development: {
+    name: "Development",
+    slug: "development",
+    description:
+      "Technical prompts for developers covering code generation, debugging, system design, and architecture planning.",
+  },
+  Creative: {
+    name: "Creative",
+    slug: "creative",
+    description:
+      "Narrative design, storytelling frameworks, and creative writing prompts for content creators and writers.",
+  },
+};
+
+const slugToName = Object.fromEntries(
+  Object.entries(categoryMetadata).map(([, meta]) => [meta.slug, meta.name]),
+);
+
+export function resolveCategoryName(slug: string): string | undefined {
+  return slugToName[slug.toLowerCase()];
+}
+
+export function resolveCategorySlug(name: string): string | undefined {
+  return categoryMetadata[name]?.slug;
+}

--- a/src/pages/category/page.tsx
+++ b/src/pages/category/page.tsx
@@ -1,0 +1,169 @@
+import { useMemo } from "react";
+import { useParams, Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { ArrowLeft, PackageSearch } from "lucide-react";
+import { Navigation } from "@/components/navigation";
+import { Footer } from "@/components/footer";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { browserStellarConfig } from "@/lib/stellar/browserConfig";
+import { getAllPrompts, type PromptRecord } from "@/lib/stellar/promptHashClient";
+import { formatPriceLabel } from "@/lib/stellar/format";
+import { categoryMetadata, resolveCategoryName } from "@/data/categoryMetadata";
+import { usePageMeta } from "@/lib/seo/usePageMeta";
+
+export default function CategoryPage() {
+  const { categoryName } = useParams<{ categoryName: string }>();
+  const resolvedName = resolveCategoryName(categoryName ?? "");
+  const meta = resolvedName ? categoryMetadata[resolvedName] : undefined;
+
+  usePageMeta({
+    title: meta ? `${meta.name} Prompts` : "Category",
+    description: meta?.description ?? "Browse prompts in this category.",
+  });
+
+  const promptsQuery = useQuery({
+    queryKey: ["marketplace-prompts"],
+    queryFn: async () => {
+      if (!browserStellarConfig.promptHashContractId) return [];
+      return getAllPrompts(browserStellarConfig);
+    },
+  });
+
+  const categoryPrompts = useMemo(() => {
+    if (!resolvedName || !promptsQuery.data) return [];
+    return promptsQuery.data.filter(
+      (prompt) =>
+        prompt.active && prompt.category.toLowerCase() === resolvedName.toLowerCase(),
+    );
+  }, [resolvedName, promptsQuery.data]);
+
+  return (
+    <div className="min-h-screen bg-[#020617] text-white selection:bg-emerald-500/30">
+      <Navigation />
+
+      {/* Category Hero */}
+      <header className="relative overflow-hidden px-4 pb-16 pt-20 sm:px-6">
+        <div className="absolute top-0 left-1/2 -translate-x-1/2 w-full h-[300px] bg-emerald-500/10 blur-[120px] pointer-events-none" />
+
+        <div className="mx-auto max-w-7xl relative">
+          <Link
+            to="/browse"
+            className="inline-flex items-center gap-2 text-sm text-slate-400 hover:text-emerald-400 transition-colors mb-8"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back to Browse
+          </Link>
+
+          {meta ? (
+            <div className="max-w-3xl">
+              <Badge className="mb-4 bg-emerald-500/10 text-emerald-400 border-emerald-500/20 px-3 py-1 text-xs uppercase tracking-wider">
+                {meta.name}
+              </Badge>
+              <h1 className="text-4xl font-bold tracking-tight sm:text-5xl mb-4 bg-gradient-to-b from-white to-slate-400 bg-clip-text text-transparent leading-[1.1]">
+                {meta.name} Prompts
+              </h1>
+              <p className="text-lg text-slate-400 leading-relaxed max-w-2xl">
+                {meta.description}
+              </p>
+            </div>
+          ) : (
+            <div className="max-w-3xl">
+              <h1 className="text-4xl font-bold tracking-tight sm:text-5xl mb-4 bg-gradient-to-b from-white to-slate-400 bg-clip-text text-transparent leading-[1.1]">
+                Category Not Found
+              </h1>
+              <p className="text-lg text-slate-400 leading-relaxed max-w-2xl">
+                The category "{categoryName}" does not exist. Browse all available
+                categories and prompts.
+              </p>
+              <Button className="mt-6 bg-emerald-500 hover:bg-emerald-600 text-slate-950 font-bold h-12 px-8 rounded-xl">
+                <Link to="/browse">Browse All Prompts</Link>
+              </Button>
+            </div>
+          )}
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-7xl px-4 pb-24 sm:px-6">
+        {promptsQuery.isLoading ? (
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
+            {[...Array(3)].map((_, i) => (
+              <div
+                key={i}
+                className="h-[400px] rounded-3xl border border-white/5 bg-white/[0.02] animate-pulse"
+              />
+            ))}
+          </div>
+        ) : categoryPrompts.length === 0 && meta ? (
+          <div className="flex flex-col items-center justify-center py-24 text-center space-y-4">
+            <div className="p-4 rounded-full bg-slate-900 border border-white/5">
+              <PackageSearch className="h-8 w-8 text-slate-500" />
+            </div>
+            <div className="space-y-1">
+              <h3 className="text-lg font-semibold">No prompts in this category yet</h3>
+              <p className="text-slate-500 max-w-[320px]">
+                This category is still growing. Check back soon for new prompt
+                listings, or browse other categories.
+              </p>
+            </div>
+            <Link to="/browse">
+              <Button
+                variant="outline"
+                className="mt-2 border-white/10 bg-white/5 text-slate-100 hover:bg-white/10"
+              >
+                Browse All Categories
+              </Button>
+            </Link>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
+            {categoryPrompts.map((prompt) => (
+              <CategoryPromptCard key={prompt.id.toString()} prompt={prompt} />
+            ))}
+          </div>
+        )}
+      </main>
+
+      <Footer />
+    </div>
+  );
+}
+
+function CategoryPromptCard({ prompt }: { prompt: PromptRecord }) {
+  return (
+    <Link to={`/prompts/${prompt.id.toString()}`}>
+      <Card className="group relative flex flex-col border-white/5 bg-white/[0.02] hover:bg-white/[0.04] transition-all duration-300 hover:-translate-y-1 cursor-pointer overflow-hidden rounded-[24px] h-full">
+        <div className="relative aspect-[16/10] overflow-hidden">
+          <img
+            src={prompt.imageUrl || "/images/codeguru.png"}
+            alt={prompt.title}
+            className="h-full w-full object-cover transition-transform duration-700 group-hover:scale-110"
+          />
+          <div className="absolute inset-0 bg-gradient-to-t from-[#020617] via-transparent to-transparent opacity-60" />
+        </div>
+        <CardContent className="flex flex-1 flex-col p-4 sm:p-6">
+          <div className="flex-1 space-y-3">
+            <div className="flex items-start justify-between gap-3">
+              <h3 className="text-base font-bold leading-tight transition-colors group-hover:text-emerald-400 sm:text-lg">
+                {prompt.title}
+              </h3>
+              <p className="text-lg font-black text-emerald-400 sm:text-xl font-mono tracking-tight shrink-0">
+                {formatPriceLabel(prompt.priceStroops)}
+              </p>
+            </div>
+            <p className="line-clamp-2 text-sm text-slate-400 leading-relaxed">
+              {prompt.previewText}
+            </p>
+          </div>
+          <div className="mt-4 flex items-center gap-2 text-xs text-slate-500">
+            <Badge className="bg-slate-800 text-slate-300 border-none">
+              {prompt.category}
+            </Badge>
+            <span>{prompt.salesCount} sales</span>
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/src/pages/prompts/[id].tsx
+++ b/src/pages/prompts/[id].tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useRouter } from 'next/router';
+import { useParams } from 'react-router-dom';
 import PurchaseProgress from '../../components/PurchaseProgress';
 
 // Prompt preview page — shows ONLY public preview metadata. Hidden prompt content is never fetched.
@@ -46,8 +46,7 @@ const MOCK_PROMPTS: Record<string, PromptPreview> = {
 };
 
 export default function PromptPreviewPage() {
-  const router = useRouter();
-  const { id } = router.query as { id?: string };
+  const { id } = useParams<{ id: string }>();
 
   const [prompt, setPrompt] = useState<PromptPreview | null>(null);
   const [loading, setLoading] = useState(true);
@@ -212,7 +211,7 @@ export default function PromptPreviewPage() {
                     onClose={() => setShowPurchaseModal(false)}
                     onViewUnlocked={() => {
                       setShowPurchaseModal(false);
-                      router.push('/profile/MyPurchasesPage');
+                      window.location.href = '/purchases';
                     }}
                   />
                 )}


### PR DESCRIPTION
Closes #239

## Summary
Add dedicated landing pages for major prompt categories.

## Changes
- **New**: \src/data/categoryMetadata.ts\ — Category metadata with descriptions and slug resolution
- **New**: \src/pages/category/page.tsx\ — Category landing page with hero, filtered prompts, loading/empty/not-found states
- **Modified**: \src/App.tsx\ — Added \/category/:categoryName\ and \/prompts/:id\ routes
- **Modified**: \src/components/category-showcase.jsx\ — Updated to slug-based routing
- **Modified**: \src/pages/prompts/[id].tsx\ — Fixed to use react-router-dom instead of next/router

## Acceptance Criteria
- [x] Add category route structure (\/category/:categoryName\)
- [x] Show category-specific prompts (filter from contract)
- [x] Add category description section (hero with badge, title, description)
- [x] Add empty state for new categories