### PR TITLE
feat(payments): implement XLM payment gateway for prompt purchases

### DIFF
--- a/src/lib/payments/xlmGateway.test.ts
+++ b/src/lib/payments/xlmGateway.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  submitXlmPromptPayment,
+  buildXlmPromptPaymentArgs,
+  type XlmPaymentStatusUpdate,
+} from "./xlmGateway";
+import { prepareContractCall } from "@/lib/stellar/tx";
+import { Api } from "@stellar/stellar-sdk/rpc";
+
+vi.mock("@stellar/stellar-sdk", () => ({
+  TransactionBuilder: {
+    fromXDR: vi.fn(() => ({ signed: true })),
+  },
+}));
+
+vi.mock("@stellar/stellar-sdk/rpc", () => ({
+  Api: {
+    GetTransactionStatus: {
+      SUCCESS: "SUCCESS",
+      FAILED: "FAILED",
+      NOT_FOUND: "NOT_FOUND",
+    },
+  },
+}));
+
+vi.mock("@/lib/stellar/tx", () => ({
+  scValArg: vi.fn((value: unknown, type?: string) => ({ value, type })),
+  prepareContractCall: vi.fn(),
+}));
+
+const config = {
+  rpcUrl: "https://stellar.test/rpc",
+  networkPassphrase: "Test SDF Network ; September 2015",
+  promptHashContractId: "CPROMPTHASH",
+};
+
+const signer = {
+  signTransaction: vi.fn(),
+};
+
+function mockPrepared(pollStatus: string = Api.GetTransactionStatus.SUCCESS) {
+  const server = {
+    sendTransaction: vi.fn().mockResolvedValue({
+      status: "PENDING",
+      hash: "abc123",
+    }),
+    pollTransaction: vi.fn().mockResolvedValue({
+      status: pollStatus,
+      resultXdr: { toXDR: () => "failed-xdr" },
+    }),
+  };
+
+  vi.mocked(prepareContractCall).mockResolvedValue({
+    preparedTransaction: { toXDR: () => "prepared-xdr" } as any,
+    simulation: {} as any,
+    server: server as any,
+  });
+
+  return server;
+}
+
+describe("XLM prompt payment gateway", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    signer.signTransaction.mockResolvedValue({ signedTxXdr: "signed-xdr" });
+  });
+
+  it("builds the buy_prompt payment args with native XLM stroops", () => {
+    expect(
+      buildXlmPromptPaymentArgs({
+        config,
+        signer,
+        buyerAddress: "GBUYER",
+        promptId: "42",
+        amountStroops: 50_0000000n,
+      }),
+    ).toEqual([
+      { value: "GBUYER", type: "address" },
+      { value: 42n, type: "u64" },
+      { value: null, type: undefined },
+      { value: 50_0000000n, type: "i128" },
+      { value: null, type: undefined },
+    ]);
+  });
+
+  it("submits and confirms a successful XLM payment", async () => {
+    const server = mockPrepared();
+    const statuses: XlmPaymentStatusUpdate[] = [];
+
+    const result = await submitXlmPromptPayment({
+      config,
+      signer,
+      buyerAddress: "GBUYER",
+      promptId: 7n,
+      amountStroops: 12_0000000n,
+      onStatus: (update) => statuses.push(update),
+    });
+
+    expect(prepareContractCall).toHaveBeenCalledWith(
+      config,
+      "GBUYER",
+      "CPROMPTHASH",
+      "buy_prompt",
+      expect.any(Array),
+    );
+    expect(signer.signTransaction).toHaveBeenCalledWith("prepared-xdr", {
+      address: "GBUYER",
+      networkPassphrase: config.networkPassphrase,
+    });
+    expect(server.sendTransaction).toHaveBeenCalledTimes(1);
+    expect(server.pollTransaction).toHaveBeenCalledWith(
+      "abc123",
+      expect.any(Object),
+    );
+    expect(result).toEqual({
+      txHash: "abc123",
+      success: true,
+      status: "confirmed",
+    });
+    expect(statuses.map((update) => update.status)).toEqual([
+      "awaiting_approval",
+      "submitting",
+      "pending",
+      "confirmed",
+    ]);
+  });
+
+  it("surfaces failed Stellar confirmations", async () => {
+    mockPrepared(Api.GetTransactionStatus.FAILED);
+    const statuses: XlmPaymentStatusUpdate[] = [];
+
+    await expect(
+      submitXlmPromptPayment({
+        config,
+        signer,
+        buyerAddress: "GBUYER",
+        promptId: 7n,
+        amountStroops: 12_0000000n,
+        onStatus: (update) => statuses.push(update),
+      }),
+    ).rejects.toThrow(/Transaction failed/);
+
+    expect(statuses.map((update) => update.status)).toContain("failed");
+  });
+
+  it("surfaces still-pending confirmations to the caller", async () => {
+    mockPrepared(Api.GetTransactionStatus.NOT_FOUND);
+    const statuses: XlmPaymentStatusUpdate[] = [];
+
+    await expect(
+      submitXlmPromptPayment({
+        config,
+        signer,
+        buyerAddress: "GBUYER",
+        promptId: 7n,
+        amountStroops: 12_0000000n,
+        onStatus: (update) => statuses.push(update),
+      }),
+    ).rejects.toThrow(/still pending/);
+
+    expect(statuses[statuses.length - 1]).toMatchObject({
+      status: "pending",
+      txHash: "abc123",
+    });
+  });
+});

--- a/src/lib/payments/xlmGateway.ts
+++ b/src/lib/payments/xlmGateway.ts
@@ -1,0 +1,172 @@
+import { TransactionBuilder } from "@stellar/stellar-sdk";
+import { Api } from "@stellar/stellar-sdk/rpc";
+import {
+  prepareContractCall,
+  scValArg,
+  type StellarNetworkConfig,
+  type WalletTransactionSigner,
+} from "@/lib/stellar/tx";
+
+export type XlmPaymentStatus =
+  | "awaiting_approval"
+  | "submitting"
+  | "pending"
+  | "confirmed"
+  | "failed";
+
+export interface XlmPaymentStatusUpdate {
+  status: XlmPaymentStatus;
+  message: string;
+  txHash?: string;
+}
+
+export interface XlmPromptPaymentRequest {
+  config: StellarNetworkConfig & { promptHashContractId: string };
+  signer: WalletTransactionSigner;
+  buyerAddress: string;
+  promptId: string | bigint | number;
+  amountStroops: string | bigint | number;
+  referrer?: string | null;
+  onStatus?: (_update: XlmPaymentStatusUpdate) => void;
+}
+
+export interface XlmPromptPaymentResult {
+  txHash: string;
+  success: true;
+  status: "confirmed";
+}
+
+const POLL_ATTEMPTS = 20;
+
+function normalizePositiveBigInt(
+  value: string | bigint | number,
+  label: string,
+): bigint {
+  const normalized = BigInt(value);
+  if (normalized <= 0n) {
+    throw new Error(`${label} must be greater than zero.`);
+  }
+  return normalized;
+}
+
+function emit(
+  onStatus: XlmPromptPaymentRequest["onStatus"],
+  update: XlmPaymentStatusUpdate,
+) {
+  onStatus?.(update);
+}
+
+export function buildXlmPromptPaymentArgs(request: XlmPromptPaymentRequest) {
+  const promptId = normalizePositiveBigInt(request.promptId, "promptId");
+  const amount = normalizePositiveBigInt(
+    request.amountStroops,
+    "amountStroops",
+  );
+
+  return [
+    scValArg(request.buyerAddress, "address"),
+    scValArg(promptId, "u64"),
+    request.referrer ? scValArg(request.referrer, "address") : scValArg(null),
+    scValArg(amount, "i128"),
+    scValArg(null),
+  ];
+}
+
+export async function submitXlmPromptPayment(
+  request: XlmPromptPaymentRequest,
+): Promise<XlmPromptPaymentResult> {
+  const args = buildXlmPromptPaymentArgs(request);
+
+  emit(request.onStatus, {
+    status: "awaiting_approval",
+    message: "Review and approve the XLM payment in your wallet.",
+  });
+
+  const prepared = await prepareContractCall(
+    request.config,
+    request.buyerAddress,
+    request.config.promptHashContractId,
+    "buy_prompt",
+    args,
+  );
+
+  const signed = await request.signer.signTransaction(
+    prepared.preparedTransaction.toXDR(),
+    {
+      address: request.buyerAddress,
+      networkPassphrase: request.config.networkPassphrase,
+    },
+  );
+
+  emit(request.onStatus, {
+    status: "submitting",
+    message: "Submitting XLM payment to Stellar.",
+  });
+
+  const signedTransaction = TransactionBuilder.fromXDR(
+    signed.signedTxXdr,
+    request.config.networkPassphrase,
+  );
+  const submission = await prepared.server.sendTransaction(signedTransaction);
+
+  if (submission.status === "TRY_AGAIN_LATER") {
+    emit(request.onStatus, {
+      status: "failed",
+      message: "Stellar RPC asked the payment to retry later.",
+    });
+    throw new Error("The Stellar RPC asked the client to retry later.");
+  }
+
+  if (submission.status === "ERROR") {
+    const details = submission.errorResult?.toXDR("base64");
+    emit(request.onStatus, {
+      status: "failed",
+      message: "XLM payment submission failed.",
+    });
+    throw new Error(
+      details
+        ? `Transaction submission failed: ${details}`
+        : "Transaction submission failed.",
+    );
+  }
+
+  emit(request.onStatus, {
+    status: "pending",
+    message: "XLM payment submitted. Waiting for ledger confirmation.",
+    txHash: submission.hash,
+  });
+
+  const result = await prepared.server.pollTransaction(submission.hash, {
+    attempts: POLL_ATTEMPTS,
+    sleepStrategy: () => 1_000,
+  });
+
+  if (result.status === Api.GetTransactionStatus.SUCCESS) {
+    emit(request.onStatus, {
+      status: "confirmed",
+      message: "XLM payment confirmed. Unlocking your prompt.",
+      txHash: submission.hash,
+    });
+    return {
+      txHash: submission.hash,
+      success: true,
+      status: "confirmed",
+    };
+  }
+
+  if (result.status === Api.GetTransactionStatus.FAILED) {
+    emit(request.onStatus, {
+      status: "failed",
+      message: "XLM payment failed on Stellar.",
+      txHash: submission.hash,
+    });
+    throw new Error(`Transaction failed: ${result.resultXdr.toXDR("base64")}`);
+  }
+
+  emit(request.onStatus, {
+    status: "pending",
+    message: "XLM payment is still pending confirmation.",
+    txHash: submission.hash,
+  });
+  throw new Error("Transaction is still pending confirmation.");
+}

--- a/src/pages/browse/PromptModal.tsx
+++ b/src/pages/browse/PromptModal.tsx
@@ -61,6 +61,7 @@ import { stroopsToXlmString } from "../../lib/stellar/format";
 import { NetworkMismatchBanner } from "../../components/wallet/NetworkMismatchBanner";
 import { detectNetworkMismatch } from "../../lib/wallet/networkDetection";
 import { mapWalletError, type MappedWalletError } from "../../lib/stellar/tx";
+import { submitXlmPromptPayment, type XlmPaymentStatusUpdate } from "../../lib/payments/xlmGateway";
 
 export type BuyerStatus =
   | "IDLE"
@@ -255,6 +256,7 @@ export const PromptModal: React.FC<PromptModalProps> = ({
 
   const [status, setStatus] = useState<BuyerStatus>("IDLE");
   const [txHash, setTxHash] = useState<string>("");
+  const [paymentMessage, setPaymentMessage] = useState<string>("");
   const [secretContent, setSecretContent] = useState<string>("");
   const [isCheckingAccess, setIsCheckingAccess] = useState(false);
   const [showReviewForm, setShowReviewForm] = useState(false);
@@ -334,7 +336,7 @@ export const PromptModal: React.FC<PromptModalProps> = ({
   useEffect(() => {
     if (isOpen && wallet?.address) {
       setIsCheckingAccess(true);
-      PromptHashClient.checkAccess(itemId, wallet.address)
+      PromptHashClient.checkAccess(browserStellarConfig, wallet.address, itemId)
         .then((hasAccess) => setStatus(hasAccess ? "PURCHASED_LOCKED" : "IDLE"))
         .catch(() => setStatus("IDLE"))
         .finally(() => setIsCheckingAccess(false));
@@ -382,18 +384,42 @@ export const PromptModal: React.FC<PromptModalProps> = ({
       if (networkState.type === "disconnected") {
         throw new Error("Please connect your wallet first");
       }
-      
-      setStatus("AWAITING_APPROVAL");
-      const mockHash = "tx_" + Math.random().toString(16).slice(2, 14);
-      setTxHash(mockHash);
-      setStatus("CONFIRMING");
-      return await PromptHashClient.purchasePrompt(itemId, wallet.address);
+
+      if (!wallet.signTransaction) {
+        throw new Error("Wallet does not support transaction signing.");
+      }
+
+      const prompt = promptDetail ?? await PromptHashClient.getPrompt(browserStellarConfig, BigInt(itemId));
+      const handleStatus = (update: XlmPaymentStatusUpdate) => {
+        setPaymentMessage(update.message);
+        if (update.txHash) {
+          setTxHash(update.txHash);
+        }
+        if (update.status === "awaiting_approval") {
+          setStatus("AWAITING_APPROVAL");
+        } else if (update.status === "submitting" || update.status === "pending") {
+          setStatus("CONFIRMING");
+        } else if (update.status === "failed") {
+          setStatus("ERROR");
+        }
+      };
+
+      return await submitXlmPromptPayment({
+        config: browserStellarConfig,
+        signer: { signTransaction: wallet.signTransaction },
+        buyerAddress: wallet.address,
+        promptId: itemId,
+        amountStroops: prompt.priceStroops,
+        onStatus: handleStatus,
+      });
     },
     {
+      pendingMessage: "Preparing XLM payment...",
+      successMessage: "XLM payment confirmed.",
       onSuccess: (data) => {
         setStatus("UNLOCKING");
         onRefresh?.();
-        runUnlock(data.txHash || txHash).catch(() => {});
+        runUnlock(data.txHash).catch(() => {});
       },
       onError: () => setStatus("ERROR"),
     },
@@ -522,6 +548,9 @@ export const PromptModal: React.FC<PromptModalProps> = ({
                   <p className="text-slate-200 font-bold text-lg italic tracking-tight">
                     Confirming in Wallet...
                   </p>
+                  {paymentMessage && (
+                    <p className="max-w-sm text-xs text-slate-400">{paymentMessage}</p>
+                  )}
                 </div>
               )}
 
@@ -529,7 +558,7 @@ export const PromptModal: React.FC<PromptModalProps> = ({
                 <div className="py-6 text-center" role="status" aria-live="polite">
                   <StatusBanner
                     status="pending"
-                    message="Broadcasting to Stellar..."
+                    message={paymentMessage || "Broadcasting XLM payment to Stellar..."}
                   />
                   {txHash && (
                     <a

--- a/src/test/wallet/PurchaseButton.test.tsx
+++ b/src/test/wallet/PurchaseButton.test.tsx
@@ -1,27 +1,32 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { screen, waitFor, within } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "../render";
 import { PromptModal } from "@/pages/browse/PromptModal";
 import type { WalletContextType } from "@/providers/WalletProvider";
 import { PromptHashClient } from "@/lib/stellar/promptHashClient";
+import { submitXlmPromptPayment } from "@/lib/payments/xlmGateway";
 
 // Preserves module boundaries and provides all necessary configuration keys
 vi.mock("@/lib/env", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/env")>();
   return {
     ...actual,
-    stellarWalletNetwork: "Test SDF Network ; September 2015",
-    rpcUrl: "https://soroban-testnet.stellar.org",
-    networkPassphrase: "Test SDF Network ; September 2015",
     allowHttp: false,
-    promptHashContractId: "CCONTRACTMOCKADDRESS1234567890ABCDEF",
+    nativeAssetContractId: "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+    networkPassphrase: "Test SDF Network ; September 2015",
+    promptHashContractId: "CPROMPTHASH",
+    rpcUrl: "https://soroban-testnet.stellar.org",
+    simulationAccount: "GSIMULATION",
+    stellarWalletNetwork: "Test SDF Network ; September 2015",
     browserStellarConfig: {
-      stellarWalletNetwork: "Test SDF Network ; September 2015",
-      rpcUrl: "https://soroban-testnet.stellar.org",
-      networkPassphrase: "Test SDF Network ; September 2015",
       allowHttp: false,
-      promptHashContractId: "CCONTRACTMOCKADDRESS1234567890ABCDEF",
+      nativeAssetContractId: "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+      networkPassphrase: "Test SDF Network ; September 2015",
+      promptHashContractId: "CPROMPTHASH",
+      rpcUrl: "https://soroban-testnet.stellar.org",
+      simulationAccount: "GSIMULATION",
+      stellarWalletNetwork: "Test SDF Network ; September 2015",
     },
   };
 });
@@ -38,6 +43,10 @@ vi.mock("@/lib/stellar/promptHashClient", () => ({
 // Mock unlock function
 vi.mock("@/lib/prompts/unlock", () => ({
   unlockPrompt: vi.fn(),
+}));
+
+vi.mock("@/lib/payments/xlmGateway", () => ({
+  submitXlmPromptPayment: vi.fn(),
 }));
 
 // Mock review client
@@ -68,6 +77,11 @@ describe("Purchase Button States", () => {
     vi.clearAllMocks();
     vi.mocked(PromptHashClient.checkAccess).mockResolvedValue(false);
     vi.mocked(PromptHashClient.getPrompt).mockResolvedValue(mockPrompt);
+    vi.mocked(submitXlmPromptPayment).mockResolvedValue({
+      txHash: "test",
+      success: true,
+      status: "confirmed",
+    });
   });
 
   it("disables purchase button when wallet is disconnected", async () => {
@@ -96,6 +110,7 @@ describe("Purchase Button States", () => {
       network: "Test SDF Network ; September 2015",
       connect: vi.fn(),
       disconnect: vi.fn(),
+      signTransaction: vi.fn(),
       signMessage: vi.fn(),
       networkCompatibility: { compatible: true } as any,
     };
@@ -118,15 +133,19 @@ describe("Purchase Button States", () => {
       network: "Test SDF Network ; September 2015",
       connect: vi.fn(),
       disconnect: vi.fn(),
+      signTransaction: vi.fn(),
       signMessage: vi.fn(),
       networkCompatibility: { compatible: true } as any,
     };
 
-    vi.mocked(PromptHashClient.purchasePrompt).mockImplementation(
-      () =>
-        new Promise((resolve) =>
-          setTimeout(() => resolve({ txHash: "test", success: true }), 100),
-        ),
+    vi.mocked(submitXlmPromptPayment).mockImplementation(
+      ({ onStatus }) => new Promise((resolve) => {
+        onStatus?.({
+          status: "awaiting_approval",
+          message: "Review and approve the XLM payment in your wallet.",
+        });
+        setTimeout(() => resolve({ txHash: "test", success: true, status: "confirmed" }), 100);
+      })
     );
 
     renderWithProviders(
@@ -134,11 +153,15 @@ describe("Purchase Button States", () => {
       { wallet: mockWallet },
     );
 
-    const dialog = await screen.findByRole("dialog");
-    
-    // Fallback click simulation to jump straight across lifecycle updates safely
     await waitFor(() => {
-      expect(within(dialog).getByText(/Acquire License/i)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /confirm & purchase/i })).toBeInTheDocument();
+    });
+
+    const purchaseButton = screen.getByRole("button", { name: /confirm & purchase/i });
+    await user.click(purchaseButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Confirming in Wallet/i)).toBeInTheDocument();
     });
   });
 
@@ -150,12 +173,13 @@ describe("Purchase Button States", () => {
       network: "Test SDF Network ; September 2015",
       connect: vi.fn(),
       disconnect: vi.fn(),
+      signTransaction: vi.fn(),
       signMessage: vi.fn(),
       networkCompatibility: { compatible: true } as any,
     };
 
-    vi.mocked(PromptHashClient.purchasePrompt).mockRejectedValue(
-      new Error("Insufficient XLM balance"),
+    vi.mocked(submitXlmPromptPayment).mockRejectedValue(
+      new Error("Insufficient XLM balance")
     );
 
     renderWithProviders(
@@ -163,9 +187,15 @@ describe("Purchase Button States", () => {
       { wallet: mockWallet },
     );
 
-    const dialog = await screen.findByRole("dialog");
     await waitFor(() => {
-      expect(within(dialog).getByText(/Acquire License/i)).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /confirm & purchase/i })).toBeInTheDocument();
+    });
+
+    const purchaseButton = screen.getByRole("button", { name: /confirm & purchase/i });
+    await user.click(purchaseButton);
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/does not have enough XLM/i).length).toBeGreaterThan(0);
     });
   });
 
@@ -176,6 +206,7 @@ describe("Purchase Button States", () => {
       network: "PUBLIC",
       connect: vi.fn(),
       disconnect: vi.fn(),
+      signTransaction: vi.fn(),
       signMessage: vi.fn(),
       networkCompatibility: { compatible: true } as any,
     };
@@ -197,6 +228,7 @@ describe("Purchase Button States", () => {
       network: "Test SDF Network ; September 2015",
       connect: vi.fn(),
       disconnect: vi.fn(),
+      signTransaction: vi.fn(),
       signMessage: vi.fn(),
       networkCompatibility: { compatible: true } as any,
     };


### PR DESCRIPTION
Closes #298
What was done
Implemented an XLM payment gateway allowing users to pay for prompts directly using Stellar Lumens, with wallet signing and live status updates.
Changes

XLM gateway — new xlmGateway.ts prepares buy_prompt, signs via wallet, submits to Stellar RPC, polls for confirmation, and emits pending/confirmed/failed status events
Prompt modal integration — PromptModal.tsx wired to use the gateway and surface real-time payment status to the user
Tests — added success/failure/pending coverage for the gateway, plus updated modal payment tests

Test results

Gateway and purchase button tests passing ✅

Notes

Typecheck has pre-existing unrelated failures in the repo (missing @vercel/node, mongoose, ./ui/dialog, next/router, and existing TS errors in validation/sell/browse files) — none introduced by this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an XLM prompt purchase flow with live payment progress updates (approval, submitting, pending, confirmed).
  * Wallet confirmation now shows real-time payment status messages during checkout.

* **Bug Fixes**
  * Improved handling and user-facing feedback for failed and still-pending Stellar transactions.
  * Updated the prompt access/purchase checks to align with the latest Stellar payment flow.

* **Tests**
  * Added automated coverage for confirmed, failed, and pending XLM payment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->