### PR TITLE
feat: add co-creator revenue split support to prompt listings

### DIFF
--- a/src/lib/stellar/promptHashClient.ts
+++ b/src/lib/stellar/promptHashClient.ts
@@ -9,7 +9,7 @@ let hasWarnedMock = false;
 const warnMockUse = () => {
   if (hasWarnedMock) return;
   console.warn(
-    "⚠️ USING MOCK PromptHashClient: Contract calls are currently stubbed and will not hit the Stellar network.",
+    "âš ï¸ USING MOCK PromptHashClient: Contract calls are currently stubbed and will not hit the Stellar network.",
   );
   hasWarnedMock = true;
 };
@@ -42,7 +42,23 @@ export interface PromptRecord {
   wrappedKey?: string;
 }
 
-export interface RevenueSplitInput {`n  recipient: string;`n  bps: number;`n}`n`nexport interface CreatePromptInput {`n  imageUrl: string;`n  title: string;`n  category: string;`n  previewText: string;`n  encryptedPrompt: string;`n  encryptionIv: string;`n  wrappedKey: string;`n  contentHash: string;`n  priceStroops: bigint;`n  splits?: RevenueSplitInput[];`n}`n
+export interface RevenueSplitInput {
+  recipient: string;
+  bps: number;
+}
+
+export interface CreatePromptInput {
+  imageUrl: string;
+  title: string;
+  category: string;
+  previewText: string;
+  encryptedPrompt: string;
+  encryptionIv: string;
+  wrappedKey: string;
+  contentHash: string;
+  priceStroops: bigint;
+  splits?: RevenueSplitInput[];
+}
 
 export class PromptHashClient {
   /**
@@ -136,12 +152,18 @@ export class PromptHashClient {
     ];
   }
 
-  static async getPromptsByBuyer(_config: PromptHashConfig, _address: string): Promise<PromptRecord[]> {
+  static async getPromptsByBuyer(
+    _config: PromptHashConfig,
+    _address: string,
+  ): Promise<PromptRecord[]> {
     warnMockUse();
     return [];
   }
 
-  static async getPromptsByCreator(_config: PromptHashConfig, _address: string): Promise<PromptRecord[]> {
+  static async getPromptsByCreator(
+    _config: PromptHashConfig,
+    _address: string,
+  ): Promise<PromptRecord[]> {
     warnMockUse();
     return [];
   }

--- a/src/lib/stellar/promptHashClient.ts
+++ b/src/lib/stellar/promptHashClient.ts
@@ -42,7 +42,7 @@ export interface PromptRecord {
   wrappedKey?: string;
 }
 
-export type CreatePromptInput = unknown;
+export interface RevenueSplitInput {`n  recipient: string;`n  bps: number;`n}`n`nexport interface CreatePromptInput {`n  imageUrl: string;`n  title: string;`n  category: string;`n  previewText: string;`n  encryptedPrompt: string;`n  encryptionIv: string;`n  wrappedKey: string;`n  contentHash: string;`n  priceStroops: bigint;`n  splits?: RevenueSplitInput[];`n}`n
 
 export class PromptHashClient {
   /**

--- a/src/lib/validation/listing.ts
+++ b/src/lib/validation/listing.ts
@@ -8,7 +8,7 @@ export const LISTING_LIMITS = {
   fullPrompt: 50_000,
   encryptedPayload: 4096,
   wrappedKey: 256,
-  encryptionIv: 64,
+  encryptionIv: 64,`n  maxCoCreators: 10,`n  maxSplitBps: 9_500,
 } as const;
 
 export const ESTIMATED_ENCRYPTION_OVERHEAD = 1.37;
@@ -58,7 +58,7 @@ export function validateListingForm(
   const category = trim(input.category);
   const previewText = trim(input.previewText);
   const fullPrompt = trim(input.fullPrompt);
-  const priceXlm = trim(input.priceXlm);
+  const priceXlm = trim(input.priceXlm);`n  const coCreators = input.coCreators ?? [];
 
   if (!imageUrl) {
     errors.imageUrl = "Add an image URL so your listing has a cover on browse cards.";
@@ -111,7 +111,7 @@ export function validateListingForm(
       `Keep the prompt under ~${maxPlaintext.toLocaleString()} characters.`;
   }
 
-  if (!priceXlm) {
+  if (coCreators.length > LISTING_LIMITS.maxCoCreators) {`n    errors.coCreators = `You can add up to ${LISTING_LIMITS.maxCoCreators} co-creators per listing.`;`n  } else if (coCreators.length > 0) {`n    const seen = new Set<string>();`n    let totalSplitBps = 0;`n`n    for (const [index, coCreator] of coCreators.entries()) {`n      const address = trim(coCreator.address);`n      const shareBps = normalizeShareBps(coCreator.sharePercent);`n`n      if (!address) {`n        errors.coCreators = `Add a wallet address for co-creator ${index + 1}.`;`n        break;`n      }`n`n      if (!/^[GC][A-Z2-7]{20,}$/i.test(address)) {`n        errors.coCreators = `Use a valid Stellar address for co-creator ${index + 1}.`;`n        break;`n      }`n`n      const key = address.toUpperCase();`n      if (seen.has(key)) {`n        errors.coCreators = "Each co-creator wallet can only appear once.";`n        break;`n      }`n      seen.add(key);`n`n      if (!Number.isFinite(shareBps) || shareBps <= 0) {`n        errors.coCreators = `Set a revenue share greater than 0% for co-creator ${index + 1}.`;`n        break;`n      }`n`n      if (shareBps > LISTING_LIMITS.maxSplitBps) {`n        errors.coCreators = `Each co-creator share must stay at or below ${LISTING_LIMITS.maxSplitBps / 100}%.`;`n        break;`n      }`n`n      totalSplitBps += shareBps;`n    }`n`n    if (!errors.coCreators && totalSplitBps > LISTING_LIMITS.maxSplitBps) {`n      errors.coCreators = "Combined co-creator shares must stay at or below 95% so the creator remainder and platform fee still fit.";`n    }`n  }`n`n  if (!priceXlm) {
     errors.priceXlm = "Enter a price in XLM — use a value greater than zero.";
   } else {
     try {
@@ -197,7 +197,7 @@ export function buildListingChecklistItems(
     { id: "previewText", label: "Preview text" },
     { id: "fullPrompt", label: "Full prompt content" },
     { id: "priceXlm", label: "Price" },
-    { id: "imageUrl", label: "Image URL" },
+    { id: "imageUrl", label: "Image URL" },`n    { id: "coCreators", label: "Revenue sharing" },
   ];
 
   for (const { id, label } of fieldChecks) {

--- a/src/lib/validation/listing.ts
+++ b/src/lib/validation/listing.ts
@@ -8,10 +8,17 @@ export const LISTING_LIMITS = {
   fullPrompt: 50_000,
   encryptedPayload: 4096,
   wrappedKey: 256,
-  encryptionIv: 64,`n  maxCoCreators: 10,`n  maxSplitBps: 9_500,
+  encryptionIv: 64,
+  maxCoCreators: 10,
+  maxSplitBps: 9_500,
 } as const;
 
 export const ESTIMATED_ENCRYPTION_OVERHEAD = 1.37;
+
+export type RevenueSplitFormInput = {
+  address: string;
+  sharePercent: string;
+};
 
 export type ListingFormInput = {
   imageUrl: string;
@@ -20,6 +27,7 @@ export type ListingFormInput = {
   previewText: string;
   fullPrompt: string;
   priceXlm: string;
+  coCreators: RevenueSplitFormInput[];
 };
 
 export type ListingValidationErrors = Partial<
@@ -44,6 +52,8 @@ export interface ListingChecklistItem {
   hint?: string;
 }
 
+const STELLAR_ADDRESS_PATTERN = /^[GC][A-Z2-7]{20,}$/i;
+
 function trim(value: string) {
   return value.trim();
 }
@@ -58,7 +68,8 @@ export function validateListingForm(
   const category = trim(input.category);
   const previewText = trim(input.previewText);
   const fullPrompt = trim(input.fullPrompt);
-  const priceXlm = trim(input.priceXlm);`n  const coCreators = input.coCreators ?? [];
+  const priceXlm = trim(input.priceXlm);
+  const coCreators = input.coCreators ?? [];
 
   if (!imageUrl) {
     errors.imageUrl = "Add an image URL so your listing has a cover on browse cards.";
@@ -85,7 +96,7 @@ export function validateListingForm(
 
   if (!previewText) {
     errors.previewText =
-      "Add preview text — this public snippet appears on browse cards before purchase.";
+      "Add preview text â€” this public snippet appears on browse cards before purchase.";
   } else if (previewText.length < 10) {
     errors.previewText =
       "Write at least 10 characters of preview text so buyers know what they are getting.";
@@ -95,7 +106,7 @@ export function validateListingForm(
 
   if (!fullPrompt) {
     errors.fullPrompt =
-      "Paste the full prompt content — it is encrypted in your browser before submission.";
+      "Paste the full prompt content â€” it is encrypted in your browser before submission.";
   } else if (fullPrompt.length < 10) {
     errors.fullPrompt =
       "Add at least 10 characters of prompt content so buyers receive meaningful value.";
@@ -111,8 +122,8 @@ export function validateListingForm(
       `Keep the prompt under ~${maxPlaintext.toLocaleString()} characters.`;
   }
 
-  if (coCreators.length > LISTING_LIMITS.maxCoCreators) {`n    errors.coCreators = `You can add up to ${LISTING_LIMITS.maxCoCreators} co-creators per listing.`;`n  } else if (coCreators.length > 0) {`n    const seen = new Set<string>();`n    let totalSplitBps = 0;`n`n    for (const [index, coCreator] of coCreators.entries()) {`n      const address = trim(coCreator.address);`n      const shareBps = normalizeShareBps(coCreator.sharePercent);`n`n      if (!address) {`n        errors.coCreators = `Add a wallet address for co-creator ${index + 1}.`;`n        break;`n      }`n`n      if (!/^[GC][A-Z2-7]{20,}$/i.test(address)) {`n        errors.coCreators = `Use a valid Stellar address for co-creator ${index + 1}.`;`n        break;`n      }`n`n      const key = address.toUpperCase();`n      if (seen.has(key)) {`n        errors.coCreators = "Each co-creator wallet can only appear once.";`n        break;`n      }`n      seen.add(key);`n`n      if (!Number.isFinite(shareBps) || shareBps <= 0) {`n        errors.coCreators = `Set a revenue share greater than 0% for co-creator ${index + 1}.`;`n        break;`n      }`n`n      if (shareBps > LISTING_LIMITS.maxSplitBps) {`n        errors.coCreators = `Each co-creator share must stay at or below ${LISTING_LIMITS.maxSplitBps / 100}%.`;`n        break;`n      }`n`n      totalSplitBps += shareBps;`n    }`n`n    if (!errors.coCreators && totalSplitBps > LISTING_LIMITS.maxSplitBps) {`n      errors.coCreators = "Combined co-creator shares must stay at or below 95% so the creator remainder and platform fee still fit.";`n    }`n  }`n`n  if (!priceXlm) {
-    errors.priceXlm = "Enter a price in XLM — use a value greater than zero.";
+  if (!priceXlm) {
+    errors.priceXlm = "Enter a price in XLM â€” use a value greater than zero.";
   } else {
     try {
       const price = xlmToStroops(priceXlm);
@@ -124,6 +135,57 @@ export function validateListingForm(
         error instanceof Error
           ? error.message
           : "Enter a valid XLM amount with up to 7 decimal places.";
+    }
+  }
+
+  if (coCreators.length > LISTING_LIMITS.maxCoCreators) {
+    errors.coCreators =
+      `Add up to ${LISTING_LIMITS.maxCoCreators} co-creators per listing.`;
+  } else if (coCreators.length > 0) {
+    const seenAddresses = new Set<string>();
+    let totalSplitBps = 0;
+
+    for (const coCreator of coCreators) {
+      const address = trim(coCreator.address).toUpperCase();
+      const sharePercent = trim(coCreator.sharePercent);
+      const parsedSharePercent = Number(sharePercent);
+
+      if (!address) {
+        errors.coCreators = "Enter a Stellar address for each co-creator.";
+        break;
+      }
+
+      if (!STELLAR_ADDRESS_PATTERN.test(address)) {
+        errors.coCreators =
+          "Use a valid Stellar public key for each co-creator address.";
+        break;
+      }
+
+      if (seenAddresses.has(address)) {
+        errors.coCreators =
+          "Each co-creator address can only appear once per listing.";
+        break;
+      }
+
+      if (!sharePercent || Number.isNaN(parsedSharePercent)) {
+        errors.coCreators =
+          "Enter a valid revenue share percentage for each co-creator.";
+        break;
+      }
+
+      if (parsedSharePercent <= 0) {
+        errors.coCreators =
+          "Each co-creator share must be greater than 0%.";
+        break;
+      }
+
+      totalSplitBps += Math.round(parsedSharePercent * 100);
+      seenAddresses.add(address);
+    }
+
+    if (!errors.coCreators && totalSplitBps > LISTING_LIMITS.maxSplitBps) {
+      errors.coCreators =
+        `Co-creator shares cannot exceed ${(LISTING_LIMITS.maxSplitBps / 100).toFixed(2)}% in total.`;
     }
   }
 
@@ -197,7 +259,8 @@ export function buildListingChecklistItems(
     { id: "previewText", label: "Preview text" },
     { id: "fullPrompt", label: "Full prompt content" },
     { id: "priceXlm", label: "Price" },
-    { id: "imageUrl", label: "Image URL" },`n    { id: "coCreators", label: "Revenue sharing" },
+    { id: "imageUrl", label: "Image URL" },
+    { id: "coCreators", label: "Co-creators" },
   ];
 
   for (const { id, label } of fieldChecks) {
@@ -236,7 +299,7 @@ export function buildListingChecklistItems(
       id: "prompt-length",
       label: "Full prompt seems short",
       status: "warn",
-      hint: "Buyers expect substantial prompt content — consider expanding it",
+      hint: "Buyers expect substantial prompt content â€” consider expanding it",
     });
   }
 
@@ -255,6 +318,20 @@ export function buildListingChecklistItems(
       label: "Price is very low",
       status: "warn",
       hint: "Listings under 0.5 XLM may signal low quality to buyers",
+    });
+  }
+
+  const totalRevenueSharePercent = (input.coCreators ?? []).reduce(
+    (sum, coCreator) => sum + (Number(trim(coCreator.sharePercent)) || 0),
+    0,
+  );
+
+  if (!errors.coCreators && totalRevenueSharePercent > 0) {
+    items.push({
+      id: "revenue-share",
+      label: "Revenue sharing configured",
+      status: "info",
+      hint: `${totalRevenueSharePercent.toFixed(2)}% shared across co-creators.`,
     });
   }
 

--- a/src/pages/sell/CreatePromptForm.tsx
+++ b/src/pages/sell/CreatePromptForm.tsx
@@ -33,6 +33,7 @@ import { xlmToStroops } from "@/lib/stellar/format";
 import { createPrompt } from "@/lib/stellar/promptHashClient";
 import {
   LISTING_LIMITS,
+  RevenueSplitFormInput,
   validateListingForm,
   validateEncryptedPayload,
 } from "@/lib/validation/listing";
@@ -54,6 +55,7 @@ interface FormData {
   previewText: string;
   fullPrompt: string;
   priceXlm: string;
+  coCreators: RevenueSplitFormInput[];
 }
 
 interface CreatePromptFormProps {
@@ -69,6 +71,12 @@ const createEmptyFormData = (): FormData => ({
   previewText: "",
   fullPrompt: "",
   priceXlm: "2",
+  coCreators: [],
+});
+
+const createEmptyCoCreator = (): RevenueSplitFormInput => ({
+  address: "",
+  sharePercent: "",
 });
 
 export function CreatePromptForm({ onCreated }: CreatePromptFormProps) {
@@ -107,7 +115,15 @@ export function CreatePromptForm({ onCreated }: CreatePromptFormProps) {
     [formData, offChainStorage],
   );
 
-  const checklistHasFailures = checklistItems.some((i) => i.status === "fail");`n`n  const totalRevenueSharePercent = useMemo(`n    () =>`n      formData.coCreators.reduce((total, coCreator) => {`n        const numeric = Number(coCreator.sharePercent.trim());`n        return Number.isFinite(numeric) ? total + numeric : total;`n      }, 0),`n    [formData.coCreators],`n  );
+  const checklistHasFailures = checklistItems.some((i) => i.status === "fail");
+  const totalRevenueSharePercent = useMemo(
+    () =>
+      formData.coCreators.reduce(
+        (sum, coCreator) => sum + (Number(coCreator.sharePercent.trim()) || 0),
+        0,
+      ),
+    [formData.coCreators],
+  );
 
   const clearDraft = () => {
     if (draftStorageKey) {
@@ -146,6 +162,7 @@ export function CreatePromptForm({ onCreated }: CreatePromptFormProps) {
         setFormData((current) => ({
           ...current,
           ...parsed.formData,
+          coCreators: parsed.formData.coCreators ?? current.coCreators,
         }));
         setDraftRestored(true);
         setLastSavedAt(parsed.savedAt ?? null);
@@ -203,7 +220,55 @@ export function CreatePromptForm({ onCreated }: CreatePromptFormProps) {
     });
   };
 
-  const handleCoCreatorChange = (`n    index: number,`n    field: keyof RevenueSplitFormRow,`n    value: string,`n  ) => {`n    setFormData((previous) => ({`n      ...previous,`n      coCreators: previous.coCreators.map((coCreator, rowIndex) =>`n        rowIndex === index ? { ...coCreator, [field]: value } : coCreator,`n      ),`n    }));`n    setErrors((previous) => {`n      const next = { ...previous };`n      delete next.coCreators;`n      return next;`n    });`n  };`n`n  const addCoCreator = () => {`n    setFormData((previous) => ({`n      ...previous,`n      coCreators: [...previous.coCreators, { address: "", sharePercent: "" }],`n    }));`n    setErrors((previous) => {`n      const next = { ...previous };`n      delete next.coCreators;`n      return next;`n    });`n  };`n`n  const removeCoCreator = (index: number) => {`n    setFormData((previous) => ({`n      ...previous,`n      coCreators: previous.coCreators.filter((_, rowIndex) => rowIndex !== index),`n    }));`n    setErrors((previous) => {`n      const next = { ...previous };`n      delete next.coCreators;`n      return next;`n    });`n  };`n`n  const validateForm = () => {
+  const handleCoCreatorChange = (
+    index: number,
+    field: keyof RevenueSplitFormInput,
+    value: string,
+  ) => {
+    setFormData((previous) => ({
+      ...previous,
+      coCreators: previous.coCreators.map((coCreator, currentIndex) =>
+        currentIndex === index ? { ...coCreator, [field]: value } : coCreator,
+      ),
+    }));
+    setErrors((previous) => {
+      const next = { ...previous };
+      delete next.coCreators;
+      return next;
+    });
+  };
+
+  const addCoCreator = () => {
+    setFormData((previous) => {
+      if (previous.coCreators.length >= LISTING_LIMITS.maxCoCreators) {
+        return previous;
+      }
+
+      return {
+        ...previous,
+        coCreators: [...previous.coCreators, createEmptyCoCreator()],
+      };
+    });
+    setErrors((previous) => {
+      const next = { ...previous };
+      delete next.coCreators;
+      return next;
+    });
+  };
+
+  const removeCoCreator = (index: number) => {
+    setFormData((previous) => ({
+      ...previous,
+      coCreators: previous.coCreators.filter((_, currentIndex) => currentIndex !== index),
+    }));
+    setErrors((previous) => {
+      const next = { ...previous };
+      delete next.coCreators;
+      return next;
+    });
+  };
+
+  const validateForm = () => {
     const nextErrors = validateListingForm(formData, { offChainStorage });
     setErrors(nextErrors);
     return Object.keys(nextErrors).length === 0;
@@ -277,6 +342,10 @@ export function CreatePromptForm({ onCreated }: CreatePromptFormProps) {
           wrappedKey,
           contentHash: encrypted.contentHash,
           priceStroops: xlmToStroops(formData.priceXlm),
+          splits: formData.coCreators.map((coCreator) => ({
+            recipient: coCreator.address.trim(),
+            bps: Math.round(Number(coCreator.sharePercent.trim()) * 100),
+          })),
         },
       );
 
@@ -433,6 +502,94 @@ export function CreatePromptForm({ onCreated }: CreatePromptFormProps) {
       </div>
 
       <PricingGuidance currentPriceXlm={formData.priceXlm} />
+
+      <div className="space-y-3 rounded-2xl border border-slate-800 bg-slate-950/40 p-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h3 className="text-sm font-medium text-slate-100">
+              Co-creators and revenue splits
+            </h3>
+            <p className="text-xs text-slate-400">
+              Share a portion of each sale with collaborators already supported by the contract.
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            className="gap-2"
+            onClick={addCoCreator}
+            disabled={formData.coCreators.length >= LISTING_LIMITS.maxCoCreators}
+          >
+            <Plus className="h-4 w-4" />
+            Add co-creator
+          </Button>
+        </div>
+
+        {formData.coCreators.length > 0 ? (
+          <div className="space-y-3">
+            {formData.coCreators.map((coCreator, index) => (
+              <div
+                key={`${index}-${coCreator.address}`}
+                className="grid gap-3 rounded-xl border border-slate-800/80 bg-slate-900/50 p-3 md:grid-cols-[minmax(0,1fr)_140px_auto]"
+              >
+                <div className="space-y-2">
+                  <label className="text-xs font-medium text-slate-300">
+                    Stellar address
+                  </label>
+                  <Input
+                    value={coCreator.address}
+                    onChange={(event) =>
+                      handleCoCreatorChange(index, "address", event.target.value)
+                    }
+                    autoComplete="off"
+                    placeholder="G..."
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-xs font-medium text-slate-300">
+                    Share %
+                  </label>
+                  <Input
+                    value={coCreator.sharePercent}
+                    onChange={(event) =>
+                      handleCoCreatorChange(index, "sharePercent", event.target.value)
+                    }
+                    inputMode="decimal"
+                    autoComplete="off"
+                    placeholder="15"
+                  />
+                </div>
+                <div className="flex items-end">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="px-3 text-slate-300 hover:text-white"
+                    onClick={() => removeCoCreator(index)}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-slate-400">
+            Add collaborators here when a prompt has multiple creators.
+          </p>
+        )}
+
+        <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-slate-400">
+          <span>Total shared: {totalRevenueSharePercent.toFixed(2)}%</span>
+          <span>Primary creator keeps: {Math.max(0, 100 - totalRevenueSharePercent).toFixed(2)}%</span>
+        </div>
+
+        {errors.coCreators ? (
+          <p className="flex items-center gap-1 text-sm text-red-400">
+            <AlertCircle className="h-3.5 w-3.5" />
+            {errors.coCreators}
+          </p>
+        ) : null}
+      </div>
 
       <div className="space-y-2">
         <label htmlFor="fullPrompt" className="text-sm font-medium">

--- a/src/pages/sell/CreatePromptForm.tsx
+++ b/src/pages/sell/CreatePromptForm.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { AlertCircle, Loader2 } from "lucide-react";
+import { AlertCircle, Loader2, Plus, Trash2 } from "lucide-react";
 import {
   ListingQualityChecklist,
   buildChecklistItems,
@@ -107,7 +107,7 @@ export function CreatePromptForm({ onCreated }: CreatePromptFormProps) {
     [formData, offChainStorage],
   );
 
-  const checklistHasFailures = checklistItems.some((i) => i.status === "fail");
+  const checklistHasFailures = checklistItems.some((i) => i.status === "fail");`n`n  const totalRevenueSharePercent = useMemo(`n    () =>`n      formData.coCreators.reduce((total, coCreator) => {`n        const numeric = Number(coCreator.sharePercent.trim());`n        return Number.isFinite(numeric) ? total + numeric : total;`n      }, 0),`n    [formData.coCreators],`n  );
 
   const clearDraft = () => {
     if (draftStorageKey) {
@@ -203,7 +203,7 @@ export function CreatePromptForm({ onCreated }: CreatePromptFormProps) {
     });
   };
 
-  const validateForm = () => {
+  const handleCoCreatorChange = (`n    index: number,`n    field: keyof RevenueSplitFormRow,`n    value: string,`n  ) => {`n    setFormData((previous) => ({`n      ...previous,`n      coCreators: previous.coCreators.map((coCreator, rowIndex) =>`n        rowIndex === index ? { ...coCreator, [field]: value } : coCreator,`n      ),`n    }));`n    setErrors((previous) => {`n      const next = { ...previous };`n      delete next.coCreators;`n      return next;`n    });`n  };`n`n  const addCoCreator = () => {`n    setFormData((previous) => ({`n      ...previous,`n      coCreators: [...previous.coCreators, { address: "", sharePercent: "" }],`n    }));`n    setErrors((previous) => {`n      const next = { ...previous };`n      delete next.coCreators;`n      return next;`n    });`n  };`n`n  const removeCoCreator = (index: number) => {`n    setFormData((previous) => ({`n      ...previous,`n      coCreators: previous.coCreators.filter((_, rowIndex) => rowIndex !== index),`n    }));`n    setErrors((previous) => {`n      const next = { ...previous };`n      delete next.coCreators;`n      return next;`n    });`n  };`n`n  const validateForm = () => {
     const nextErrors = validateListingForm(formData, { offChainStorage });
     setErrors(nextErrors);
     return Object.keys(nextErrors).length === 0;


### PR DESCRIPTION
## Summary
This PR wires the existing revenue-sharing contract support into the seller listing flow so creators can configure co-creator splits directly from the frontend when publishing a prompt.

## What changed
- added typed CreatePromptInput and RevenueSplitInput payload support in the Prompt Hash client mock so the UI can submit split data cleanly
- extended listing validation to support co-creator entries, including duplicate-address checks, Stellar public key validation, positive percentage validation, contributor count limits, and a 95% total split ceiling
- updated the create prompt form with co-creator management UI, add/remove controls, live revenue share totals, and submission wiring for split basis points
- preserved the current no-install, no-test workflow and left unrelated CI state untouched, as requested

## Why this helps
The contract already supports creator splits, but the listing flow did not expose that capability to users. This change closes that gap by letting prompt authors configure collaborators at creation time, reducing manual follow-up and making the feature actually reachable from the product surface.

## Notes
- not run locally per request
- CI was not addressed in this PR

Closes #288
Closes #287
Closes #282
Closes #281
