### PR TITLE
feat(prompts): redesign prompt detail page with licensing sidebar and XLM purchase flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,15 @@ CHALLENGE_TOKEN_SECRET=super-secret-challenge-token-string
 UNLOCK_PUBLIC_KEY=ZHVtbXktcHVibGljLWtleS12YWx1ZS1oZXJl
 UNLOCK_PRIVATE_KEY=ZHVtbXktcHJpdmF0ZS1rZXktdmFsdWUtaGVyZQ==
 
+# Server-only JWT session runtime. Keep these out of browser-exposed PUBLIC_ vars.
+# JWT_SESSION_SECRET signs wallet session JWTs after Stellar wallet auth.
+# JWT_SESSION_ISSUER and JWT_SESSION_AUDIENCE bind tokens to this app.
+# JWT_SESSION_TTL_SECONDS controls how long a wallet session remains valid.
+JWT_SESSION_SECRET=replace-with-32-byte-random-secret
+JWT_SESSION_ISSUER=prompt-hash-stellar
+JWT_SESSION_AUDIENCE=prompt-hash-stellar-web
+JWT_SESSION_TTL_SECONDS=86400
+
 # Optional — unlock service rotation (see docs/secret-rotation.md)
 # ADMIN_ROTATION_TOKEN=
 # CHALLENGE_TOKEN_SECRET_PREVIOUS=

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -82,6 +82,18 @@ yarn dev
 | `UNLOCK_PUBLIC_KEY` | Yes | Must match `PUBLIC_UNLOCK_PUBLIC_KEY` |
 | `UNLOCK_PRIVATE_KEY` | Yes | Base64 private key for unwrap |
 
+### Serverless JWT sessions
+
+These variables are server-only. Never prefix them with `PUBLIC_` and never
+ship them to the browser bundle.
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| `JWT_SESSION_SECRET` | Yes, when wallet sessions are enabled | 32+ byte random secret used to sign session JWTs |
+| `JWT_SESSION_ISSUER` | Recommended | Stable issuer, for example `prompt-hash-stellar` |
+| `JWT_SESSION_AUDIENCE` | Recommended | Expected client audience, for example `prompt-hash-stellar-web` |
+| `JWT_SESSION_TTL_SECONDS` | Recommended | Session lifetime in seconds; default local example is `86400` |
+
 ### Contract tooling
 
 | Variable / file | Required | Notes |

--- a/src/lib/stellar/promptHashClient.ts
+++ b/src/lib/stellar/promptHashClient.ts
@@ -1,16 +1,21 @@
-/**
- * WARNING: MOCK CONTRACT IMPLEMENTATION
- * This file currently stubs all on-chain reads/writes with mock data.
- * This should NOT reach production.
- * TODO: Restore real Soroban contract integration before release.
- */
+import { xdr } from "@stellar/stellar-sdk";
 import { Server } from "@stellar/stellar-sdk/rpc";
+import { approveNativeAssetSpend } from "./nativeAssetClient";
+import {
+  getRpcServer,
+  prepareContractCall,
+  readContract,
+  scValArg,
+  submitPreparedTransaction,
+  type WalletTransactionSigner,
+} from "./tx";
 
 let hasWarnedMock = false;
 const warnMockUse = () => {
   if (hasWarnedMock) return;
   console.warn(
     "⚠️ USING MOCK PromptHashClient: Contract calls are currently stubbed and will not hit the Stellar network.",
+    "Using mock PromptHashClient data because contract configuration is incomplete.",
   );
   hasWarnedMock = true;
 };
@@ -24,7 +29,6 @@ export interface PromptHashConfig {
   simulationAccount?: string;
 }
 
-// Added the missing interface required by the UI
 export interface PromptRecord {
   id: bigint;
   creator: string;
@@ -41,6 +45,10 @@ export interface PromptRecord {
   encryptedPrompt?: string;
   encryptionIv?: string;
   wrappedKey?: string;
+  revision?: number;
+  maxSupply?: number;
+  expiresAt?: number;
+  asset?: string;
 }
 
 export interface RevenueSplitInput {
@@ -61,50 +69,241 @@ export interface CreatePromptInput {
   splits?: RevenueSplitInput[];
 }
 
+export interface PurchasePromptOptions {
+  config?: PromptHashConfig;
+  signer?: WalletTransactionSigner;
+  forceFailure?: string;
+  delay?: number;
+}
+
+export interface PurchasePromptResult {
+  txHash: string;
+  approvalTxHash?: string;
+  success: boolean;
+  confirmedAtLedger?: number;
+}
+
+type ContractPrompt = Record<string, unknown>;
+
+function isContractReady(config: PromptHashConfig): boolean {
+  return Boolean(
+    config.rpcUrl &&
+      config.promptHashContractId &&
+      config.nativeAssetContractId &&
+      config.simulationAccount,
+  );
+}
+
+function readField<T>(value: ContractPrompt, key: string, fallback: T): unknown {
+  return Object.prototype.hasOwnProperty.call(value, key) ? value[key] : fallback;
+}
+
+function optionalString(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  return String(value);
+}
+
+function normalizeTags(value: unknown): string[] {
+  return Array.isArray(value) ? value.map(String) : [];
+}
+
+function normalizeHash(value: unknown): string {
+  if (value && typeof value === "object" && "toString" in value) {
+    return String(value);
+  }
+  return String(value ?? "");
+}
+
+function normalizePrompt(prompt: ContractPrompt): PromptRecord {
+  return {
+    id: BigInt(String(readField(prompt, "id", 0))),
+    creator: String(readField(prompt, "creator", "")),
+    priceStroops: BigInt(
+      String(readField(prompt, "price_stroops", readField(prompt, "priceStroops", 0))),
+    ),
+    title: String(readField(prompt, "title", "Untitled prompt")),
+    category: String(readField(prompt, "category", "General")),
+    previewText: String(
+      readField(prompt, "preview_text", readField(prompt, "previewText", "")),
+    ),
+    description: optionalString(readField(prompt, "description", undefined)),
+    tags: normalizeTags(readField(prompt, "tags", [])),
+    imageUrl: String(
+      readField(prompt, "image_url", readField(prompt, "imageUrl", "")),
+    ),
+    salesCount: Number(
+      readField(prompt, "sales_count", readField(prompt, "salesCount", 0)),
+    ),
+    active: Boolean(readField(prompt, "active", true)),
+    contentHash: normalizeHash(
+      readField(prompt, "content_hash", readField(prompt, "contentHash", "")),
+    ),
+    encryptedPrompt: optionalString(
+      readField(
+        prompt,
+        "encrypted_prompt",
+        readField(prompt, "encryptedPrompt", undefined),
+      ),
+    ),
+    encryptionIv: optionalString(
+      readField(prompt, "encryption_iv", readField(prompt, "encryptionIv", undefined)),
+    ),
+    wrappedKey: optionalString(
+      readField(prompt, "wrapped_key", readField(prompt, "wrappedKey", undefined)),
+    ),
+    revision: Number(readField(prompt, "revision", 0)),
+    maxSupply: Number(
+      readField(prompt, "max_supply", readField(prompt, "maxSupply", 0)),
+    ),
+    expiresAt: Number(
+      readField(prompt, "expires_at", readField(prompt, "expiresAt", 0)),
+    ),
+    asset: optionalString(readField(prompt, "asset", undefined)),
+  };
+}
+
+const mockPrompts: PromptRecord[] = [
+  {
+    id: 1n,
+    creator: "GD...1234",
+    priceStroops: 50_0000000n,
+    title: "GPT-4 Technical Architect",
+    category: "Development",
+    previewText:
+      "A high-performance prompt for generating system design documents.",
+    description:
+      "A full prompt designed to help architects craft scalable system blueprints and integration plans.",
+    tags: ["AI", "Architecture"],
+    imageUrl: "",
+    salesCount: 12,
+    active: true,
+    contentHash: "mock_hash_000000000001",
+    revision: 0,
+  },
+  {
+    id: 2n,
+    creator: "GB...5678",
+    priceStroops: 120_0000000n,
+    title: "Creative Storyteller Pro",
+    category: "Creative",
+    previewText:
+      "Unlock deep narrative structures and character development.",
+    description:
+      "A storytelling prompt built to help craft plot outlines, characters, and emotional arcs for long-form fiction.",
+    tags: ["Storytelling", "Creative"],
+    imageUrl: "",
+    salesCount: 45,
+    active: true,
+    contentHash: "mock_hash_000000000002",
+    revision: 0,
+  },
+];
+
 export class PromptHashClient {
-  /**
-   * Checks if the user already has access to the prompt.
-   */
   static async checkAccess(
-    _config: PromptHashConfig | string,
-    _address: string,
-    _itemId?: string | bigint,
+    configOrItemId: PromptHashConfig | string,
+    address: string,
+    itemId?: string | bigint,
   ): Promise<boolean> {
-    warnMockUse();
-    return new Promise((resolve) => {
-      setTimeout(() => resolve(false), 1000);
-    });
+    const config =
+      typeof configOrItemId === "string" ? undefined : configOrItemId;
+    const promptId = typeof configOrItemId === "string" ? configOrItemId : itemId;
+
+    if (!config || !isContractReady(config) || !promptId) {
+      warnMockUse();
+      return new Promise((resolve) => {
+        setTimeout(() => resolve(false), 250);
+      });
+    }
+
+    return readContract<boolean>(
+      config,
+      config.promptHashContractId,
+      "has_access",
+      [scValArg(address, "address"), scValArg(BigInt(promptId), "u64")],
+    );
   }
 
   static async getPrompt(
-    _config: PromptHashConfig,
+    config: PromptHashConfig,
     promptId: bigint,
   ): Promise<PromptRecord> {
+    if (isContractReady(config)) {
+      const prompt = await readContract<ContractPrompt>(
+        config,
+        config.promptHashContractId,
+        "get_prompt",
+        [scValArg(promptId, "u64")],
+      );
+      return normalizePrompt(prompt);
+    }
+
     warnMockUse();
-    const prompts = await PromptHashClient.getAllPrompts(_config);
-    const match = prompts.find((p) => p.id === promptId);
+    const match = mockPrompts.find((p) => p.id === promptId);
     if (!match) {
       throw new Error(`Prompt #${promptId.toString()} not found.`);
     }
     return match;
   }
 
-  /**
-   * Invokes the Soroban contract to purchase a prompt.
-   */
   static async purchasePrompt(
-    _itemId: string,
-    _userAddress: string,
-    options?: { forceFailure?: string; delay?: number },
-  ): Promise<{ txHash: string; success: boolean }> {
+    itemId: string,
+    userAddress: string,
+    options?: PurchasePromptOptions,
+  ): Promise<PurchasePromptResult> {
+    if (options?.forceFailure) {
+      throw new Error(options.forceFailure);
+    }
+
+    if (options?.config && options.signer && isContractReady(options.config)) {
+      const config = options.config;
+      const prompt = await PromptHashClient.getPrompt(config, BigInt(itemId));
+      const amount = prompt.priceStroops;
+      const server = getRpcServer(config);
+      const latestLedger = await server.getLatestLedger();
+      const expirationLedger = Number(latestLedger.sequence) + 1200;
+
+      const approval = await approveNativeAssetSpend(
+        config,
+        options.signer,
+        userAddress,
+        config.promptHashContractId,
+        amount,
+        expirationLedger,
+      );
+
+      const prepared = await prepareContractCall(
+        config,
+        userAddress,
+        config.promptHashContractId,
+        "buy_prompt",
+        [
+          scValArg(userAddress, "address"),
+          scValArg(BigInt(itemId), "u64"),
+          xdr.ScVal.scvVoid(),
+          scValArg(amount, "i128"),
+          xdr.ScVal.scvVoid(),
+        ],
+      );
+      const purchase = await submitPreparedTransaction(
+        config,
+        prepared,
+        options.signer,
+        userAddress,
+      );
+
+      return {
+        txHash: purchase.txHash,
+        approvalTxHash: approval.txHash,
+        success: true,
+        confirmedAtLedger: purchase.ledger,
+      };
+    }
+
     warnMockUse();
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       const delay = options?.delay ?? 2000;
       setTimeout(() => {
-        if (options?.forceFailure) {
-          return reject(new Error(options.forceFailure));
-        }
-
         const mockHash =
           "tx_" + Math.random().toString(16).slice(2, 14).padStart(12, "0");
         resolve({ txHash: mockHash, success: true });
@@ -113,65 +312,58 @@ export class PromptHashClient {
   }
 
   static async getAllPrompts(
-    _config: PromptHashConfig,
+    config: PromptHashConfig,
   ): Promise<PromptRecord[]> {
+    if (isContractReady(config)) {
+      const prompts = await readContract<ContractPrompt[]>(
+        config,
+        config.promptHashContractId,
+        "get_all_prompts",
+      );
+      return prompts.map(normalizePrompt);
+    }
+
     warnMockUse();
-    // Returning mock data so the Browse page isn't empty
-    return [
-      {
-        id: 1n,
-        creator: "GD...1234",
-        priceStroops: 50000000n, // 5 XLM
-        title: "GPT-4 Technical Architect",
-        category: "Development",
-        previewText:
-          "A high-performance prompt for generating system design documents...",
-        description:
-          "A full prompt designed to help architects craft scalable system blueprints and integration plans.",
-        tags: ["AI", "Architecture"],
-        imageUrl: "",
-        salesCount: 12,
-        active: true,
-        contentHash: "mock_hash_000000000001",
-      },
-      {
-        id: 2n,
-        creator: "GB...5678",
-        priceStroops: 120000000n, // 12 XLM
-        title: "Creative Storyteller Pro",
-        category: "Creative",
-        previewText:
-          "Unlock deep narrative structures and character development...",
-        description:
-          "A storytelling prompt built to help craft plot outlines, characters, and emotional arcs for long-form fiction.",
-        tags: ["Storytelling", "Creative"],
-        imageUrl: "",
-        salesCount: 45,
-        active: true,
-        contentHash: "mock_hash_000000000002",
-      },
-    ];
+    return mockPrompts;
   }
 
   static async getPromptsByBuyer(
-    _config: PromptHashConfig,
-    _address: string,
+    config: PromptHashConfig,
+    address: string,
   ): Promise<PromptRecord[]> {
+    if (isContractReady(config)) {
+      const prompts = await readContract<ContractPrompt[]>(
+        config,
+        config.promptHashContractId,
+        "get_prompts_by_buyer",
+        [scValArg(address, "address")],
+      );
+      return prompts.map(normalizePrompt);
+    }
     warnMockUse();
     return [];
   }
 
   static async getPromptsByCreator(
-    _config: PromptHashConfig,
-    _address: string,
+    config: PromptHashConfig,
+    address: string,
   ): Promise<PromptRecord[]> {
+    if (isContractReady(config)) {
+      const prompts = await readContract<ContractPrompt[]>(
+        config,
+        config.promptHashContractId,
+        "get_prompts_by_creator",
+        [scValArg(address, "address")],
+      );
+      return prompts.map(normalizePrompt);
+    }
     warnMockUse();
     return [];
   }
 
   static async createPrompt(
     _config: PromptHashConfig,
-    _walletSignerLike: any,
+    _walletSignerLike: WalletTransactionSigner,
     _address: string,
     _data: CreatePromptInput,
   ) {
@@ -181,7 +373,7 @@ export class PromptHashClient {
 
   static async setPromptSaleStatus(
     _config: PromptHashConfig,
-    _walletSignerLike: any,
+    _walletSignerLike: WalletTransactionSigner,
     _address: string,
     _promptId: string,
     _isForSale: boolean,
@@ -192,7 +384,7 @@ export class PromptHashClient {
 
   static async updatePromptPrice(
     _config: PromptHashConfig,
-    _walletSignerLike: any,
+    _walletSignerLike: WalletTransactionSigner,
     _address: string,
     _promptId: string,
     _newPrice: string,
@@ -248,17 +440,11 @@ export class PromptHashClient {
   }
 }
 
-// --- Standalone exports to satisfy existing UI component imports ---
 export const hasAccess = async (
   config: PromptHashConfig,
   address: string,
   itemId: string | bigint,
-) =>
-  PromptHashClient.checkAccess(
-    config,
-    address,
-    typeof itemId === "bigint" ? itemId.toString() : itemId,
-  );
+) => PromptHashClient.checkAccess(config, address, itemId);
 export const getPrompt = async (config: PromptHashConfig, promptId: bigint) =>
   PromptHashClient.getPrompt(config, promptId);
 export const getAllPrompts = async (config: PromptHashConfig) =>
@@ -273,13 +459,13 @@ export const getPromptsByCreator = async (
 ) => PromptHashClient.getPromptsByCreator(config, address);
 export const createPrompt = async (
   config: PromptHashConfig,
-  walletSignerLike: any,
+  walletSignerLike: WalletTransactionSigner,
   address: string,
   data: CreatePromptInput,
 ) => PromptHashClient.createPrompt(config, walletSignerLike, address, data);
 export const setPromptSaleStatus = async (
   config: PromptHashConfig,
-  walletSignerLike: any,
+  walletSignerLike: WalletTransactionSigner,
   address: string,
   promptId: string,
   isForSale: boolean,
@@ -293,7 +479,7 @@ export const setPromptSaleStatus = async (
   );
 export const updatePromptPrice = async (
   config: PromptHashConfig,
-  walletSignerLike: any,
+  walletSignerLike: WalletTransactionSigner,
   address: string,
   promptId: string,
   newPrice: string,
@@ -305,9 +491,18 @@ export const updatePromptPrice = async (
     promptId,
     newPrice,
   );
-
 export const getRecentPurchases = async (
   config: PromptHashConfig,
   limit?: number
 ) => PromptHashClient.getRecentPurchases(config, limit);
 
+export const buyPromptAccess = async (
+  config: PromptHashConfig,
+  signer: WalletTransactionSigner,
+  address: string,
+  itemId: string | bigint,
+) =>
+  PromptHashClient.purchasePrompt(String(itemId), address, {
+    config,
+    signer,
+  });

--- a/src/pages/prompts/PromptDetailPage.tsx
+++ b/src/pages/prompts/PromptDetailPage.tsx
@@ -1,37 +1,99 @@
+import { useEffect, useMemo, useState } from "react";
+import type { ReactNode } from "react";
 import { Link, useParams } from "react-router-dom";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   ArrowLeft,
+  Check,
+  CheckCircle,
+  Copy,
+  ExternalLink,
+  Flag,
   History,
   Loader2,
+  LockKeyhole,
+  MessageSquare,
   ShieldCheck,
   ShoppingBag,
   Sparkles,
-  User,
+  Wallet,
 } from "lucide-react";
-import { Navigation } from "@/components/navigation";
 import { Footer } from "@/components/footer";
+import { MarkdownContent } from "@/components/MarkdownContent";
+import { Navigation } from "@/components/navigation";
+import { NetworkMismatchBanner } from "@/components/wallet/NetworkMismatchBanner";
+import { ReportDialog } from "@/components/prompts/ReportDialog";
+import { ReviewForm } from "@/components/prompts/ReviewForm";
+import { ReviewList } from "@/components/prompts/ReviewList";
+import { StarRating } from "@/components/prompts/StarRating";
+import { StatusBanner } from "@/components/StatusBanner";
+import { UnlockErrorBanner } from "@/components/UnlockErrorBanner";
+import { UnlockExplainer } from "@/components/UnlockExplainer";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { browserStellarConfig } from "@/lib/stellar/browserConfig";
-import { getPrompt } from "@/lib/stellar/promptHashClient";
-import { formatPriceLabel } from "@/lib/stellar/format";
-import { usePageMeta } from "@/lib/seo/usePageMeta";
 import { ShareButtons } from "@/components/prompts/ShareButtons";
 import { PromptRevisionHistory } from "@/components/analytics/PromptRevisionHistory";
-import { MarkdownContent } from "@/components/MarkdownContent";
 import { UserAvatar } from "@/components/UserAvatar";
+import { useWallet } from "@/hooks/useWallet";
+import { copyToClipboard } from "@/lib/clipboard/secureClipboard";
+import { usePageMeta } from "@/lib/seo/usePageMeta";
+import { browserStellarConfig } from "@/lib/stellar/browserConfig";
+import { formatPriceLabel } from "@/lib/stellar/format";
+import {
+  PromptHashClient,
+  getPrompt,
+  type PurchasePromptResult,
+} from "@/lib/stellar/promptHashClient";
+import { mapWalletError } from "@/lib/stellar/tx";
+import { detectNetworkMismatch } from "@/lib/wallet/networkDetection";
+import { unlockPrompt } from "@/lib/prompts/unlock";
+import { ReviewClient } from "@/lib/reviews/reviewClient";
 
 const FALLBACK_IMAGE = "/images/codeguru.png";
 
+type BuyerStatus =
+  | "IDLE"
+  | "CHECKING_ACCESS"
+  | "AWAITING_APPROVAL"
+  | "CONFIRMING"
+  | "PURCHASED_LOCKED"
+  | "UNLOCKING"
+  | "SUCCESS"
+  | "ERROR";
+
 function summarise(text: string, max = 160): string {
   const clean = text.trim().replace(/\s+/g, " ");
-  return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean;
+  return clean.length > max ? `${clean.slice(0, max - 1)}...` : clean;
+}
+
+function shortAddress(value: string): string {
+  return value.length > 14 ? `${value.slice(0, 6)}...${value.slice(-4)}` : value;
+}
+
+function explorerTxUrl(txHash: string): string {
+  const network = browserStellarConfig.networkPassphrase
+    .toLowerCase()
+    .includes("public")
+    ? "public"
+    : "testnet";
+  return `https://stellar.expert/explorer/${network}/tx/${txHash}`;
 }
 
 export default function PromptDetailPage() {
   const { id = "" } = useParams();
+  const queryClient = useQueryClient();
+  const wallet = useWallet();
   const isValidId = /^\d+$/.test(id);
+
+  const [copied, setCopied] = useState(false);
+  const [status, setStatus] = useState<BuyerStatus>("IDLE");
+  const [purchaseResult, setPurchaseResult] =
+    useState<PurchasePromptResult | null>(null);
+  const [purchaseError, setPurchaseError] = useState<unknown>(null);
+  const [unlockError, setUnlockError] = useState<unknown>(null);
+  const [secretContent, setSecretContent] = useState("");
+  const [showReviewForm, setShowReviewForm] = useState(false);
+  const [showReportDialog, setShowReportDialog] = useState(false);
 
   const {
     data: prompt,
@@ -43,8 +105,42 @@ export default function PromptDetailPage() {
     enabled: isValidId,
   });
 
-  // Drive the share preview (Open Graph / Twitter card) from the prompt details
-  // so links shared to social platforms show the title, summary and cover image.
+  const { data: hasAccess, isFetching: isCheckingAccess } = useQuery({
+    queryKey: ["prompt-access", id, wallet.address],
+    queryFn: () =>
+      PromptHashClient.checkAccess(browserStellarConfig, wallet.address!, id),
+    enabled: isValidId && Boolean(wallet.address),
+  });
+
+  const { data: reviewData, isLoading: reviewsLoading } = useQuery({
+    queryKey: ["reviews", id],
+    queryFn: () => ReviewClient.getReviews(id),
+    enabled: isValidId,
+    staleTime: 60_000,
+  });
+
+  useEffect(() => {
+    if (!wallet.address) {
+      setStatus("IDLE");
+      setSecretContent("");
+      return;
+    }
+    if (isCheckingAccess) {
+      setStatus((current) =>
+        current === "SUCCESS" || current === "CONFIRMING"
+          ? current
+          : "CHECKING_ACCESS",
+      );
+      return;
+    }
+    if (hasAccess && status !== "SUCCESS") {
+      setStatus("PURCHASED_LOCKED");
+    }
+    if (hasAccess === false && status === "CHECKING_ACCESS") {
+      setStatus("IDLE");
+    }
+  }, [hasAccess, isCheckingAccess, status, wallet.address]);
+
   const summary = prompt
     ? summarise(prompt.description || prompt.previewText)
     : "Discover wallet-verified AI prompts secured on the Stellar blockchain.";
@@ -55,25 +151,56 @@ export default function PromptDetailPage() {
     type: "article",
   });
 
-  const jsonLd = prompt ? {
-    "@context": "https://schema.org/",
-    "@type": "Product",
-    name: prompt.title,
-    description: prompt.previewText,
-    image: prompt.imageUrl || `${window.location.origin}${FALLBACK_IMAGE}`,
-    offers: {
-      "@type": "Offer",
-      price: (Number(prompt.priceStroops) / 10000000).toFixed(2),
-      priceCurrency: "XLM",
-      availability: prompt.active ? "https://schema.org/InStock" : "https://schema.org/OutOfStock",
-    },
-    aggregateRating: {
-      "@type": "AggregateRating",
-      ratingValue: "5.0",
-      reviewCount: Math.max(1, prompt.salesCount)
-    }
-  } : null;
+  const jsonLd = prompt
+    ? {
+        "@context": "https://schema.org/",
+        "@type": "Product",
+        name: prompt.title,
+        description: prompt.previewText,
+        image:
+          prompt.imageUrl ||
+          (typeof window !== "undefined"
+            ? `${window.location.origin}${FALLBACK_IMAGE}`
+            : FALLBACK_IMAGE),
+        offers: {
+          "@type": "Offer",
+          price: (Number(prompt.priceStroops) / 10000000).toFixed(2),
+          priceCurrency: "XLM",
+          availability: prompt.active
+            ? "https://schema.org/InStock"
+            : "https://schema.org/OutOfStock",
+        },
+        aggregateRating: {
+          "@type": "AggregateRating",
+          ratingValue: reviewData?.stats.averageRating.toFixed(1) ?? "5.0",
+          reviewCount: Math.max(1, reviewData?.stats.total ?? prompt.salesCount),
+        },
+      }
+    : null;
 
+  const isCreator =
+    Boolean(prompt?.creator && wallet.address) &&
+    prompt!.creator.toLowerCase() === wallet.address!.toLowerCase();
+  const networkState = detectNetworkMismatch(
+    Boolean(wallet.address),
+    wallet.network,
+    wallet.status,
+  );
+  const reviewStats = reviewData?.stats;
+  const mappedPurchaseError = purchaseError
+    ? mapWalletError(purchaseError)
+    : null;
+  const mappedUnlockError = unlockError ? mapWalletError(unlockError) : null;
+
+  const includedItems = useMemo(
+    () => [
+      "On-chain license record tied to your wallet",
+      "Encrypted prompt unlock after access verification",
+      "Content hash integrity check before delivery",
+      "Post-purchase review and reporting tools",
+    ],
+    [],
+  );
 
   const handleCopyLink = async () => {
     const link =
@@ -84,13 +211,71 @@ export default function PromptDetailPage() {
       window.setTimeout(() => setCopied(false), 1800);
     }
   };
+
+  const handlePurchase = async () => {
+    if (!wallet.address || !prompt) {
+      setPurchaseError(new Error("Connect your Stellar wallet before purchase."));
+      setStatus("ERROR");
+      return;
+    }
+    if (!wallet.signTransaction) {
+      setPurchaseError(new Error("Wallet transaction signing is unavailable."));
+      setStatus("ERROR");
+      return;
+    }
+    if (networkState.type !== "correct") {
+      setPurchaseError(new Error(networkState.message || "Wrong network connected."));
+      setStatus("ERROR");
+      return;
+    }
+
+    setPurchaseError(null);
+    setUnlockError(null);
+    setStatus("AWAITING_APPROVAL");
+    try {
+      const result = await PromptHashClient.purchasePrompt(id, wallet.address, {
+        config: browserStellarConfig,
+        signer: { signTransaction: wallet.signTransaction },
+      });
+      setPurchaseResult(result);
+      setStatus("CONFIRMING");
+      await queryClient.invalidateQueries({ queryKey: ["prompt-detail", id] });
+      await queryClient.invalidateQueries({
+        queryKey: ["prompt-access", id, wallet.address],
+      });
+      setStatus("PURCHASED_LOCKED");
+    } catch (error) {
+      setPurchaseError(error);
+      setStatus("ERROR");
+    }
+  };
+
+  const handleUnlock = async () => {
+    if (!wallet.address || !wallet.signMessage || !prompt) return;
+    setUnlockError(null);
+    setStatus("UNLOCKING");
+    try {
+      const data = await unlockPrompt(
+        id,
+        purchaseResult?.txHash || "existing",
+        wallet.signMessage,
+        wallet.address,
+      );
+      setSecretContent(data.decryptedContent || data.plaintext);
+      setStatus("SUCCESS");
+    } catch (error) {
+      setUnlockError(error);
+      setStatus("PURCHASED_LOCKED");
+    }
+  };
+
   const notFound = !isValidId || isError || (!isLoading && !prompt);
 
   return (
-    <div className="min-h-screen bg-[#020617] text-white selection:bg-cyan-500/30">
+    <div className="min-h-screen bg-slate-950 text-white selection:bg-cyan-500/30">
       <Navigation />
 
-      <main className="mx-auto max-w-3xl px-4 py-16 sm:px-6">
+      <main className="mx-auto max-w-7xl px-4 py-10 sm:px-6 lg:px-8">
         <Button
           asChild
           variant="ghost"
@@ -104,11 +289,11 @@ export default function PromptDetailPage() {
         </Button>
 
         {isLoading && isValidId ? (
-          <div className="flex min-h-64 items-center justify-center rounded-2xl border border-white/10 bg-white/[0.02]">
+          <div className="grid min-h-96 place-items-center border border-white/10 bg-white/[0.02]">
             <Loader2 className="h-6 w-6 animate-spin text-slate-400" />
           </div>
         ) : notFound || !prompt ? (
-          <div className="grid min-h-64 place-items-center rounded-2xl border border-dashed border-white/15 bg-white/[0.02] p-8 text-center">
+          <div className="grid min-h-96 place-items-center border border-dashed border-white/15 bg-white/[0.02] p-8 text-center">
             <div className="max-w-sm">
               <h1 className="text-xl font-semibold text-white">
                 Prompt not found
@@ -128,78 +313,318 @@ export default function PromptDetailPage() {
             </div>
           </div>
         ) : (
-          <article className="overflow-hidden rounded-2xl border border-white/10 bg-[#0f1419]">
-            {jsonLd && (
-              <script
-                type="application/ld+json"
-                dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-              />
-            )}
-            <div className="aspect-[1200/630] w-full overflow-hidden bg-slate-900">
-              <img
-                src={prompt.imageUrl || FALLBACK_IMAGE}
-                alt={prompt.title}
-                className="h-full w-full object-cover"
-                onError={(event) => {
-                  event.currentTarget.src = FALLBACK_IMAGE;
-                }}
-              />
-            </div>
+          <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_360px]">
+            <article className="min-w-0">
+              {jsonLd && (
+                <script
+                  type="application/ld+json"
+                  dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+                />
+              )}
+              <div className="overflow-hidden border border-white/10 bg-slate-900">
+                <div className="aspect-[1200/560] w-full overflow-hidden bg-slate-900">
+                  <img
+                    src={prompt.imageUrl || FALLBACK_IMAGE}
+                    alt={prompt.title}
+                    className="h-full w-full object-cover"
+                    onError={(event) => {
+                      event.currentTarget.src = FALLBACK_IMAGE;
+                    }}
+                  />
+                </div>
 
-            <div className="space-y-5 p-6 sm:p-8">
-              <div className="flex flex-wrap items-center gap-2">
-                <Badge className="border-cyan-200/30 bg-cyan-200/10 text-cyan-100">
-                  <Sparkles className="mr-1 h-3 w-3" />
-                  {prompt.category}
-                </Badge>
-                {prompt.active ? (
-                  <span
-                    className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-semibold bg-emerald-500/10 text-emerald-400 border border-emerald-500/20"
-                    title="This prompt is currently available for purchase"
-                  >
-                    <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 animate-pulse" />
-                    Active
-                  </span>
-                ) : (
-                  <span
-                    className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-semibold bg-slate-500/10 text-slate-400 border border-slate-500/20"
-                    title="This prompt is not currently available for purchase"
-                  >
-                    <span className="h-1.5 w-1.5 rounded-full bg-slate-400" />
-                    Inactive
-                  </span>
-                )}
-                {prompt.contentHash && (
-                  <span
-                    className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-semibold bg-amber-500/10 text-amber-400 border border-amber-500/20"
-                    title="Content integrity verified on the Stellar blockchain"
-                  >
-                    <ShieldCheck className="h-3 w-3 text-amber-400" />
-                    Verified
-                  </span>
-                )}
-                <span
-                  className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-semibold bg-blue-500/10 text-blue-400 border border-blue-500/20"
-                  title={`${prompt.salesCount} license${prompt.salesCount !== 1 ? "s" : ""} sold`}
-                >
-                  <ShoppingBag className="h-3 w-3" />
-                  {prompt.salesCount} sold
-                </span>
+                <div className="space-y-7 p-6 sm:p-8">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge className="border-cyan-200/30 bg-cyan-200/10 text-cyan-100">
+                      <Sparkles className="mr-1 h-3 w-3" />
+                      {prompt.category}
+                    </Badge>
+                    <Badge className="border-emerald-500/20 bg-emerald-500/10 text-emerald-300">
+                      <ShieldCheck className="mr-1 h-3 w-3" />
+                      Hash verified
+                    </Badge>
+                    {hasAccess && (
+                      <Badge className="border-blue-500/20 bg-blue-500/10 text-blue-300">
+                        <CheckCircle className="mr-1 h-3 w-3" />
+                        Licensed
+                      </Badge>
+                    )}
+                    {isCreator && (
+                      <Badge className="border-amber-500/20 bg-amber-500/10 text-amber-300">
+                        Creator view
+                      </Badge>
+                    )}
+                  </div>
+
+                  <div>
+                    <h1 className="max-w-3xl text-3xl font-bold tracking-tight text-white sm:text-4xl">
+                      {prompt.title}
+                    </h1>
+                    <p className="mt-4 max-w-3xl text-base leading-7 text-slate-300">
+                      {prompt.previewText}
+                    </p>
+                  </div>
+
+                  <div className="grid gap-3 sm:grid-cols-4">
+                    <Insight label="Rating">
+                      {reviewStats && reviewStats.total > 0 ? (
+                        <span className="flex items-center gap-2">
+                          <StarRating
+                            rating={reviewStats.averageRating}
+                            readonly
+                            size="sm"
+                          />
+                          <span>{reviewStats.averageRating.toFixed(1)}</span>
+                        </span>
+                      ) : (
+                        "No reviews"
+                      )}
+                    </Insight>
+                    <Insight label="Sales">{prompt.salesCount}</Insight>
+                    <Insight label="Revision">
+                      <span className="inline-flex items-center gap-1">
+                        <History className="h-3.5 w-3.5" />
+                        v{prompt.revision ?? 0}
+                      </span>
+                    </Insight>
+                    <Insight label="Creator">
+                      <span title={prompt.creator}>{shortAddress(prompt.creator)}</span>
+                    </Insight>
+                  </div>
+
+                  <section className="border-t border-white/10 pt-7">
+                    <h2 className="text-lg font-semibold text-white">
+                      Prompt Details
+                    </h2>
+                    <div className="mt-4 text-slate-300">
+                      {prompt.description ? (
+                        <MarkdownContent>{prompt.description}</MarkdownContent>
+                      ) : (
+                        <p className="leading-7">{prompt.previewText}</p>
+                      )}
+                    </div>
+                  </section>
+
+                  <PromptRevisionHistory
+                    promptId={id}
+                    currentRevision={prompt.revision ?? 0}
+                  />
+
+                  <section className="border-t border-white/10 pt-7">
+                    <div className="mb-4 flex items-center justify-between gap-4">
+                      <h2 className="text-lg font-semibold text-white">
+                        Review Insights
+                      </h2>
+                      {reviewStats && reviewStats.total > 0 && (
+                        <span className="text-sm text-slate-400">
+                          {reviewStats.total} total
+                        </span>
+                      )}
+                    </div>
+                    <ReviewList
+                      reviews={reviewData?.reviews ?? []}
+                      isLoading={reviewsLoading}
+                    />
+                  </section>
+
+                  {status === "SUCCESS" && (
+                    <section className="border-t border-white/10 pt-7">
+                      <div className="mb-3 flex items-center gap-2 text-emerald-300">
+                        <LockKeyhole className="h-5 w-5" />
+                        <h2 className="text-lg font-semibold">
+                          Unlocked Content
+                        </h2>
+                      </div>
+                      <pre className="max-h-96 overflow-auto border border-white/10 bg-black p-4 text-sm leading-6 text-slate-200">
+                        {secretContent}
+                      </pre>
+                      {wallet.address && (
+                        <div className="mt-5 border-t border-white/10 pt-5">
+                          {!showReviewForm ? (
+                            <Button
+                              onClick={() => setShowReviewForm(true)}
+                              variant="ghost"
+                              className="border border-white/10 text-slate-100 hover:bg-white/10"
+                            >
+                              <MessageSquare className="h-4 w-4" />
+                              Write a review
+                            </Button>
+                          ) : (
+                            <ReviewForm
+                              promptId={id}
+                              onSubmit={async (review) => {
+                                await ReviewClient.submitReview(
+                                  id,
+                                  wallet.address!,
+                                  review.rating,
+                                  review.text,
+                                );
+                                await queryClient.invalidateQueries({
+                                  queryKey: ["reviews", id],
+                                });
+                                setShowReviewForm(false);
+                              }}
+                              onCancel={() => setShowReviewForm(false)}
+                            />
+                          )}
+                        </div>
+                      )}
+                    </section>
+                  )}
+                </div>
               </div>
+            </article>
 
-              <div>
-                <h1 className="text-2xl font-bold tracking-tight text-white">
-                  {prompt.title}
-                </h1>
-                <p className="mt-2 text-sm leading-6 text-slate-400">
-                  {prompt.previewText}
-                </p>
-                {prompt.description && (
-                  <div className="mt-4">
-                    <MarkdownContent>{prompt.description}</MarkdownContent>
+            <aside className="lg:sticky lg:top-6 lg:self-start">
+              <div className="border border-white/10 bg-slate-900 p-5 shadow-2xl">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+                      License price
+                    </p>
+                    <p className="mt-1 text-3xl font-black text-white">
+                      {formatPriceLabel(prompt.priceStroops)}
+                    </p>
+                  </div>
+                  <Badge className="border-white/10 bg-white/5 text-slate-200">
+                    XLM
+                  </Badge>
+                </div>
+
+                <div className="mt-5 space-y-2">
+                  {includedItems.map((item) => (
+                    <div
+                      key={item}
+                      className="flex items-start gap-2 text-sm text-slate-300"
+                    >
+                      <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />
+                      <span>{item}</span>
+                    </div>
+                  ))}
+                </div>
+
+                <div className="mt-5 border-t border-white/10 pt-5">
+                  <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">
+                    Licensing options
+                  </p>
+                  <div className="space-y-2">
+                    <Option label="Standard wallet license" selected />
+                    <Option label="Lease access" disabled />
+                    <Option label="Resale transfer" disabled />
+                  </div>
+                </div>
+
+                <div className="mt-5 space-y-3 border-t border-white/10 pt-5">
+                  <NetworkMismatchBanner />
+                  {status === "CHECKING_ACCESS" && (
+                    <StatusBanner
+                      status="pending"
+                      message="Checking wallet access on-chain..."
+                    />
+                  )}
+                  {status === "AWAITING_APPROVAL" && (
+                    <StatusBanner
+                      status="pending"
+                      message="Approve XLM spend in your wallet."
+                    />
+                  )}
+                  {status === "CONFIRMING" && (
+                    <StatusBanner
+                      status="pending"
+                      message="Purchase submitted. Waiting for Stellar confirmation..."
+                    />
+                  )}
+                  {status === "PURCHASED_LOCKED" && (
+                    <div className="space-y-3">
+                      <StatusBanner
+                        status="success"
+                        message="License verified. Sign to decrypt the prompt."
+                      />
+                      <UnlockExplainer state="signing" />
+                      {mappedUnlockError && (
+                        <UnlockErrorBanner
+                          message={mappedUnlockError.userMessage}
+                          onRetry={handleUnlock}
+                        />
+                      )}
+                      <Button
+                        onClick={handleUnlock}
+                        className="h-12 w-full bg-emerald-400 font-bold text-slate-950 hover:bg-emerald-300"
+                      >
+                        <LockKeyhole className="h-4 w-4" />
+                        Decrypt content
+                      </Button>
+                    </div>
+                  )}
+                  {status === "UNLOCKING" && (
+                    <StatusBanner
+                      status="pending"
+                      message="Verifying signed challenge and decrypting content..."
+                    />
+                  )}
+                  {status === "SUCCESS" && (
+                    <StatusBanner
+                      status="success"
+                      message="Purchase confirmed and prompt unlocked."
+                    />
+                  )}
+                  {status === "ERROR" && mappedPurchaseError && (
+                    <div className="space-y-2">
+                      <StatusBanner
+                        status="error"
+                        message={mappedPurchaseError.userMessage}
+                      />
+                      <p className="text-xs leading-5 text-slate-400">
+                        {mappedPurchaseError.recoveryHint}
+                      </p>
+                    </div>
+                  )}
+
+                  {!wallet.address ? (
+                    <Button
+                      disabled
+                      className="h-12 w-full bg-white font-bold text-slate-950"
+                    >
+                      <Wallet className="h-4 w-4" />
+                      Connect wallet to buy
+                    </Button>
+                  ) : isCreator ? (
+                    <Button
+                      asChild
+                      className="h-12 w-full bg-cyan-200 font-bold text-slate-950 hover:bg-cyan-100"
+                    >
+                      <Link to="/sell">Manage listing</Link>
+                    </Button>
+                  ) : status === "IDLE" || status === "ERROR" ? (
+                    <Button
+                      onClick={handlePurchase}
+                      disabled={!prompt.active || networkState.type !== "correct"}
+                      className="h-12 w-full bg-white font-bold text-slate-950 hover:bg-emerald-300"
+                    >
+                      <Wallet className="h-4 w-4" />
+                      Pay with XLM
+                    </Button>
+                  ) : null}
+                </div>
+
+                {purchaseResult?.txHash && (
+                  <div className="mt-5 border-t border-white/10 pt-5 text-xs text-slate-400">
+                    <p className="mb-2 font-semibold text-slate-300">
+                      Transaction confirmation
+                    </p>
+                    <a
+                      href={explorerTxUrl(purchaseResult.txHash)}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="inline-flex max-w-full items-center gap-2 text-cyan-200 hover:text-cyan-100"
+                    >
+                      <span className="truncate font-mono">
+                        {purchaseResult.txHash}
+                      </span>
+                      <ExternalLink className="h-3.5 w-3.5 shrink-0" />
+                    </a>
                   </div>
                 )}
-              </div>
 
               <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-slate-400">
                 <span className="inline-flex items-center gap-2">
@@ -237,13 +662,83 @@ export default function PromptDetailPage() {
                   </span>
                   <ShareButtons title={prompt.title} summary={summary} />
                 </div>
+                <div className="grid grid-cols-2 gap-2">
+                  <Button
+                    variant="ghost"
+                    onClick={handleCopyLink}
+                    className="border border-white/10 text-slate-200 hover:bg-white/10"
+                  >
+                    {copied ? (
+                      <Check className="h-4 w-4 text-emerald-400" />
+                    ) : (
+                      <Copy className="h-4 w-4" />
+                    )}
+                    Share
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    onClick={() => setShowReportDialog(true)}
+                    className="border border-red-500/20 text-red-300 hover:bg-red-500/10"
+                  >
+                    <Flag className="h-4 w-4" />
+                    Report
+                  </Button>
+                </div>
               </div>
-            </div>
-          </article>
+              </div>
+            </aside>
+          </div>
         )}
       </main>
 
+      <ReportDialog
+        promptId={id}
+        isOpen={showReportDialog}
+        onClose={() => setShowReportDialog(false)}
+        userAddress={wallet.address}
+      />
       <Footer />
+    </div>
+  );
+}
+
+function Insight({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="border border-white/10 bg-white/[0.03] p-3">
+      <p className="text-xs uppercase tracking-wider text-slate-500">{label}</p>
+      <div className="mt-1 min-h-6 text-sm font-semibold text-slate-100">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function Option({
+  label,
+  selected,
+  disabled,
+}: {
+  label: string;
+  selected?: boolean;
+  disabled?: boolean;
+}) {
+  return (
+    <div
+      className={`flex items-center justify-between border px-3 py-2 text-sm ${
+        selected
+          ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-200"
+          : "border-white/10 bg-white/[0.02] text-slate-500"
+      }`}
+      aria-disabled={disabled}
+    >
+      <span>{label}</span>
+      {selected ? <Check className="h-4 w-4" /> : <span>Soon</span>}
     </div>
   );
 }

--- a/src/test/integration/prompt-detail-page-297.test.tsx
+++ b/src/test/integration/prompt-detail-page-297.test.tsx
@@ -1,0 +1,220 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Route, Routes } from "react-router-dom";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import PromptDetailPage from "@/pages/prompts/PromptDetailPage";
+import { renderWithProviders } from "@/test/render";
+import { getPrompt, PromptHashClient } from "@/lib/stellar/promptHashClient";
+import { unlockPrompt } from "@/lib/prompts/unlock";
+
+const prompt = {
+  id: 297n,
+  creator: "GCREATORACCOUNT1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ123456",
+  priceStroops: 75_0000000n,
+  title: "Ownership-aware launch prompt",
+  category: "Marketing",
+  previewText: "Preview text for buyers before checkout.",
+  description: "Detailed prompt guidance with usage notes.",
+  tags: ["launch", "copy"],
+  imageUrl: "",
+  salesCount: 9,
+  active: true,
+  contentHash: "hash_297",
+  revision: 2,
+};
+
+const mocked = vi.hoisted(() => ({
+  reviews: {
+    reviews: [
+      {
+        id: "review-1",
+        promptId: "297",
+        userAddress: "GBUYERACCOUNT1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567",
+        rating: 5,
+        text: "Clear and immediately usable.",
+        createdAt: Date.now(),
+        verified: true,
+      },
+    ],
+    stats: {
+      total: 1,
+      averageRating: 5,
+      distribution: { 5: 1, 4: 0, 3: 0, 2: 0, 1: 0 },
+    },
+  },
+}));
+
+vi.mock("@/lib/stellar/browserConfig", () => ({
+  browserStellarConfig: {
+    rpcUrl: "https://stellar.test/rpc",
+    networkPassphrase: "Test SDF Network ; September 2015",
+    allowHttp: false,
+    promptHashContractId: "prompt-hash-contract",
+    nativeAssetContractId: "native-asset-contract",
+    simulationAccount: "GSIMULATIONACCOUNT1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+  },
+}));
+
+vi.mock("@/lib/stellar/promptHashClient", () => ({
+  getPrompt: vi.fn(),
+  PromptHashClient: {
+    checkAccess: vi.fn(),
+    purchasePrompt: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/prompts/unlock", () => ({
+  unlockPrompt: vi.fn(),
+}));
+
+vi.mock("@/lib/reviews/reviewClient", () => ({
+  ReviewClient: {
+    getReviews: vi.fn().mockResolvedValue(mocked.reviews),
+    submitReview: vi.fn(),
+  },
+}));
+
+vi.mock("@/components/navigation", () => ({
+  Navigation: () => <nav aria-label="Main navigation" />,
+}));
+
+vi.mock("@/components/footer", () => ({
+  Footer: () => <footer />,
+}));
+
+describe("Issue #297 prompt detail page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(PromptHashClient.checkAccess).mockResolvedValue(false);
+    vi.mocked(PromptHashClient.purchasePrompt).mockResolvedValue({
+      txHash: "purchase_hash_297",
+      approvalTxHash: "approval_hash_297",
+      success: true,
+      confirmedAtLedger: 123,
+    });
+    vi.mocked(unlockPrompt).mockResolvedValue({
+      decryptedContent: "Unlocked paid prompt body.",
+      plaintext: "Unlocked paid prompt body.",
+    });
+    vi.mocked(getPrompt).mockResolvedValue(prompt);
+  });
+
+  it("renders review insights and sticky licensing actions", async () => {
+    renderPromptDetail();
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "Ownership-aware launch prompt",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Review Insights")).toBeInTheDocument();
+    expect(screen.getByText("License price")).toBeInTheDocument();
+    expect(screen.getByText("Standard wallet license")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /share/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /report/i })).toBeInTheDocument();
+  });
+
+  it("submits a real XLM purchase request with signer/config and confirms access", async () => {
+    const user = userEvent.setup();
+    const signTransaction = vi.fn();
+
+    renderPromptDetail({
+      wallet: {
+        address: "GBUYERACCOUNT1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567",
+        status: "connected",
+        network: "Test SDF Network ; September 2015",
+        signTransaction,
+        signMessage: vi.fn(),
+      },
+    });
+
+    const purchaseButton = await screen.findByRole("button", {
+      name: /pay with xlm/i,
+    });
+    await user.click(purchaseButton);
+
+    await waitFor(() => {
+      expect(PromptHashClient.purchasePrompt).toHaveBeenCalledWith(
+        "297",
+        "GBUYERACCOUNT1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567",
+        expect.objectContaining({
+          config: expect.objectContaining({
+            promptHashContractId: "prompt-hash-contract",
+            nativeAssetContractId: "native-asset-contract",
+          }),
+          signer: { signTransaction },
+        }),
+      );
+    });
+
+    expect(
+      await screen.findByText(/license verified/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText("purchase_hash_297")).toBeInTheDocument();
+  });
+
+  it("unlocks token-gated content only after on-chain access is detected", async () => {
+    const user = userEvent.setup();
+    vi.mocked(PromptHashClient.checkAccess).mockResolvedValue(true);
+    const signMessage = vi.fn().mockResolvedValue({ signedMessage: "sig" });
+
+    renderPromptDetail({
+      wallet: {
+        address: "GBUYERACCOUNT1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567",
+        status: "connected",
+        network: "Test SDF Network ; September 2015",
+        signMessage,
+      },
+    });
+
+    const decryptButton = await screen.findByRole("button", {
+      name: /decrypt content/i,
+    });
+    await user.click(decryptButton);
+
+    expect(await screen.findByText("Unlocked Content")).toBeInTheDocument();
+    expect(screen.getByText("Unlocked paid prompt body.")).toBeInTheDocument();
+    expect(unlockPrompt).toHaveBeenCalledWith(
+      "297",
+      "existing",
+      signMessage,
+      "GBUYERACCOUNT1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567",
+    );
+  });
+
+  it("shows improved purchase recovery messaging", async () => {
+    const user = userEvent.setup();
+    vi.mocked(PromptHashClient.purchasePrompt).mockRejectedValue(
+      new Error("op_underfunded"),
+    );
+
+    renderPromptDetail({
+      wallet: {
+        address: "GBUYERACCOUNT1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567",
+        status: "connected",
+        network: "Test SDF Network ; September 2015",
+        signTransaction: vi.fn(),
+      },
+    });
+
+    await user.click(
+      await screen.findByRole("button", { name: /pay with xlm/i }),
+    );
+
+    expect(
+      await screen.findByText(/does not have enough xlm/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/add funds to your wallet/i),
+    ).toBeInTheDocument();
+  });
+});
+
+function renderPromptDetail(options = {}) {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/prompts/:id" element={<PromptDetailPage />} />
+    </Routes>,
+    { route: "/prompts/297", ...options },
+  );
+}

--- a/src/test/wallet/PurchaseButton.test.tsx
+++ b/src/test/wallet/PurchaseButton.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { screen, waitFor, within } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "../render";
 import { PromptModal } from "@/pages/browse/PromptModal";
@@ -11,17 +11,21 @@ vi.mock("@/lib/env", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/env")>();
   return {
     ...actual,
-    stellarWalletNetwork: "Test SDF Network ; September 2015",
-    rpcUrl: "https://soroban-testnet.stellar.org",
-    networkPassphrase: "Test SDF Network ; September 2015",
     allowHttp: false,
-    promptHashContractId: "CCONTRACTMOCKADDRESS1234567890ABCDEF",
+    nativeAssetContractId: "native-asset-contract",
+    networkPassphrase: "Test SDF Network ; September 2015",
+    promptHashContractId: "prompt-hash-contract",
+    rpcUrl: "https://stellar.test/rpc",
+    simulationAccount: "GSIMULATIONACCOUNT1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    stellarWalletNetwork: "Test SDF Network ; September 2015",
     browserStellarConfig: {
-      stellarWalletNetwork: "Test SDF Network ; September 2015",
-      rpcUrl: "https://soroban-testnet.stellar.org",
-      networkPassphrase: "Test SDF Network ; September 2015",
       allowHttp: false,
-      promptHashContractId: "CCONTRACTMOCKADDRESS1234567890ABCDEF",
+      nativeAssetContractId: "native-asset-contract",
+      networkPassphrase: "Test SDF Network ; September 2015",
+      promptHashContractId: "prompt-hash-contract",
+      rpcUrl: "https://stellar.test/rpc",
+      simulationAccount: "GSIMULATIONACCOUNT1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+      stellarWalletNetwork: "Test SDF Network ; September 2015",
     },
   };
 });
@@ -134,11 +138,18 @@ describe("Purchase Button States", () => {
       { wallet: mockWallet },
     );
 
-    const dialog = await screen.findByRole("dialog");
-    
-    // Fallback click simulation to jump straight across lifecycle updates safely
     await waitFor(() => {
-      expect(within(dialog).getByText(/Acquire License/i)).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /confirm & purchase/i })).toBeInTheDocument();
+    });
+
+    const purchaseButton = screen.getByRole("button", { name: /confirm & purchase/i });
+    await user.click(purchaseButton);
+
+    await waitFor(() => {
+      expect(PromptHashClient.purchasePrompt).toHaveBeenCalledWith(
+        "1",
+        "GCTESTADDRESS1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
+      );
     });
   });
 
@@ -163,9 +174,15 @@ describe("Purchase Button States", () => {
       { wallet: mockWallet },
     );
 
-    const dialog = await screen.findByRole("dialog");
     await waitFor(() => {
-      expect(within(dialog).getByText(/Acquire License/i)).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /confirm & purchase/i })).toBeInTheDocument();
+    });
+
+    const purchaseButton = screen.getByRole("button", { name: /confirm & purchase/i });
+    await user.click(purchaseButton);
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/does not have enough xlm/i).length).toBeGreaterThan(0);
     });
   });
 


### PR DESCRIPTION
Closes #297
What was done
Redesigned the prompt detail page to surface review insights, ownership-aware actions, and a complete on-chain licensing purchase flow using XLM.
Changes

Redesigned PromptDetailPage.tsx — review insights, ownership-aware actions, token-gated unlock, sticky licensing sidebar (pricing, included checklist, licensing options, sharing, reporting)
Real Stellar purchase flow — added to promptHashClient.ts: XLM approval, buy_prompt, transaction submission, polling/confirmation, and access refresh support
Improved error handling — updated purchase error messaging and post-purchase refresh/confirmation behavior
Documentation — JWT session environment variables documented in .env.example and docs/environments.md
Tests — added issue-specific integration tests and updated purchase button tests for current payment/error behavior

Test results

10 tests passing across integration and purchase button suites ✅
Lint passing on all touched files ✅

Notes

npm run typecheck is blocked by pre-existing unrelated repo errors (missing @vercel/node, mongoose, ./ui/dialog, and other pre-existing TS issues in tests/sell/browse files) — none introduced by this PR