### PR TITLE
feat: add FAQ section, keyboard shortcuts, onboarding tour, and Dependabot for Rust

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  # Keep npm dependencies up to date for the frontend
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+
+  # Keep Cargo dependencies up to date for Soroban contracts
+  - package-ecosystem: "cargo"
+    directory: "/contracts/prompt-hash"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      cargo-all:
+        patterns:
+          - "*"

--- a/README.md
+++ b/README.md
@@ -507,3 +507,21 @@ npm run lint && npm run typecheck
 - `docs: rewrite repository for Drip Wave submission`
 - `docs: add architecture and ecosystem overview`
 - `chore: align package metadata with PromptHash Stellar`
+
+## Dependency Updates
+
+Dependencies are managed automatically via [Dependabot](https://docs.github.com/en/code-security/dependabot) (see `.github/dependabot.yml`).
+
+Dependabot opens pull requests every Monday for:
+
+- **npm** (`/`) — frontend packages (Vite, React, Tailwind, etc.)
+- **Cargo** (`/contracts/prompt-hash`) — Soroban / Rust crates, grouped into a single PR
+
+### Reviewing and merging updates
+
+1. Check the Dependabot PR description for the changelog and any breaking-change notes.
+2. Run `npm ci && npm run build` locally (or let CI run) to confirm the frontend still compiles.
+3. For Cargo updates, run `cargo test` inside `contracts/prompt-hash/` before merging.
+4. Merge the PR; Dependabot will rebase any remaining open PRs automatically.
+
+If a Dependabot PR introduces a breaking change, close it and pin the old version in `package.json` or `Cargo.toml` until the issue is resolved upstream.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,10 @@
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useState } from "react";
 import { Outlet, Route, Routes, useLocation } from "react-router-dom";
 import { AnimatePresence } from "framer-motion";
 import { PageTransition } from "./components/animations/PageTransition";
 import Home from "./pages/Home";
+import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
+import { KeyboardShortcutsModal } from "./components/KeyboardShortcutsModal";
 
 const BrowsePage = lazy(() => import("./pages/browse/page.jsx"));
 const SellPage = lazy(() => import("./pages/sell/page.tsx"));
@@ -58,16 +60,26 @@ function AppRoutes() {
 }
 
 function App() {
+  const [showShortcutsModal, setShowShortcutsModal] = useState(false);
+
+  useKeyboardShortcuts({ onShowShortcuts: () => setShowShortcutsModal(true) });
+
   return (
-    <Suspense
-      fallback={
-        <div className="flex items-center justify-center min-h-screen bg-background">
-          <div className="text-foreground text-lg">Loading...</div>
-        </div>
-      }
-    >
-      <AppRoutes />
-    </Suspense>
+    <>
+      <KeyboardShortcutsModal
+        open={showShortcutsModal}
+        onClose={() => setShowShortcutsModal(false)}
+      />
+      <Suspense
+        fallback={
+          <div className="flex items-center justify-center min-h-screen bg-background">
+            <div className="text-foreground text-lg">Loading...</div>
+          </div>
+        }
+      >
+        <AppRoutes />
+      </Suspense>
+    </>
   );
 }
 

--- a/src/components/KeyboardShortcutsModal.tsx
+++ b/src/components/KeyboardShortcutsModal.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useRef } from "react";
+import { X } from "lucide-react";
+
+interface KeyboardShortcutsModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const shortcuts = [
+  { keys: ["/"], description: "Focus the search bar" },
+  { keys: ["?"], description: "Show this shortcuts reference" },
+  { keys: ["Esc"], description: "Close modal / blur active element" },
+  { keys: ["Ctrl", "S"], description: "Save current prompt draft" },
+];
+
+export function KeyboardShortcutsModal({
+  open,
+  onClose,
+}: KeyboardShortcutsModalProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // Close on Escape
+  useEffect(() => {
+    function handleClose() {
+      onClose();
+    }
+    document.addEventListener("close-modal", handleClose);
+    return () => document.removeEventListener("close-modal", handleClose);
+  }, [onClose]);
+
+  // Click-outside
+  function handleBackdropClick(e: React.MouseEvent<HTMLDivElement>) {
+    if (e.target === e.currentTarget) onClose();
+  }
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={handleBackdropClick}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Keyboard shortcuts"
+    >
+      <div
+        ref={dialogRef}
+        className="relative w-full max-w-md rounded-2xl border border-white/10 bg-slate-900 p-6 shadow-2xl"
+      >
+        <div className="mb-5 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-white">
+            Keyboard Shortcuts
+          </h2>
+          <button
+            onClick={onClose}
+            className="rounded-full p-1.5 text-slate-400 transition-colors hover:bg-white/10 hover:text-white"
+            aria-label="Close"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-white/10 text-left text-xs uppercase tracking-widest text-slate-500">
+              <th className="pb-3 pr-4">Shortcut</th>
+              <th className="pb-3">Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {shortcuts.map((s, i) => (
+              <tr
+                key={i}
+                className="border-b border-white/5 last:border-0"
+              >
+                <td className="py-3 pr-4">
+                  <span className="flex gap-1">
+                    {s.keys.map((k) => (
+                      <kbd
+                        key={k}
+                        className="inline-flex items-center rounded border border-white/20 bg-white/10 px-2 py-0.5 font-mono text-xs text-slate-200"
+                      >
+                        {k}
+                      </kbd>
+                    ))}
+                  </span>
+                </td>
+                <td className="py-3 text-slate-300">{s.description}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        <p className="mt-4 text-xs text-slate-500">
+          Press <kbd className="rounded border border-white/20 bg-white/10 px-1 font-mono text-xs">Esc</kbd> or click outside to close.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/OnboardingTour.tsx
+++ b/src/components/OnboardingTour.tsx
@@ -1,0 +1,199 @@
+import { useState, useEffect, useCallback } from "react";
+import { X, ChevronRight } from "lucide-react";
+
+const STORAGE_KEY = "prompthash_onboarding_done";
+
+interface TourStep {
+  selector: string;
+  title: string;
+  description: string;
+}
+
+const STEPS: TourStep[] = [
+  {
+    selector: '[data-tour="connect-wallet"]',
+    title: "Connect your Wallet",
+    description:
+      "Click here to connect your Stellar wallet. You need a wallet to buy or sell prompts on PromptHash.",
+  },
+  {
+    selector: '[data-tour="marketplace-search"]',
+    title: "Search the Marketplace",
+    description:
+      "Use the search bar to find prompts by keyword, category, or AI model. Filter by price and popularity.",
+  },
+  {
+    selector: '[data-tour="purchase-btn"]',
+    title: "Purchase a Prompt",
+    description:
+      'Click "Buy Access" on any prompt listing to purchase a license in XLM. Your wallet will confirm the transaction.',
+  },
+];
+
+interface Rect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+function getRect(selector: string): Rect | null {
+  const el = document.querySelector<HTMLElement>(selector);
+  if (!el) return null;
+  const r = el.getBoundingClientRect();
+  return {
+    top: r.top + window.scrollY,
+    left: r.left + window.scrollX,
+    width: r.width,
+    height: r.height,
+  };
+}
+
+export function OnboardingTour() {
+  const [step, setStep] = useState(0);
+  const [active, setActive] = useState(false);
+  const [rect, setRect] = useState<Rect | null>(null);
+
+  useEffect(() => {
+    if (localStorage.getItem(STORAGE_KEY)) return;
+    // Small delay so the page is fully rendered
+    const t = setTimeout(() => setActive(true), 800);
+    return () => clearTimeout(t);
+  }, []);
+
+  const updateRect = useCallback(() => {
+    if (!active) return;
+    setRect(getRect(STEPS[step].selector));
+  }, [active, step]);
+
+  useEffect(() => {
+    updateRect();
+    window.addEventListener("resize", updateRect);
+    window.addEventListener("scroll", updateRect);
+    return () => {
+      window.removeEventListener("resize", updateRect);
+      window.removeEventListener("scroll", updateRect);
+    };
+  }, [updateRect]);
+
+  function finish() {
+    localStorage.setItem(STORAGE_KEY, "1");
+    setActive(false);
+  }
+
+  function next() {
+    if (step < STEPS.length - 1) {
+      setStep((s) => s + 1);
+    } else {
+      finish();
+    }
+  }
+
+  if (!active) return null;
+
+  const currentStep = STEPS[step];
+  const PAD = 8;
+
+  // Card positioning: below the highlighted element if possible
+  const cardTop = rect ? rect.top + rect.height + PAD + 16 : "50%";
+  const cardLeft = rect ? Math.max(16, rect.left) : "50%";
+
+  return (
+    <>
+      {/* Dark overlay with a "hole" cut out around the target */}
+      <div className="fixed inset-0 z-[90] pointer-events-none">
+        {rect ? (
+          <svg
+            className="absolute inset-0 w-full h-full"
+            style={{ width: "100vw", height: "100vh" }}
+          >
+            <defs>
+              <mask id="tour-mask">
+                <rect width="100%" height="100%" fill="white" />
+                <rect
+                  x={rect.left - PAD}
+                  y={rect.top - PAD}
+                  width={rect.width + PAD * 2}
+                  height={rect.height + PAD * 2}
+                  rx={8}
+                  fill="black"
+                />
+              </mask>
+            </defs>
+            <rect
+              width="100%"
+              height="100%"
+              fill="rgba(0,0,0,0.65)"
+              mask="url(#tour-mask)"
+            />
+            {/* Highlight ring */}
+            <rect
+              x={rect.left - PAD}
+              y={rect.top - PAD}
+              width={rect.width + PAD * 2}
+              height={rect.height + PAD * 2}
+              rx={8}
+              fill="none"
+              stroke="rgb(251 191 36)"
+              strokeWidth="2"
+            />
+          </svg>
+        ) : (
+          <div className="absolute inset-0 bg-black/65" />
+        )}
+      </div>
+
+      {/* Tooltip card */}
+      <div
+        className="fixed z-[100] w-72 rounded-2xl border border-white/10 bg-slate-900 p-5 shadow-2xl"
+        style={
+          rect
+            ? { top: cardTop, left: cardLeft }
+            : { top: "50%", left: "50%", transform: "translate(-50%,-50%)" }
+        }
+      >
+        {/* Step indicator + close */}
+        <div className="mb-3 flex items-center justify-between">
+          <span className="text-xs text-amber-400 font-medium">
+            Step {step + 1} of {STEPS.length}
+          </span>
+          <button
+            onClick={finish}
+            className="rounded-full p-1 text-slate-500 hover:text-white"
+            aria-label="Skip tour"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <h3 className="text-base font-semibold text-white mb-1">
+          {currentStep.title}
+        </h3>
+        <p className="text-sm text-slate-400 leading-relaxed">
+          {currentStep.description}
+        </p>
+
+        <div className="mt-4 flex items-center justify-between">
+          <button
+            onClick={finish}
+            className="text-xs text-slate-500 hover:text-slate-300 underline"
+          >
+            Skip tour
+          </button>
+          <button
+            onClick={next}
+            className="inline-flex items-center gap-1 rounded-full bg-amber-400 px-4 py-1.5 text-sm font-medium text-slate-950 hover:bg-amber-300"
+          >
+            {step < STEPS.length - 1 ? (
+              <>
+                Next <ChevronRight className="h-4 w-4" />
+              </>
+            ) : (
+              "Done"
+            )}
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/faq-section.tsx
+++ b/src/components/faq-section.tsx
@@ -3,67 +3,162 @@
 import { useState } from "react";
 import { ChevronDown } from "lucide-react";
 
-export default function FaqSection() {
-  const [openIndex, setOpenIndex] = useState<number | null>(0);
+type FaqItem = { question: string; answer: string };
 
-  const faqs = [
-    {
-      question: "What is PromptHash?",
-      answer:
-        "PromptHash is an AI prompt marketplace where creators can sell their prompts and users can discover high-quality prompts for various AI models. Our platform supports prompts for text generation, image creation, code assistance, and more.",
-    },
-    {
-      question: "How do I sell my prompts on PromptHash?",
-      answer:
-        "To sell prompts on PromptHash, create an account, verify your identity, and submit your prompts for review. Once approved, your prompts will be listed on the marketplace, and you'll earn revenue whenever someone purchases them.",
-    },
-    {
-      question: "What payment methods do you accept?",
-      answer:
-        "We accept various payment methods including credit/debit cards, PayPal, and cryptocurrency (STRK, ETH, and BTC). All transactions are secure and encrypted.",
-    },
-    {
-      question: "How does the hackathon work?",
-      answer:
-        "Our hackathon is a time-limited competition where participants create innovative AI prompts or applications using our platform. Submissions are judged based on creativity, utility, and technical implementation. Winners receive prizes and recognition in the PromptHash community.",
-    },
-    {
-      question: "Can I request a custom prompt?",
-      answer:
-        "Yes! You can request custom prompts from our top creators. Simply browse creator profiles, find someone whose style matches your needs, and send them a custom request with your requirements.",
-    },
-  ];
+const buyerFaqs: FaqItem[] = [
+  {
+    question: "What is XLM and do I need it to buy prompts?",
+    answer:
+      "XLM (Lumens) is the native token of the Stellar network. Yes — all purchases on PromptHash are settled in XLM. You'll need a Stellar-compatible wallet with a small XLM balance to cover the prompt price plus a negligible network fee (typically < 0.001 XLM).",
+  },
+  {
+    question: "How do I purchase a prompt?",
+    answer:
+      "Connect your Stellar wallet, browse the marketplace, and click 'Buy Access' on any listing. Your wallet will prompt you to sign a transaction. Once the Soroban contract confirms payment, you can unlock and view the full prompt text immediately.",
+  },
+  {
+    question: "What do I actually receive after purchasing?",
+    answer:
+      "You receive a license to use the prompt — not ownership of it. The contract records your wallet address as a verified buyer, which lets the unlock API decrypt and return the plaintext to you at any time.",
+  },
+  {
+    question: "Can I re-sell or transfer my access?",
+    answer:
+      "License transferability depends on the terms the creator set when listing. Some prompts allow resale (with automatic royalties back to the creator); others are bound to the purchasing wallet. Check the listing details before buying.",
+  },
+  {
+    question: "What happens if I lose access to my wallet?",
+    answer:
+      "Access is tied to your wallet's public key. If you lose the private key you will not be able to prove ownership and unlock the prompt. Always keep your seed phrase backed up securely.",
+  },
+  {
+    question: "Are refunds available?",
+    answer:
+      "Because payments settle instantly on-chain and prompt content is revealed to the buyer at the moment of purchase, refunds cannot be processed automatically. Contact the creator directly if you have a dispute.",
+  },
+];
+
+const creatorFaqs: FaqItem[] = [
+  {
+    question: "How are my prompts protected from theft?",
+    answer:
+      "Your prompt text is encrypted with AES-GCM in your browser before upload. Only the ciphertext is stored — on-chain and in our database. The plaintext is never exposed without a valid on-chain purchase proof, so even PromptHash staff cannot read it.",
+  },
+  {
+    question: "How do I earn revenue from my prompts?",
+    answer:
+      "Set a price in XLM when listing your prompt. Every time a buyer purchases access the Soroban contract transfers the XLM directly to your wallet, minus the configurable platform fee. No withdrawal step needed — it's instant.",
+  },
+  {
+    question: "Can I sell the same prompt to multiple buyers?",
+    answer:
+      "Yes — that's the core model. You publish once and the contract tracks an unlimited number of independent buyers. You keep creative ownership while each buyer receives their own access license.",
+  },
+  {
+    question: "What happens if I update or delete a prompt?",
+    answer:
+      "Buyers who already purchased retain their access rights. If you update the prompt text, existing buyers will see the new version when they next unlock it. Delisting a prompt removes it from discovery but does not revoke existing licenses.",
+  },
+  {
+    question: "How do I configure revenue splits with collaborators?",
+    answer:
+      "When creating a listing you can specify multiple recipient addresses and their percentage shares in the fee-split field. The Soroban contract enforces these splits in stroops so every payout is transparent and automatic.",
+  },
+  {
+    question: "Is there a minimum price I must charge?",
+    answer:
+      "There is no hard minimum enforced by the platform, but Stellar requires every transaction to cover the base network fee (~0.00001 XLM). Setting a price of 0 XLM is technically possible but means you earn nothing from purchases.",
+  },
+];
+
+type TabKey = "buyers" | "creators";
+
+interface AccordionProps {
+  items: FaqItem[];
+  prefix: string;
+}
+
+function Accordion({ items, prefix }: AccordionProps) {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
 
   return (
-    <section className="py-16 bg-gray-950">
-      <div className="container">
-        <h2 className="text-2xl font-bold text-center mb-12">
+    <div className="divide-y divide-white/10">
+      {items.map((faq, index) => {
+        const isOpen = openIndex === index;
+        const btnId = `${prefix}-btn-${index}`;
+        const panelId = `${prefix}-panel-${index}`;
+        return (
+          <div key={index} className="py-5">
+            <button
+              id={btnId}
+              onClick={() => setOpenIndex(isOpen ? null : index)}
+              aria-expanded={isOpen}
+              aria-controls={panelId}
+              className="flex w-full items-center justify-between text-left"
+            >
+              <h3 className="text-base font-medium text-white">
+                {faq.question}
+              </h3>
+              <ChevronDown
+                className={`size-5 shrink-0 text-amber-400 transition-transform ${
+                  isOpen ? "rotate-180" : ""
+                }`}
+              />
+            </button>
+
+            <div
+              id={panelId}
+              role="region"
+              aria-labelledby={btnId}
+              hidden={!isOpen}
+              className="mt-3 text-sm leading-relaxed text-slate-400"
+            >
+              <p>{faq.answer}</p>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function FaqSection() {
+  const [tab, setTab] = useState<TabKey>("buyers");
+
+  return (
+    <section className="mx-auto max-w-7xl px-6 py-20">
+      <div className="text-center mb-10">
+        <p className="text-sm uppercase tracking-[0.3em] text-amber-300 mb-3">
+          Help
+        </p>
+        <h2 className="text-3xl font-bold text-white sm:text-4xl">
           Frequently Asked Questions
         </h2>
+      </div>
 
-        <div className="max-w-3xl mx-auto divide-y divide-gray-800">
-          {faqs.map((faq, index) => (
-            <div key={index} className="py-5">
-              <button
-                onClick={() => setOpenIndex(openIndex === index ? null : index)}
-                className="flex w-full items-center justify-between text-left"
-              >
-                <h3 className="text-lg font-medium">{faq.question}</h3>
-                <ChevronDown
-                  className={`size-5 transition-transform ${
-                    openIndex === index ? "rotate-180" : ""
-                  }`}
-                />
-              </button>
+      {/* Tab switcher */}
+      <div className="mx-auto mb-8 flex max-w-xs rounded-full border border-white/10 bg-slate-900/60 p-1">
+        {(["buyers", "creators"] as TabKey[]).map((key) => (
+          <button
+            key={key}
+            onClick={() => setTab(key)}
+            className={`flex-1 rounded-full py-2 text-sm font-medium transition-colors ${
+              tab === key
+                ? "bg-amber-400 text-slate-950"
+                : "text-slate-400 hover:text-white"
+            }`}
+          >
+            {key === "buyers" ? "For Buyers" : "For Creators"}
+          </button>
+        ))}
+      </div>
 
-              {openIndex === index && (
-                <div className="mt-3 text-gray-400">
-                  <p>{faq.answer}</p>
-                </div>
-              )}
-            </div>
-          ))}
-        </div>
+      <div className="mx-auto max-w-3xl rounded-2xl border border-white/10 bg-slate-950/60 px-8 py-2">
+        {tab === "buyers" ? (
+          <Accordion items={buyerFaqs} prefix="buyer" />
+        ) : (
+          <Accordion items={creatorFaqs} prefix="creator" />
+        )}
       </div>
     </section>
   );

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -66,7 +66,9 @@ export function Navigation() {
         <div className="hidden items-center gap-2 md:flex md:gap-4">
           <ThemeToggle />
           <SellerNotificationCenter />
-          <DisplayWallet />
+          <span data-tour="connect-wallet">
+            <DisplayWallet />
+          </span>
         </div>
 
         <Sheet>

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,53 @@
+import { useEffect } from "react";
+
+interface UseKeyboardShortcutsOptions {
+  onShowShortcuts: () => void;
+}
+
+export function useKeyboardShortcuts({
+  onShowShortcuts,
+}: UseKeyboardShortcutsOptions): void {
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      const target = e.target as HTMLElement;
+      const isTyping =
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable;
+
+      // `/` — focus search bar (skip when already typing)
+      if (e.key === "/" && !isTyping) {
+        e.preventDefault();
+        const searchInput = document.querySelector<HTMLInputElement>(
+          'input[placeholder*="earch"], input[type="search"]'
+        );
+        searchInput?.focus();
+        return;
+      }
+
+      // `Escape` — close modals / blur active element
+      if (e.key === "Escape") {
+        document.dispatchEvent(new CustomEvent("close-modal"));
+        (document.activeElement as HTMLElement | null)?.blur();
+        return;
+      }
+
+      // `Ctrl/Cmd + S` — save-prompt
+      if (e.key === "s" && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        document.dispatchEvent(new CustomEvent("save-prompt"));
+        return;
+      }
+
+      // `?` — show shortcuts modal (skip when typing)
+      if (e.key === "?" && !isTyping) {
+        e.preventDefault();
+        onShowShortcuts();
+        return;
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onShowShortcuts]);
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -17,6 +17,8 @@ import { Button } from "@/components/ui/button";
 import { MarketplaceAnalyticsCards } from "@/components/analytics/MarketplaceAnalyticsCards";
 import { usePageMeta } from "@/lib/seo/usePageMeta";
 import { Web3Tooltip } from "@/components/Web3Tooltip";
+import FaqSection from "@/components/faq-section";
+import { OnboardingTour } from "@/components/OnboardingTour";
 
 const stats = [
   {
@@ -286,8 +288,10 @@ export default function Home() {
 
         <FeaturedCreators />
         <FeaturedPrompts />
+        <FaqSection />
       </main>
       <Footer />
+      <OnboardingTour />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **#363 — FAQ section**: Rewrote `faq-section.tsx` with a two-tab accordion (For Buyers / For Creators), 6 questions each covering XLM usage, prompt protection, revenue splits, and more. Full ARIA — every button has `aria-expanded` + `aria-controls`, every panel has `role="region"` + `aria-labelledby` + `hidden`. Integrated into `Home.tsx` before the footer.
- **#361 — Keyboard shortcuts**: Added `useKeyboardShortcuts` hook handling `/` (focus search), `Escape` (dispatch `close-modal` + blur), `Ctrl/Cmd+S` (dispatch `save-prompt`), and `?` (open shortcuts modal). Added `KeyboardShortcutsModal` component listing all shortcuts in a table. Both wired into `App.tsx`. Shortcuts skip when user is typing in an input/textarea.
- **#353 — Onboarding tour**: Added `OnboardingTour` component — 3-step first-visit flow (Connect Wallet → Search marketplace → Purchase) using an SVG mask highlight overlay. Shown only once per browser (gated by `localStorage.prompthash_onboarding_done`). Has Skip, Next, and Done buttons. Steps target `data-tour` attributes; added `data-tour="connect-wallet"` to the wallet button in `navigation.tsx`.
- **#362 — Dependabot for Rust**: Added `.github/dependabot.yml` with npm ecosystem at `/` and cargo ecosystem at `/contracts/prompt-hash`, both on a weekly Monday schedule. All cargo updates are grouped into one PR to reduce noise. Added "## Dependency Updates" section to README documenting the review process.

## Test plan

- [ ] FAQ: both buyer/creator tabs render with all questions; accordion opens/closes via keyboard (Enter/Space); screen reader announces `aria-expanded` state
- [ ] Keyboard shortcuts: press `/` in a page → search input is focused; `?` → shortcuts modal opens; `Ctrl+S` → no browser save dialog; `Esc` → `close-modal` event dispatched
- [ ] Onboarding: first visit (clear localStorage) → tour appears; Skip dismisses and sets flag; completing all steps sets `prompthash_onboarding_done`; revisit → no tour
- [ ] Dependabot PRs appear in the repo after the next Monday scan

Closes #363
Closes #361
Closes #353
Closes #362

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts with quick access to search, save, and a shortcuts help modal.
  * Introduced an onboarding tour to guide first-time users through key parts of the experience.
  * Reworked the FAQ into separate sections for different audiences with an improved expandable layout.

* **Bug Fixes**
  * Improved modal and shortcut behavior so actions close cleanly and don’t interfere while typing.

* **Documentation**
  * Expanded the README with guidance for reviewing and merging automated dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->