### PR TITLE
Add verifiable purchase receipts and contract upgrade preflight checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,11 @@ UNLOCK_PRIVATE_KEY=ZHVtbXktcHJpdmF0ZS1rZXktdmFsdWUtaGVyZQ==
 # CHALLENGE_TOKEN_ROTATION_TIMESTAMP=
 # CHALLENGE_TOKEN_GRACE_PERIOD_MS=300000
 
+# Purchase receipt signing (see docs/api-reference.md#purchase-receipts, #436)
+# Ed25519 keypair, base64-encoded — generate with libsodium's crypto_sign_keypair().
+RECEIPT_SIGNING_PUBLIC_KEY=ZHVtbXktcmVjZWlwdC1wdWJsaWMta2V5LWhlcmU=
+RECEIPT_SIGNING_PRIVATE_KEY=ZHVtbXktcmVjZWlwdC1wcml2YXRlLWtleS1oZXJl
+
 # Optional — rate limiting (falls back to in-memory when unset)
 # REDIS_URL=
 

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -55,3 +55,6 @@ jobs:
 
       - name: Build release Wasm artifacts
         run: cargo build --workspace --release --target wasm32v1-none --locked
+
+      - name: Upgrade preflight self-check (#435)
+        run: python3 scripts/preflight_upgrade.py check --self-check

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ packages/*
 !packages/.gitkeep
 !src/contracts/util.ts
 .omx/
+
+# Signed upgrade-preflight manifests (#435) — generated per run, not committed.
+deploy-manifests/

--- a/api/prompts/receipt.ts
+++ b/api/prompts/receipt.ts
@@ -1,0 +1,87 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { withObservability } from "../../src/lib/observability/wrapper";
+import { buildAndSignReceipt, type ReceiptContractConfig } from "../../src/lib/stellar/receipts";
+import connectDb from "../../server/src/db/connectDb";
+import Purchase from "../../server/src/models/Purchase";
+
+/**
+ * GET /api/prompts/receipt?promptId=&buyerWallet=&txHash=
+ *
+ * Issues an independently verifiable purchase receipt (#436). `txHash` is
+ * optional — when omitted, the most recent matching `Purchase` record is
+ * used only to look up the transaction hash; every other field on the
+ * receipt is re-derived from Stellar RPC, never from the database row.
+ */
+function getServerConfig(): ReceiptContractConfig {
+  const rpcUrl =
+    process.env.PUBLIC_STELLAR_RPC_URL ?? "https://soroban-testnet.stellar.org";
+  const networkPassphrase =
+    process.env.PUBLIC_STELLAR_NETWORK_PASSPHRASE ??
+    "Test SDF Network ; September 2015";
+  const promptHashContractId = process.env.PUBLIC_PROMPT_HASH_CONTRACT_ID ?? "";
+  const nativeAssetContractId =
+    process.env.PUBLIC_STELLAR_NATIVE_ASSET_CONTRACT_ID ??
+    "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
+
+  return {
+    rpcUrl,
+    networkPassphrase,
+    promptHashContractId,
+    nativeAssetContractId,
+    allowHttp: new URL(rpcUrl).hostname === "localhost",
+  };
+}
+
+async function handler(req: VercelRequest, res: VercelResponse): Promise<void> {
+  if (req.method !== "GET") {
+    res.status(405).json({ error: "Method not allowed." });
+    return;
+  }
+
+  const { promptId, buyerWallet, txHash: txHashParam } = req.query ?? {};
+
+  if (!promptId || !buyerWallet) {
+    res.status(400).json({ error: "promptId and buyerWallet are required." });
+    return;
+  }
+
+  try {
+    let txHash = typeof txHashParam === "string" ? txHashParam : undefined;
+
+    if (!txHash) {
+      await connectDb();
+      const purchase = await Purchase.findOne({
+        promptId: String(promptId),
+        buyerWallet: String(buyerWallet).toLowerCase(),
+      }).sort({ createdAt: -1 });
+
+      if (!purchase?.txHash) {
+        res
+          .status(404)
+          .json({ error: "No purchase transaction found for this prompt/buyer." });
+        return;
+      }
+      txHash = purchase.txHash;
+    }
+
+    const config = getServerConfig();
+    if (!config.promptHashContractId) {
+      res.status(500).json({ error: "PUBLIC_PROMPT_HASH_CONTRACT_ID is not configured." });
+      return;
+    }
+
+    const signed = await buildAndSignReceipt({
+      config,
+      promptId: String(promptId),
+      buyerWallet: String(buyerWallet),
+      txHash,
+    });
+
+    res.status(200).json(signed);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to build receipt.";
+    res.status(400).json({ error: message });
+  }
+}
+
+export default withObservability(handler, "prompts/receipt");

--- a/contracts/prompt-hash/MIGRATION.md
+++ b/contracts/prompt-hash/MIGRATION.md
@@ -1,0 +1,31 @@
+# Contract Migration Notes
+
+`scripts/preflight_upgrade.py` blocks an upgrade whenever it detects a
+breaking change to the contract's public interface (a removed/changed
+trait function, error code, storage-key/record shape, or event) relative to
+`contracts/prompt-hash/spec-baseline.json`.
+
+If a change is intentionally breaking, acknowledge **every** reported line
+here with one `ACK-BREAKING:` entry per change (copy the exact line the
+preflight tool printed), describe the migration/rollback plan below it, then
+regenerate the baseline:
+
+```bash
+python3 scripts/preflight_upgrade.py generate-baseline
+git add contracts/prompt-hash/spec-baseline.json contracts/prompt-hash/MIGRATION.md
+```
+
+## Log
+
+<!--
+Example:
+
+### 2026-01-01 — renamed `has_access` to `check_access`
+
+ACK-BREAKING: function `has_access` was removed from PromptHashTrait
+
+Migration: `has_access` was renamed to `check_access` with an identical
+signature. Existing storage is untouched — no data migration is required.
+Indexers/SDK consumers must switch to the new method name before the
+old contract version is decommissioned.
+-->

--- a/contracts/prompt-hash/spec-baseline.json
+++ b/contracts/prompt-hash/spec-baseline.json
@@ -1,0 +1,330 @@
+{
+  "data_types": {
+    "AccessPass": [
+      "pub id: u128",
+      "pub creator: Address",
+      "pub title: String",
+      "pub duration_secs: u64",
+      "pub price_stroops: i128",
+      "pub asset: Address",
+      "pub active: bool",
+      "pub sales_count: u64"
+    ],
+    "Bundle": [
+      "pub id: u128",
+      "pub creator: Address",
+      "pub title: String",
+      "pub prompt_ids: Vec<u128>",
+      "pub price_stroops: i128",
+      "pub asset: Address",
+      "pub active: bool",
+      "pub sales_count: u64",
+      "pub expires_at: u64"
+    ],
+    "CatalogPassPurchase": [
+      "pub creator: Address",
+      "pub buyer: Address",
+      "pub pass_id: u128",
+      "pub expires_at: u64"
+    ],
+    "DisputeReason": [
+      "InvalidEncryptedPayload",
+      "MissingMetadata",
+      "FailedIntegrityVerification"
+    ],
+    "DisputeStatus": [
+      "Open",
+      "Refunded",
+      "Rejected"
+    ],
+    "InstanceDataKey": [
+      "PromptCounter",
+      "FeePercentage",
+      "FeeWallet",
+      "XlmAddress",
+      "Reentrancy",
+      "ReferralPercentage",
+      "IsPaused",
+      "VoucherKey(u128",
+      "BytesN<32>)",
+      "ListingRevision(u128",
+      "u32)",
+      "PurchaseDispute(u128",
+      "Address)",
+      "Bundle(u128)",
+      "BundleCounter",
+      "CreatorBundles(Address)",
+      "AccessPass(u128)",
+      "AccessPassCounter",
+      "CreatorAccessPasses(Address)",
+      "CatalogPass(Address",
+      "Address)"
+    ],
+    "ListingConfig": [
+      "pub price: i128",
+      "pub asset: Address",
+      "pub expires_at: u64",
+      "pub splits: Vec<Split>",
+      "pub tags: Vec<String>",
+      "pub max_supply: u64"
+    ],
+    "ListingRevisionRecord": [
+      "pub prompt_id: u64",
+      "pub revision: u32",
+      "pub title: String",
+      "pub category: String",
+      "pub preview_text: String",
+      "pub image_url: String",
+      "pub price_stroops: i128",
+      "pub revised_at: u64"
+    ],
+    "PricingConfig": [
+      "pub price: i128",
+      "pub asset: Address"
+    ],
+    "Prompt": [
+      "pub id: u64",
+      "pub creator: Address",
+      "pub image_url: String",
+      "pub title: String",
+      "pub category: String",
+      "pub preview_text: String",
+      "pub encrypted_prompt: String",
+      "pub encryption_iv: String",
+      "pub wrapped_key: String",
+      "pub content_hash: BytesN<32>",
+      "pub price_stroops: i128",
+      "pub asset: Address",
+      "pub active: bool",
+      "pub sales_count: u64",
+      "pub max_supply: u64",
+      "pub expires_at: u64",
+      "pub splits: Vec<Split>",
+      "pub revision: u32",
+      "pub tags: Vec<String>"
+    ],
+    "Purchase": [
+      "pub prompt_id: u64",
+      "pub original_creator: Address",
+      "pub owner: Address",
+      "pub original_price: i128",
+      "pub last_transfer_price: i128",
+      "pub transfer_count: u32",
+      "pub last_transferred_at: u64",
+      "pub expires_at: u64"
+    ],
+    "PurchaseDispute": [
+      "pub prompt_id: u64",
+      "pub buyer: Address",
+      "pub reason: DisputeReason",
+      "pub opened_at: u64",
+      "pub resolved_at: u64",
+      "pub status: DisputeStatus"
+    ],
+    "Split": [
+      "pub recipient: Address",
+      "pub bps: u32"
+    ]
+  },
+  "errors": {
+    "AccessPassNotFound": "40",
+    "AlreadyPurchased": "5",
+    "ArithmeticOverflow": "17",
+    "BundleNotFound": "39",
+    "ContractIsPaused": "19",
+    "CreatorCannotBuy": "3",
+    "DisputeAlreadyOpen": "35",
+    "DisputeNotFound": "36",
+    "DisputeResolved": "37",
+    "DuplicateSplitRecipient": "32",
+    "FeeExceedsMaximum": "34",
+    "FeeWalletNotSet": "15",
+    "InvalidAccessDuration": "41",
+    "InvalidAsset": "26",
+    "InvalidBundle": "38",
+    "InvalidCategoryLength": "9",
+    "InvalidDiscountPercentage": "24",
+    "InvalidEncryptedPromptLength": "11",
+    "InvalidFeePercentage": "7",
+    "InvalidImageUrlLength": "13",
+    "InvalidIvLength": "14",
+    "InvalidLicenseTransfer": "30",
+    "InvalidPaymentAmount": "21",
+    "InvalidPreviewLength": "10",
+    "InvalidPrice": "6",
+    "InvalidReferralPercentage": "23",
+    "InvalidSplits": "27",
+    "InvalidTitleLength": "8",
+    "InvalidVoucher": "22",
+    "InvalidWrappedKeyLength": "12",
+    "LicenseNotFound": "29",
+    "ListingExpired": "28",
+    "MaxSupplyReached": "25",
+    "PromptInactive": "4",
+    "PromptNotFound": "2",
+    "ReentrancyGuard": "18",
+    "ReferrerCannotBeBuyerOrCreator": "20",
+    "RevisionFieldsUnchanged": "31",
+    "TooManySplits": "33",
+    "Unauthorized": "1",
+    "XlmAddressNotSet": "16"
+  },
+  "events": {
+    "AccessPassCreated": [
+      "pub pass_id: u128",
+      "pub creator: Address",
+      "pub duration_secs: u64",
+      "pub price_stroops: i128"
+    ],
+    "AccessPassPurchased": [
+      "pub pass_id: u128",
+      "pub buyer: Address",
+      "pub creator: Address",
+      "pub expires_at: u64"
+    ],
+    "BundleCreated": [
+      "pub bundle_id: u128",
+      "pub creator: Address",
+      "pub price_stroops: i128"
+    ],
+    "BundlePurchased": [
+      "pub bundle_id: u128",
+      "pub buyer: Address",
+      "pub creator: Address",
+      "pub price_stroops: i128"
+    ],
+    "ContractPausedStateChanged": [
+      "pub is_paused: bool"
+    ],
+    "DisputeOpened": [
+      "pub prompt_id: u64",
+      "pub buyer: Address"
+    ],
+    "DisputeResolved": [
+      "pub prompt_id: u64",
+      "pub buyer: Address",
+      "pub refunded: bool"
+    ],
+    "FeeUpdated": [
+      "pub new_fee_percentage: u32"
+    ],
+    "FeeWalletUpdated": [
+      "pub new_fee_wallet: Address"
+    ],
+    "LicenseTransferred": [
+      "pub prompt_id: u64",
+      "pub seller: Address",
+      "pub buyer: Address",
+      "pub creator: Address",
+      "pub resale_price: i128",
+      "pub royalty_amount: i128"
+    ],
+    "ListingExtended": [
+      "pub prompt_id: u64",
+      "pub new_expires_at: u64"
+    ],
+    "ListingRevised": [
+      "pub prompt_id: u64",
+      "pub new_revision: u32"
+    ],
+    "PlatformFeeUpdated": [
+      "pub old_fee: u32",
+      "pub new_fee: u32",
+      "pub admin: Address"
+    ],
+    "PromptAdminModerated": [
+      "pub prompt_id: u128",
+      "pub admin: Address",
+      "pub active: bool"
+    ],
+    "PromptCreated": [
+      "pub prompt_id: u64",
+      "pub creator: Address",
+      "pub price_stroops: i128",
+      "pub asset: Address"
+    ],
+    "PromptPriceUpdated": [
+      "pub prompt_id: u64",
+      "pub price_stroops: i128"
+    ],
+    "PromptPurchased": [
+      "pub prompt_id: u64",
+      "pub buyer: Address",
+      "pub creator: Address",
+      "pub price_stroops: i128",
+      "pub referrer: Option<Address>"
+    ],
+    "PromptSaleStatusUpdated": [
+      "pub prompt_id: u64",
+      "pub active: bool"
+    ],
+    "PromptTipped": [
+      "pub prompt_id: u64",
+      "pub buyer: Address",
+      "pub amount_tipped: i128"
+    ],
+    "SplitsUpdated": [
+      "pub prompt_id: u64"
+    ],
+    "VoucherAdded": [
+      "pub prompt_id: u64",
+      "pub hashed_code: soroban_sdk::BytesN<32>",
+      "pub discount_bps: u32"
+    ],
+    "VoucherRemoved": [
+      "pub prompt_id: u64",
+      "pub hashed_code: soroban_sdk::BytesN<32>"
+    ]
+  },
+  "functions": {
+    "__constructor": "fn __constructor( env: Env, admin: Address, fee_wallet: Address, xlm_sac: Address, ) -> Result<(), Error>",
+    "add_voucher": "fn add_voucher( env: Env, creator: Address, prompt_id: u64, hashed_code: BytesN<32>, discount_bps: u32, ) -> Result<(), Error>",
+    "admin_set_prompt_sale_status": "fn admin_set_prompt_sale_status( env: Env, admin: Address, prompt_id: u128, active: bool, ) -> Result<(), Error>",
+    "buy_access_pass": "fn buy_access_pass( env: Env, buyer: Address, pass_id: u128, payment_amount_stroops: i128, ) -> Result<(), Error>",
+    "buy_bundle": "fn buy_bundle( env: Env, buyer: Address, bundle_id: u128, payment_amount_stroops: i128, ) -> Result<(), Error>",
+    "buy_prompt": "fn buy_prompt( env: Env, buyer: Address, prompt_id: u64, referrer: Option<Address>, payment_amount_stroops: i128, voucher: Option<Bytes>, ) -> Result<(), Error>",
+    "buy_prompts_bulk": "fn buy_prompts_bulk( env: Env, buyer: Address, prompt_ids: Vec<u64>, payment_amounts: Vec<i128>, referrer: Option<Address>, ) -> Result<(), Error>",
+    "create_access_pass": "fn create_access_pass( env: Env, creator: Address, title: String, duration_secs: u64, price_stroops: i128, asset: Address, ) -> Result<u128, Error>",
+    "create_bundle": "fn create_bundle( env: Env, creator: Address, title: String, prompt_ids: Vec<u128>, price_stroops: i128, asset: Address, expires_at: u64, ) -> Result<u128, Error>",
+    "create_prompt": "fn create_prompt( env: Env, creator: Address, image_url: String, title: String, category: String, preview_text: String, encrypted_prompt: String, encryption_iv: String, wrapped_key: String, content_hash: BytesN<32>, listing: ListingConfig, ) -> Result<u64, Error>",
+    "extend_all_ttl": "fn extend_all_ttl(env: Env) -> Result<(), Error>",
+    "extend_listing": "fn extend_listing( env: Env, creator: Address, prompt_id: u64, new_expires_at: u64, ) -> Result<(), Error>",
+    "extend_ttl": "fn extend_ttl(env: Env, key: DataKey) -> Result<(), Error>",
+    "get_access_pass": "fn get_access_pass(env: Env, pass_id: u128) -> Result<AccessPass, Error>",
+    "get_access_passes_by_creator": "fn get_access_passes_by_creator(env: Env, creator: Address) -> Result<Vec<AccessPass>, Error>",
+    "get_all_prompts": "fn get_all_prompts(env: Env) -> Result<Vec<Prompt>, Error>",
+    "get_bundle": "fn get_bundle(env: Env, bundle_id: u128) -> Result<Bundle, Error>",
+    "get_bundles_by_creator": "fn get_bundles_by_creator(env: Env, creator: Address) -> Result<Vec<Bundle>, Error>",
+    "get_dispute": "fn get_dispute(env: Env, prompt_id: u64, buyer: Address) -> Result<PurchaseDispute, Error>",
+    "get_fee_percentage": "fn get_fee_percentage(env: Env) -> u32",
+    "get_fee_wallet": "fn get_fee_wallet(env: Env) -> Option<Address>",
+    "get_listing_revision": "fn get_listing_revision( env: Env, prompt_id: u64, revision: u32, ) -> Result<ListingRevisionRecord, Error>",
+    "get_platform_fee": "fn get_platform_fee(env: Env) -> u32",
+    "get_prompt": "fn get_prompt(env: Env, prompt_id: u64) -> Result<Prompt, Error>",
+    "get_prompts_by_buyer": "fn get_prompts_by_buyer(env: Env, buyer: Address) -> Result<Vec<Prompt>, Error>",
+    "get_prompts_by_category": "fn get_prompts_by_category(env: Env, category: String) -> Result<Vec<Prompt>, Error>",
+    "get_prompts_by_creator": "fn get_prompts_by_creator(env: Env, creator: Address) -> Result<Vec<Prompt>, Error>",
+    "get_prompts_by_ids": "fn get_prompts_by_ids(env: Env, prompt_ids: Vec<u64>) -> Result<Vec<Prompt>, Error>",
+    "get_prompts_by_tag": "fn get_prompts_by_tag(env: Env, tag: String) -> Result<Vec<Prompt>, Error>",
+    "get_referral_percentage": "fn get_referral_percentage(env: Env) -> u32",
+    "get_xlm_sac": "fn get_xlm_sac(env: Env) -> Option<Address>",
+    "has_access": "fn has_access(env: Env, user: Address, prompt_id: u64) -> Result<bool, Error>",
+    "is_paused": "fn is_paused(env: Env) -> bool",
+    "lease_prompt": "fn lease_prompt( env: Env, buyer: Address, prompt_id: u64, lease_duration_secs: u64, ) -> Result<(), Error>",
+    "open_dispute": "fn open_dispute( env: Env, buyer: Address, prompt_id: u64, reason: DisputeReason, ) -> Result<(), Error>",
+    "remove_voucher": "fn remove_voucher( env: Env, creator: Address, prompt_id: u64, hashed_code: BytesN<32>, ) -> Result<(), Error>",
+    "resolve_dispute": "fn resolve_dispute( env: Env, admin: Address, prompt_id: u64, buyer: Address, refund: bool, ) -> Result<(), Error>",
+    "revise_listing": "fn revise_listing( env: Env, creator: Address, prompt_id: u64, title: String, category: String, preview_text: String, image_url: String, price_stroops: i128, ) -> Result<u32, Error>",
+    "set_fee_percentage": "fn set_fee_percentage(env: Env, new_fee_percentage: u32) -> Result<(), Error>",
+    "set_fee_wallet": "fn set_fee_wallet(env: Env, new_fee_wallet: Address) -> Result<(), Error>",
+    "set_pause_status": "fn set_pause_status(env: Env, paused: bool) -> Result<(), Error>",
+    "set_prompt_max_supply": "fn set_prompt_max_supply( env: Env, creator: Address, prompt_id: u64, max_supply: u64, ) -> Result<(), Error>",
+    "set_prompt_sale_status": "fn set_prompt_sale_status( env: Env, creator: Address, prompt_id: u64, active: bool, ) -> Result<(), Error>",
+    "set_referral_percentage": "fn set_referral_percentage(env: Env, new_referral_percentage: u32) -> Result<(), Error>",
+    "transfer_license": "fn transfer_license( env: Env, seller: Address, prompt_id: u64, new_buyer: Address, resale_price: i128, ) -> Result<(), Error>",
+    "update_platform_fee": "fn update_platform_fee(env: Env, admin: Address, new_fee: u32) -> Result<(), Error>",
+    "update_prompt_price": "fn update_prompt_price( env: Env, creator: Address, prompt_id: u64, price_stroops: i128, ) -> Result<(), Error>",
+    "update_splits": "fn update_splits( env: Env, creator: Address, prompt_id: u64, new_splits: Vec<Split>, ) -> Result<(), Error>",
+    "upgrade": "fn upgrade(env: Env, new_wasm_hash: BytesN<32>) -> Result<(), Error>"
+  }
+}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -236,6 +236,42 @@ Issues a short-lived challenge token for wallet verification.
 
 Verifies the wallet signature and on-chain entitlement before returning decrypted content.
 
+## Purchase Receipts (#436)
+
+### Get a purchase receipt
+
+`GET /api/prompts/receipt?promptId=&buyerWallet=&txHash=`
+
+`txHash` is optional — when omitted, the most recent matching `Purchase`
+record is used only to look up the hash. Every other field is re-derived
+from the confirmed transaction and its contract event on Stellar RPC, never
+from the (mutable) database row. Responds with:
+
+```json
+{
+  "receipt": { "version": 1, "network": { ... }, "contract": { ... }, "prompt": { ... }, "buyer": "G...", "amount": { "stroops": "..." }, "transaction": { ... }, "event": { ... } },
+  "signature": "base64 Ed25519 signature over the canonicalized receipt",
+  "signerPublicKey": "base64 Ed25519 public key"
+}
+```
+
+Verify a receipt independently — against Stellar RPC only, no PromptHash API
+or database access required — with `@prompthash/sdk`:
+
+```ts
+import { verifyReceipt } from "@prompthash/sdk";
+
+const result = await verifyReceipt(receipt, signature, signerPublicKey);
+// result.valid, result.checks.{signatureValid,networkMatches,transactionFound,transactionSucceeded,eventMatches}
+// result.currentEntitlement — best-effort live has_access/dispute signal, never affects `valid`
+```
+
+`result.valid` is `true` only when the signature checks out **and** the
+referenced transaction is found, succeeded, on the claimed network, and its
+decoded event matches every receipt field exactly — so a receipt with any
+tampered field, a wrong-network mismatch, or an orphaned/failed transaction
+fails verification.
+
 ## Notes For Frontend Contributors
 
 - Listing metadata is normalized server-side before persistence.

--- a/docs/operations/contract-upgrades.md
+++ b/docs/operations/contract-upgrades.md
@@ -52,3 +52,51 @@ Execute the upgrade script from the repository root:
 - **Always test upgrades on `testnet`** before executing them on production.
 - If you're altering data structures (e.g. adding fields to `Prompt`), ensure you test the migration path thoroughly. Soroban strictly enforces data types; reading an old `Prompt` struct as a new `Prompt` struct with different fields will panic if not explicitly handled via enum versioning or backward-compatible storage keys.
 - Monitor fee configurations post-upgrade to ensure no regression occurs.
+
+## Preflight Checks (#435)
+
+`scripts/upgrade.sh` runs `scripts/preflight_upgrade.py check` before it
+builds or touches the network. The gate:
+
+1. **Diffs the contract's public interface** — `PromptHashTrait` functions,
+   `Error` codes, every `#[contracttype]` enum/struct (storage keys and
+   record layouts), and `#[contractevent]` structs — against the checked-in
+   snapshot at `contracts/prompt-hash/spec-baseline.json`. Removing or
+   reshaping any of these is a breaking change; additions are not.
+2. **Fails the upgrade** if a breaking change is found and it hasn't been
+   acknowledged in `contracts/prompt-hash/MIGRATION.md` (see that file for
+   the exact format). CI runs the same diff offline on every PR that touches
+   `contracts/**` via `python3 scripts/preflight_upgrade.py check --self-check`.
+3. **Validates the deployment environment** — `CONTRACT_ID` is set and not a
+   placeholder, the RPC endpoint is reachable, and the `ADMIN_ALIAS` identity
+   is configured in the local `stellar-cli` — before any Wasm is built or
+   installed.
+4. **Writes a deployment manifest** to `deploy-manifests/` recording the
+   network, contract ID, git commit, baseline/spec hashes, and any
+   acknowledged breaking changes. Set `MANIFEST_SIGNING_KEY` to the path of
+   an Ed25519/RSA private key (PEM) to have the manifest signed with
+   `openssl dgst -sha256 -sign`; otherwise it's written unsigned with
+   instructions to sign it retroactively.
+
+After an intentional interface change, regenerate the baseline and commit it:
+
+```bash
+python3 scripts/preflight_upgrade.py generate-baseline
+```
+
+### Rollback / forward-fix
+
+- **Rollback:** every `deploy-manifests/*.json` file records the Wasm hash
+  that was live *before* the upgrade it describes (via `stellar contract
+  install` output kept in your deploy history — installed Wasm blobs remain
+  addressable by hash indefinitely). Re-run the `upgrade` invocation with
+  that previous hash to revert:
+  ```bash
+  stellar contract invoke --id $CONTRACT_ID --source $ADMIN_ALIAS \
+    --network $NETWORK -- upgrade --new_wasm_hash <previous_wasm_hash>
+  ```
+- **Forward-fix:** patch the source, regenerate the baseline if the fix is
+  itself interface-breaking, and run `scripts/upgrade.sh` again — the
+  preflight gate re-validates the new version before it ships.
+- Exercise both paths on `testnet` first; `scripts/verify.sh` confirms the
+  contract is responsive and correctly configured after either action.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -16,9 +16,11 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@stellar/stellar-sdk": "^13.0.0"
+    "@stellar/stellar-sdk": "^13.0.0",
+    "libsodium-wrappers": "^0.8.4"
   },
   "devDependencies": {
+    "@types/libsodium-wrappers": "^0.7.14",
     "typescript": "^5.0.0",
     "vitest": "^2.0.0"
   }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -7,3 +7,11 @@
 
 export { PromptHashClient } from "./client.js";
 export type { PromptInfo, PurchaseResult, ClientConfig } from "./types.js";
+export { verifyReceipt, canonicalizeReceipt } from "./receipts.js";
+export type {
+  PurchaseReceipt,
+  SignedPurchaseReceipt,
+  ReceiptCurrentEntitlement,
+  ReceiptVerificationResult,
+} from "./types.js";
+export type { VerifyReceiptOptions } from "./receipts.js";

--- a/packages/sdk/src/receipts.test.ts
+++ b/packages/sdk/src/receipts.test.ts
@@ -1,0 +1,255 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import sodium from "libsodium-wrappers";
+import { Keypair, StrKey, nativeToScVal } from "@stellar/stellar-sdk";
+import type { PurchaseReceipt } from "./types.js";
+
+interface FakeState {
+  network: { passphrase: string };
+  transaction: { status: string; ledger?: number };
+  events: Array<{ txHash: string; topic: unknown[]; value: unknown }>;
+  simulationResult: unknown;
+  accountSequence: string;
+}
+
+const { state, FakeServer } = vi.hoisted(() => {
+  const state: FakeState = {
+    network: { passphrase: "" },
+    transaction: { status: "NOT_FOUND" },
+    events: [],
+    simulationResult: { error: "no simulation configured" },
+    accountSequence: "1",
+  };
+
+  class FakeServer {
+    constructor(_url: string, _opts?: unknown) {}
+    async getNetwork() {
+      return state.network;
+    }
+    async getTransaction(_hash: string) {
+      return state.transaction;
+    }
+    async getEvents(_request: unknown) {
+      return { events: state.events };
+    }
+    async getAccount(publicKey: string) {
+      return { accountId: () => publicKey, sequenceNumber: () => state.accountSequence };
+    }
+    async simulateTransaction(_tx: unknown) {
+      return state.simulationResult;
+    }
+  }
+
+  return { state, FakeServer };
+});
+
+vi.mock("@stellar/stellar-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@stellar/stellar-sdk")>();
+  return {
+    ...actual,
+    rpc: { ...actual.rpc, Server: FakeServer },
+  };
+});
+
+const { verifyReceipt, canonicalizeReceipt } = await import("./receipts.js");
+
+const NETWORK_PASSPHRASE = "Test SDF Network ; September 2015";
+const RPC_URL = "https://soroban-testnet.stellar.org";
+const CONTRACT_ID = StrKey.encodeContract(new Uint8Array(32).fill(7));
+
+function mkEvent(topic: string, data: Record<string, unknown>, txHash: string) {
+  return {
+    txHash,
+    topic: [nativeToScVal(topic, { type: "symbol" })],
+    value: nativeToScVal(data),
+  };
+}
+
+async function sign(receipt: PurchaseReceipt) {
+  await sodium.ready;
+  const keypair = sodium.crypto_sign_keypair();
+  const message = sodium.from_string(canonicalizeReceipt(receipt));
+  const signature = sodium.crypto_sign_detached(message, keypair.privateKey);
+  return {
+    signature: sodium.to_base64(signature, sodium.base64_variants.ORIGINAL),
+    signerPublicKey: sodium.to_base64(keypair.publicKey, sodium.base64_variants.ORIGINAL),
+  };
+}
+
+function baseReceipt(overrides: Partial<PurchaseReceipt> = {}): PurchaseReceipt {
+  return {
+    version: 1,
+    network: { passphrase: NETWORK_PASSPHRASE, rpcUrl: RPC_URL },
+    contract: { id: CONTRACT_ID },
+    prompt: { id: "42", revision: 0 },
+    buyer: Keypair.random().publicKey(),
+    asset: { contractId: "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC" },
+    amount: { stroops: "10000000" },
+    transaction: { hash: "a".repeat(64), ledger: 1000, createdAt: new Date().toISOString() },
+    event: { topic: "PromptPurchased", index: 0 },
+    issuedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function configureOnChainTruth(receipt: PurchaseReceipt) {
+  state.network = { passphrase: receipt.network.passphrase };
+  state.transaction = { status: "SUCCESS", ledger: receipt.transaction.ledger };
+  state.events = [
+    mkEvent(
+      receipt.event.topic,
+      {
+        prompt_id: BigInt(receipt.prompt.id),
+        buyer: receipt.buyer,
+        price_stroops: BigInt(receipt.amount.stroops),
+      },
+      receipt.transaction.hash,
+    ),
+  ];
+}
+
+beforeEach(() => {
+  state.network = { passphrase: "" };
+  state.transaction = { status: "NOT_FOUND" };
+  state.events = [];
+  state.simulationResult = { error: "no simulation configured" };
+  state.accountSequence = "1";
+});
+
+describe("verifyReceipt", () => {
+  it("passes every check for an untampered receipt matching on-chain truth", async () => {
+    const receipt = baseReceipt();
+    configureOnChainTruth(receipt);
+    const { signature, signerPublicKey } = await sign(receipt);
+
+    const result = await verifyReceipt(receipt, signature, signerPublicKey, {
+      skipEntitlementCheck: true,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.checks).toEqual({
+      signatureValid: true,
+      networkMatches: true,
+      transactionFound: true,
+      transactionSucceeded: true,
+      eventMatches: true,
+    });
+    expect(result.errors).toEqual([]);
+  });
+
+  it("fails when a field is altered after signing (signature tamper)", async () => {
+    const receipt = baseReceipt();
+    configureOnChainTruth(receipt);
+    const { signature, signerPublicKey } = await sign(receipt);
+
+    const tampered: PurchaseReceipt = { ...receipt, amount: { stroops: "999999999" } };
+
+    const result = await verifyReceipt(tampered, signature, signerPublicKey, {
+      skipEntitlementCheck: true,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.checks.signatureValid).toBe(false);
+  });
+
+  it("fails eventMatches when a validly-signed receipt disagrees with on-chain truth", async () => {
+    const receipt = baseReceipt({ amount: { stroops: "1" } });
+    configureOnChainTruth({ ...receipt, amount: { stroops: "10000000" } });
+    const { signature, signerPublicKey } = await sign(receipt);
+
+    const result = await verifyReceipt(receipt, signature, signerPublicKey, {
+      skipEntitlementCheck: true,
+    });
+
+    expect(result.checks.signatureValid).toBe(true);
+    expect(result.checks.eventMatches).toBe(false);
+    expect(result.valid).toBe(false);
+  });
+
+  it("fails networkMatches when the RPC endpoint is on a different network", async () => {
+    const receipt = baseReceipt();
+    configureOnChainTruth(receipt);
+    state.network = { passphrase: "Public Global Stellar Network ; September 2015" };
+    const { signature, signerPublicKey } = await sign(receipt);
+
+    const result = await verifyReceipt(receipt, signature, signerPublicKey, {
+      skipEntitlementCheck: true,
+    });
+
+    expect(result.checks.networkMatches).toBe(false);
+    expect(result.valid).toBe(false);
+  });
+
+  it("fails transactionFound for an orphaned/unconfirmed transaction", async () => {
+    const receipt = baseReceipt();
+    configureOnChainTruth(receipt);
+    state.transaction = { status: "NOT_FOUND" };
+    const { signature, signerPublicKey } = await sign(receipt);
+
+    const result = await verifyReceipt(receipt, signature, signerPublicKey, {
+      skipEntitlementCheck: true,
+    });
+
+    expect(result.checks.transactionFound).toBe(false);
+    expect(result.valid).toBe(false);
+  });
+
+  it("fails transactionSucceeded for a failed transaction", async () => {
+    const receipt = baseReceipt();
+    configureOnChainTruth(receipt);
+    state.transaction = { status: "FAILED", ledger: receipt.transaction.ledger };
+    const { signature, signerPublicKey } = await sign(receipt);
+
+    const result = await verifyReceipt(receipt, signature, signerPublicKey, {
+      skipEntitlementCheck: true,
+    });
+
+    expect(result.checks.transactionFound).toBe(true);
+    expect(result.checks.transactionSucceeded).toBe(false);
+    expect(result.valid).toBe(false);
+  });
+
+  it("reports a refunded purchase via the current-entitlement signal without affecting historical validity", async () => {
+    const receipt = baseReceipt();
+    configureOnChainTruth(receipt);
+    const { signature, signerPublicKey } = await sign(receipt);
+
+    state.simulationResult = {
+      result: { retval: nativeToScVal(false, { type: "bool" }) },
+    };
+
+    const result = await verifyReceipt(receipt, signature, signerPublicKey, {
+      simulationAccount: receipt.buyer,
+    });
+
+    expect(result.valid).toBe(true); // the purchase itself still verifiably happened
+    expect(result.currentEntitlement?.hasAccess).toBe(false);
+  });
+
+  it("reports transferred/expired licenses as hasAccess:false with no dispute on record", async () => {
+    const receipt = baseReceipt();
+    configureOnChainTruth(receipt);
+    const { signature, signerPublicKey } = await sign(receipt);
+
+    let call = 0;
+    const originalSimulate = FakeServer.prototype.simulateTransaction;
+    FakeServer.prototype.simulateTransaction = async function () {
+      call += 1;
+      // First call: has_access -> false. Second call: get_dispute -> simulation error (no record).
+      if (call === 1) {
+        return { result: { retval: nativeToScVal(false, { type: "bool" }) } };
+      }
+      return { error: "no dispute found" };
+    };
+
+    const result = await verifyReceipt(receipt, signature, signerPublicKey, {
+      simulationAccount: receipt.buyer,
+    });
+
+    FakeServer.prototype.simulateTransaction = originalSimulate;
+
+    expect(result.valid).toBe(true);
+    expect(result.currentEntitlement?.hasAccess).toBe(false);
+    expect(result.currentEntitlement?.disputeStatus).toBeUndefined();
+  });
+});

--- a/packages/sdk/src/receipts.ts
+++ b/packages/sdk/src/receipts.ts
@@ -1,0 +1,262 @@
+/**
+ * Standalone purchase-receipt verifier — Issue #436.
+ *
+ * Validates a `PurchaseReceipt` directly against Stellar RPC. No PromptHash
+ * API or database access is required: every check re-derives the truth from
+ * the ledger itself and the receipt's own signature, so a receipt stays
+ * verifiable after index rebuilds or API key rotation.
+ */
+import {
+  Account,
+  BASE_FEE,
+  Contract,
+  TransactionBuilder,
+  nativeToScVal,
+  rpc as StellarRpc,
+  scValToNative,
+} from "@stellar/stellar-sdk";
+import sodium from "libsodium-wrappers";
+import type {
+  PurchaseReceipt,
+  ReceiptCurrentEntitlement,
+  ReceiptVerificationResult,
+} from "./types.js";
+
+/** Deterministic (sorted-key) JSON serialization used for both signing and verifying. */
+export function canonicalizeReceipt(receipt: PurchaseReceipt): string {
+  return JSON.stringify(sortKeysDeep(receipt));
+}
+
+function sortKeysDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeysDeep);
+  if (value !== null && typeof value === "object") {
+    return Object.keys(value as Record<string, unknown>)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = sortKeysDeep((value as Record<string, unknown>)[key]);
+        return acc;
+      }, {});
+  }
+  return value;
+}
+
+async function verifySignature(
+  receipt: PurchaseReceipt,
+  signature: string,
+  signerPublicKey: string,
+): Promise<boolean> {
+  await sodium.ready;
+  try {
+    const message = sodium.from_string(canonicalizeReceipt(receipt));
+    const sig = sodium.from_base64(signature, sodium.base64_variants.ORIGINAL);
+    const pk = sodium.from_base64(signerPublicKey, sodium.base64_variants.ORIGINAL);
+    return sodium.crypto_sign_verify_detached(sig, message, pk);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Finds the contract event this receipt claims to reference. Prefers the
+ * event at the recorded index (its position among matching events within
+ * the same transaction) and falls back to the first same-tx match.
+ */
+async function fetchMatchingEvent(
+  server: StellarRpc.Server,
+  receipt: PurchaseReceipt,
+): Promise<StellarRpc.Api.EventResponse | undefined> {
+  const response = await server.getEvents({
+    startLedger: receipt.transaction.ledger,
+    filters: [{ type: "contract", contractIds: [receipt.contract.id] }],
+    limit: 200,
+  });
+
+  const sameTx = response.events.filter((event) => event.txHash === receipt.transaction.hash);
+  return sameTx[receipt.event.index] ?? sameTx[0];
+}
+
+export interface VerifyReceiptOptions {
+  /** Overrides the RPC endpoint the receipt itself points at (defaults to `receipt.network.rpcUrl`). */
+  rpcUrl?: string;
+  allowHttp?: boolean;
+  /** A funded account used only to simulate read-only calls (has_access / get_dispute). */
+  simulationAccount?: string;
+  /** Skip the live current-entitlement lookup and only verify the historical purchase proof. */
+  skipEntitlementCheck?: boolean;
+}
+
+/**
+ * Verifies a signed purchase receipt.
+ *
+ * `valid` is true only when the signature checks out AND the referenced
+ * transaction is found, succeeded, on the claimed network, and its decoded
+ * event matches every receipt field exactly. `currentEntitlement` is a
+ * best-effort secondary signal (does the buyer still hold the license right
+ * now) that never affects `valid`, since a receipt proves a historical
+ * purchase occurred — not present-day ownership.
+ */
+export async function verifyReceipt(
+  receipt: PurchaseReceipt,
+  signature: string,
+  signerPublicKey: string,
+  options: VerifyReceiptOptions = {},
+): Promise<ReceiptVerificationResult> {
+  const errors: string[] = [];
+  const checks = {
+    signatureValid: false,
+    networkMatches: false,
+    transactionFound: false,
+    transactionSucceeded: false,
+    eventMatches: false,
+  };
+
+  checks.signatureValid = await verifySignature(receipt, signature, signerPublicKey);
+  if (!checks.signatureValid) {
+    errors.push(
+      "Receipt signature does not match its contents — the receipt has been tampered with or was not issued by the expected signer.",
+    );
+  }
+
+  const rpcUrl = options.rpcUrl ?? receipt.network.rpcUrl;
+  const server = new StellarRpc.Server(rpcUrl, {
+    allowHttp: options.allowHttp ?? new URL(rpcUrl).hostname === "localhost",
+  });
+
+  try {
+    const network = await server.getNetwork();
+    checks.networkMatches = network.passphrase === receipt.network.passphrase;
+    if (!checks.networkMatches) {
+      errors.push(
+        `Receipt claims network "${receipt.network.passphrase}" but the RPC endpoint reports "${network.passphrase}".`,
+      );
+    }
+  } catch (err) {
+    errors.push(`Unable to reach RPC to confirm network identity: ${(err as Error).message}`);
+  }
+
+  try {
+    const tx = await server.getTransaction(receipt.transaction.hash);
+    checks.transactionFound = tx.status !== "NOT_FOUND";
+    checks.transactionSucceeded = tx.status === "SUCCESS";
+
+    if (!checks.transactionFound) {
+      errors.push(
+        "Transaction was not found on this network — it may be orphaned, unconfirmed, or belong to a different network.",
+      );
+    } else if (!checks.transactionSucceeded) {
+      errors.push(`Transaction did not succeed (status: ${tx.status}).`);
+    } else if ("ledger" in tx && tx.ledger !== receipt.transaction.ledger) {
+      errors.push(
+        `Transaction ledger (${tx.ledger}) does not match the receipt's recorded ledger (${receipt.transaction.ledger}).`,
+      );
+    }
+  } catch (err) {
+    errors.push(`Unable to fetch transaction from RPC: ${(err as Error).message}`);
+  }
+
+  if (checks.transactionFound && checks.transactionSucceeded) {
+    try {
+      const event = await fetchMatchingEvent(server, receipt);
+      if (!event) {
+        errors.push("No matching contract event found for this receipt's transaction.");
+      } else {
+        const topic = scValToNative(event.topic[0]);
+        const data = scValToNative(event.value) as Record<string, unknown>;
+        const promptId = data.prompt_id !== undefined ? String(data.prompt_id) : undefined;
+        const buyer = data.buyer !== undefined ? String(data.buyer) : undefined;
+        const priceStroops =
+          data.price_stroops !== undefined
+            ? String(data.price_stroops)
+            : data.resale_price !== undefined
+              ? String(data.resale_price)
+              : undefined;
+
+        checks.eventMatches =
+          topic === receipt.event.topic &&
+          promptId === receipt.prompt.id &&
+          buyer === receipt.buyer &&
+          priceStroops === receipt.amount.stroops;
+
+        if (!checks.eventMatches) {
+          errors.push(
+            "On-chain event fields do not match the receipt — one or more receipt fields have been altered.",
+          );
+        }
+      }
+    } catch (err) {
+      errors.push(`Unable to fetch/decode contract events: ${(err as Error).message}`);
+    }
+  }
+
+  let currentEntitlement: ReceiptCurrentEntitlement | undefined;
+  if (!options.skipEntitlementCheck) {
+    currentEntitlement = await checkCurrentEntitlement(server, receipt, options).catch(
+      () => undefined,
+    );
+  }
+
+  const valid =
+    checks.signatureValid &&
+    checks.networkMatches &&
+    checks.transactionFound &&
+    checks.transactionSucceeded &&
+    checks.eventMatches;
+
+  return { valid, checks, currentEntitlement, errors };
+}
+
+/**
+ * Best-effort live read of whether the buyer still holds the license today,
+ * and whether a dispute has since refunded it. Never throws — callers treat
+ * a missing result as "unknown", not "invalid".
+ */
+async function checkCurrentEntitlement(
+  server: StellarRpc.Server,
+  receipt: PurchaseReceipt,
+  options: VerifyReceiptOptions,
+): Promise<ReceiptCurrentEntitlement> {
+  const source = options.simulationAccount ?? receipt.buyer;
+  const account = new Account(source, (await server.getAccount(source)).sequenceNumber());
+
+  const simulate = async (method: string, args: ReturnType<typeof nativeToScVal>[]) => {
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: receipt.network.passphrase,
+    })
+      .addOperation(new Contract(receipt.contract.id).call(method, ...args))
+      .setTimeout(30)
+      .build();
+    const simulation = await server.simulateTransaction(tx);
+    if (StellarRpc.Api.isSimulationError(simulation) || !simulation.result) {
+      return undefined;
+    }
+    return scValToNative(simulation.result.retval);
+  };
+
+  const hasAccessResult = await simulate("has_access", [
+    nativeToScVal(receipt.buyer, { type: "address" }),
+    nativeToScVal(BigInt(receipt.prompt.id), { type: "u64" }),
+  ]);
+
+  let disputeStatus: ReceiptCurrentEntitlement["disputeStatus"];
+  try {
+    const dispute = await simulate("get_dispute", [
+      nativeToScVal(BigInt(receipt.prompt.id), { type: "u64" }),
+      nativeToScVal(receipt.buyer, { type: "address" }),
+    ]);
+    const rawStatus = (dispute as { status?: unknown } | undefined)?.status;
+    const tag =
+      rawStatus && typeof rawStatus === "object" && "tag" in (rawStatus as Record<string, unknown>)
+        ? (rawStatus as { tag: string }).tag
+        : typeof rawStatus === "string"
+          ? rawStatus
+          : undefined;
+    if (tag === "Open" || tag === "Refunded" || tag === "Rejected") {
+      disputeStatus = tag;
+    }
+  } catch {
+    // No dispute on record for this prompt/buyer — leave undefined.
+  }
+
+  return { hasAccess: Boolean(hasAccessResult), disputeStatus };
+}

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -27,3 +27,67 @@ export interface VoteResult {
   success: boolean;
   upvotes: number;
 }
+
+/**
+ * Canonical, independently-verifiable purchase receipt (#436).
+ *
+ * Every field is derived from finalized contract state and transaction
+ * evidence — never from a mutable database row — so a receipt can be
+ * re-verified against Stellar RPC alone, without trusting the PromptHash
+ * API or database.
+ */
+export interface PurchaseReceipt {
+  version: 1;
+  network: {
+    passphrase: string;
+    rpcUrl: string;
+  };
+  contract: {
+    id: string;
+  };
+  prompt: {
+    id: string;
+    revision: number;
+  };
+  buyer: string;
+  asset: {
+    contractId: string;
+  };
+  amount: {
+    stroops: string;
+  };
+  transaction: {
+    hash: string;
+    ledger: number;
+    createdAt: string;
+  };
+  event: {
+    topic: string;
+    index: number;
+  };
+  issuedAt: string;
+}
+
+export interface SignedPurchaseReceipt {
+  receipt: PurchaseReceipt;
+  signature: string;
+  signerPublicKey: string;
+}
+
+export interface ReceiptCurrentEntitlement {
+  hasAccess: boolean;
+  disputeStatus?: "Open" | "Refunded" | "Rejected";
+}
+
+export interface ReceiptVerificationResult {
+  valid: boolean;
+  checks: {
+    signatureValid: boolean;
+    networkMatches: boolean;
+    transactionFound: boolean;
+    transactionSucceeded: boolean;
+    eventMatches: boolean;
+  };
+  currentEntitlement?: ReceiptCurrentEntitlement;
+  errors: string[];
+}

--- a/scripts/preflight_upgrade.py
+++ b/scripts/preflight_upgrade.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""
+Upgrade preflight gate for the PromptHash Soroban contract (#435).
+
+Diffs the contract's public interface (trait functions, storage-key/record
+encodings, error codes, and contract events) against a checked-in baseline
+snapshot to catch breaking storage/ABI changes before an upgrade is
+submitted, validates the deployment environment, and — on a full
+(non self-check) run — writes a deployment manifest recording exactly what
+was checked, signing it if a signing key is configured.
+
+Usage:
+    python3 scripts/preflight_upgrade.py generate-baseline
+    python3 scripts/preflight_upgrade.py check --self-check
+    NETWORK=testnet CONTRACT_ID=C... ADMIN_ALIAS=admin \\
+        python3 scripts/preflight_upgrade.py check
+"""
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONTRACT_SRC = REPO_ROOT / "contracts" / "prompt-hash" / "src"
+TYPES_RS = CONTRACT_SRC / "types.rs"
+EVENTS_RS = CONTRACT_SRC / "events.rs"
+BASELINE_PATH = REPO_ROOT / "contracts" / "prompt-hash" / "spec-baseline.json"
+MIGRATION_NOTES_PATH = REPO_ROOT / "contracts" / "prompt-hash" / "MIGRATION.md"
+MANIFEST_DIR = REPO_ROOT / "deploy-manifests"
+
+
+def normalize_ws(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def _strip_comments_and_attrs(block: str) -> str:
+    lines = []
+    for line in block.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("//") or stripped.startswith("#["):
+            continue
+        lines.append(stripped)
+    return "\n".join(lines)
+
+
+def _extract_block(text: str, header_pattern: str) -> Optional[str]:
+    match = re.search(header_pattern + r"\s*\{", text)
+    if not match:
+        return None
+    start = match.end()
+    end = text.index("}", start)
+    return text[start:end]
+
+
+def _extract_all_type_blocks(text: str) -> dict:
+    """Returns {name: {'kind', 'entries'}} for every #[contracttype] enum/struct,
+    plus the #[contracterror] enum under the reserved key '__error__'."""
+    types: dict = {}
+    for match in re.finditer(
+        r"#\[contract(type|error)\][^;]*?pub\s+(enum|struct)\s+(\w+)\s*\{",
+        text,
+        re.DOTALL,
+    ):
+        annotation, kind, name = match.groups()
+        body_start = match.end()
+        body_end = text.index("}", body_start)
+        body = _strip_comments_and_attrs(text[body_start:body_end])
+        entries = [normalize_ws(e) for e in body.split(",") if normalize_ws(e)]
+        key = "__error__" if annotation == "error" else name
+        types[key] = {"kind": kind, "entries": entries}
+    return types
+
+
+def extract_trait_functions(text: str) -> dict:
+    body = _extract_block(text, r"pub\s+trait\s+PromptHashTrait")
+    if body is None:
+        raise SystemExit("Could not find `pub trait PromptHashTrait` in types.rs")
+
+    functions: dict = {}
+    for fragment in body.split(";"):
+        cleaned = _strip_comments_and_attrs(fragment)
+        if "fn " not in cleaned:
+            continue
+        cleaned = normalize_ws(cleaned[cleaned.index("fn "):])
+        name_match = re.match(r"fn\s+(\w+)", cleaned)
+        if not name_match:
+            continue
+        functions[name_match.group(1)] = cleaned
+    return functions
+
+
+def extract_events(text: str) -> dict:
+    events: dict = {}
+    for match in re.finditer(r"#\[contractevent\]\s*struct\s+(\w+)\s*\{", text):
+        name = match.group(1)
+        body_start = match.end()
+        body_end = text.index("}", body_start)
+        body = _strip_comments_and_attrs(text[body_start:body_end])
+        events[name] = [normalize_ws(f) for f in body.split(",") if normalize_ws(f)]
+    return events
+
+
+def build_spec() -> dict:
+    types_text = TYPES_RS.read_text()
+    events_text = EVENTS_RS.read_text()
+
+    type_blocks = _extract_all_type_blocks(types_text)
+    error_entries = type_blocks.pop("__error__", {"entries": []})["entries"]
+    errors = {}
+    for entry in error_entries:
+        name, _, value = entry.partition("=")
+        errors[name.strip()] = value.strip().rstrip(",")
+
+    return {
+        "functions": extract_trait_functions(types_text),
+        "errors": errors,
+        "data_types": {name: info["entries"] for name, info in type_blocks.items()},
+        "events": extract_events(events_text),
+    }
+
+
+def spec_hash(spec: dict) -> str:
+    return hashlib.sha256(json.dumps(spec, sort_keys=True).encode()).hexdigest()
+
+
+def diff_spec(baseline: dict, current: dict) -> list:
+    """Breaking-change descriptions. Additions (new fn/error/type/event/variant) are never breaking."""
+    breaking = []
+
+    for name, sig in baseline.get("functions", {}).items():
+        if name not in current.get("functions", {}):
+            breaking.append(f"function `{name}` was removed from PromptHashTrait")
+        elif current["functions"][name] != sig:
+            breaking.append(f"function `{name}` signature changed")
+
+    for name, code in baseline.get("errors", {}).items():
+        if name not in current.get("errors", {}):
+            breaking.append(f"Error variant `{name}` (={code}) was removed")
+        elif current["errors"][name] != code:
+            breaking.append(
+                f"Error variant `{name}` discriminant changed ({code} -> {current['errors'][name]})"
+            )
+
+    for type_name, entries in baseline.get("data_types", {}).items():
+        current_entries = current.get("data_types", {}).get(type_name)
+        if current_entries is None:
+            breaking.append(f"type `{type_name}` was removed")
+            continue
+        current_set = set(current_entries)
+        for entry in entries:
+            if entry not in current_set:
+                breaking.append(f"`{type_name}`: `{entry}` was removed or changed shape")
+
+    for name, fields in baseline.get("events", {}).items():
+        current_fields = current.get("events", {}).get(name)
+        if current_fields is None:
+            breaking.append(f"event `{name}` was removed")
+        elif current_fields != fields:
+            breaking.append(f"event `{name}` field list changed")
+
+    return breaking
+
+
+def cmd_generate_baseline(_args: argparse.Namespace) -> int:
+    spec = build_spec()
+    BASELINE_PATH.write_text(json.dumps(spec, indent=2, sort_keys=True) + "\n")
+    print(f"Wrote {BASELINE_PATH.relative_to(REPO_ROOT)} ({spec_hash(spec)[:12]})")
+    return 0
+
+
+def _migration_notes_cover(breaking: list) -> Optional[str]:
+    if not MIGRATION_NOTES_PATH.exists():
+        return None
+    content = MIGRATION_NOTES_PATH.read_text()
+    acks = re.findall(r"ACK-BREAKING:\s*(.+)", content)
+    if not acks:
+        return None
+    unacknowledged = [
+        change for change in breaking if not any(change in ack or ack in change for ack in acks)
+    ]
+    return None if unacknowledged else content
+
+
+def cmd_check(args: argparse.Namespace) -> int:
+    if not BASELINE_PATH.exists():
+        print(
+            f"No baseline found at {BASELINE_PATH.relative_to(REPO_ROOT)}. "
+            "Run `generate-baseline` once and commit it.",
+            file=sys.stderr,
+        )
+        return 1
+
+    baseline = json.loads(BASELINE_PATH.read_text())
+    current = build_spec()
+    breaking = diff_spec(baseline, current)
+
+    if breaking:
+        print("BREAKING interface/storage changes detected:")
+        for change in breaking:
+            print(f"  - {change}")
+
+        if _migration_notes_cover(breaking) is None:
+            print(
+                f"\nPreflight FAILED: breaking changes must be acknowledged in "
+                f"{MIGRATION_NOTES_PATH.relative_to(REPO_ROOT)}, one `ACK-BREAKING: <description>` "
+                "line per change, before they can ship.",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"\nBreaking changes acknowledged in {MIGRATION_NOTES_PATH.name} — continuing.")
+    else:
+        print("No breaking interface/storage changes detected.")
+
+    if args.self_check:
+        return 0
+
+    env_errors = validate_environment()
+    if env_errors:
+        print("\nEnvironment preflight FAILED:", file=sys.stderr)
+        for err in env_errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+
+    write_manifest(current, breaking)
+    return 0
+
+
+def validate_environment() -> list:
+    errors = []
+    network = os.environ.get("NETWORK", "testnet")
+    contract_id = os.environ.get("CONTRACT_ID", "")
+    admin_alias = os.environ.get("ADMIN_ALIAS", "admin")
+
+    if not contract_id or contract_id.startswith("CXXXXXXXX"):
+        errors.append("CONTRACT_ID is not set or is still the placeholder.")
+
+    rpc_url = os.environ.get("RPC_URL") or {
+        "testnet": "https://soroban-testnet.stellar.org",
+        "local": "http://localhost:8000",
+    }.get(network)
+    if not rpc_url:
+        errors.append(f"No RPC_URL configured for network '{network}'.")
+    else:
+        try:
+            urllib.request.urlopen(rpc_url, timeout=5)
+        except urllib.error.HTTPError:
+            pass  # Any HTTP response (even an error code) proves the host is reachable.
+        except Exception as exc:  # noqa: BLE001 - reachability probe; report any real failure
+            errors.append(f"RPC endpoint '{rpc_url}' is unreachable: {exc}")
+
+    try:
+        result = subprocess.run(
+            ["stellar", "keys", "address", admin_alias],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode != 0:
+            errors.append(
+                f"Admin identity '{admin_alias}' is not configured in the local stellar-cli."
+            )
+    except FileNotFoundError:
+        errors.append("stellar-cli is not installed or not on PATH.")
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"Could not verify admin identity '{admin_alias}': {exc}")
+
+    return errors
+
+
+def write_manifest(current_spec: dict, breaking: list) -> None:
+    MANIFEST_DIR.mkdir(exist_ok=True)
+    git_commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"], capture_output=True, text=True, cwd=REPO_ROOT
+    ).stdout.strip()
+
+    manifest = {
+        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "network": os.environ.get("NETWORK", "testnet"),
+        "contract_id": os.environ.get("CONTRACT_ID", ""),
+        "admin_alias": os.environ.get("ADMIN_ALIAS", "admin"),
+        "git_commit": git_commit,
+        "baseline_hash": spec_hash(json.loads(BASELINE_PATH.read_text())),
+        "new_spec_hash": spec_hash(current_spec),
+        "breaking_changes": breaking,
+    }
+
+    stamp = manifest["generated_at"].replace(":", "")
+    manifest_path = MANIFEST_DIR / f"{stamp}-{manifest['network']}.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    print(f"Wrote deployment manifest: {manifest_path.relative_to(REPO_ROOT)}")
+
+    signing_key = os.environ.get("MANIFEST_SIGNING_KEY")
+    if not signing_key:
+        print(
+            "WARNING: MANIFEST_SIGNING_KEY is not set — manifest was written unsigned. "
+            "Sign it retroactively with:\n"
+            f"  openssl dgst -sha256 -sign <key.pem> -out {manifest_path}.sig {manifest_path}"
+        )
+        return
+
+    sig_path = f"{manifest_path}.sig"
+    result = subprocess.run(
+        ["openssl", "dgst", "-sha256", "-sign", signing_key, "-out", sig_path, str(manifest_path)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f"WARNING: failed to sign manifest: {result.stderr}", file=sys.stderr)
+    else:
+        print(f"Signed manifest: {sig_path}")
+        print(
+            "Verify later with:\n"
+            f"  openssl dgst -sha256 -verify <pubkey.pem> -signature {sig_path} {manifest_path}"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="PromptHash contract upgrade preflight gate.")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser(
+        "generate-baseline",
+        help="(Re)generate the checked-in spec baseline from current source.",
+    )
+
+    check_parser = sub.add_parser(
+        "check", help="Diff current source against the baseline and validate the environment."
+    )
+    check_parser.add_argument(
+        "--self-check",
+        action="store_true",
+        help=(
+            "Offline mode: only diff the spec baseline, skip live env/network checks "
+            "and manifest writing (used in CI)."
+        ),
+    )
+
+    args = parser.parse_args()
+    if args.command == "generate-baseline":
+        return cmd_generate_baseline(args)
+    return cmd_check(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -42,6 +42,14 @@ echo "🌐 Network: $NETWORK"
 echo "📄 Contract ID: $CONTRACT_ID"
 echo "🔑 Admin Alias: $ADMIN_ALIAS"
 
+# Preflight: fail fast on breaking interface/storage changes or a bad
+# deployment environment before touching the network (#435).
+echo ""
+echo "🛫 Running upgrade preflight checks..."
+NETWORK="$NETWORK" CONTRACT_ID="$CONTRACT_ID" ADMIN_ALIAS="$ADMIN_ALIAS" RPC_URL="$RPC_URL" \
+    python3 "$(dirname "$0")/preflight_upgrade.py" check
+echo "✅ Preflight checks passed."
+
 # Build and Optimize
 echo ""
 echo "📦 Building and optimizing new contract version..."

--- a/src/lib/stellar/receipts.ts
+++ b/src/lib/stellar/receipts.ts
@@ -1,0 +1,157 @@
+/**
+ * Purchase receipt construction & signing — Issue #436.
+ *
+ * Builds a canonical purchase receipt from finalized transaction and
+ * contract-event evidence (never from the mutable `Purchase` database row)
+ * and signs it so it can be independently re-verified against Stellar RPC —
+ * via `@prompthash/sdk`'s `verifyReceipt` — without needing API or database
+ * access.
+ */
+import { scValToNative } from "@stellar/stellar-sdk";
+import sodium from "libsodium-wrappers";
+import { getRpcServer, type StellarNetworkConfig } from "./tx";
+
+export interface ReceiptContractConfig extends StellarNetworkConfig {
+  promptHashContractId: string;
+  nativeAssetContractId: string;
+}
+
+export interface BuildReceiptInput {
+  config: ReceiptContractConfig;
+  promptId: string;
+  buyerWallet: string;
+  txHash: string;
+}
+
+export interface BuiltReceipt {
+  receipt: Record<string, unknown>;
+  signature: string;
+  signerPublicKey: string;
+}
+
+const PURCHASE_EVENT_TOPICS = new Set(["PromptPurchased", "LicenseTransferred"]);
+
+function sortKeysDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeysDeep);
+  if (value !== null && typeof value === "object") {
+    return Object.keys(value as Record<string, unknown>)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = sortKeysDeep((value as Record<string, unknown>)[key]);
+        return acc;
+      }, {});
+  }
+  return value;
+}
+
+/** Deterministic (sorted-key) JSON serialization — must match the SDK verifier's canonicalizer. */
+export function canonicalizeReceipt(receipt: Record<string, unknown>): string {
+  return JSON.stringify(sortKeysDeep(receipt));
+}
+
+export interface ReceiptSigningKeys {
+  publicKey: string;
+  privateKey: string;
+}
+
+/** Reads the Ed25519 receipt-signing keypair from the environment. Throws if unconfigured. */
+export function getReceiptSigningKeys(): ReceiptSigningKeys {
+  const publicKey = process.env.RECEIPT_SIGNING_PUBLIC_KEY;
+  const privateKey = process.env.RECEIPT_SIGNING_PRIVATE_KEY;
+  if (!publicKey || !privateKey) {
+    throw new Error(
+      "RECEIPT_SIGNING_PUBLIC_KEY / RECEIPT_SIGNING_PRIVATE_KEY are not configured.",
+    );
+  }
+  return { publicKey, privateKey };
+}
+
+/**
+ * Builds and signs a purchase receipt for a confirmed transaction.
+ *
+ * Looks the transaction up on-chain (never trusts a caller-supplied amount
+ * or prompt state) and locates the matching `PromptPurchased` /
+ * `LicenseTransferred` event to derive every receipt field.
+ */
+export async function buildAndSignReceipt(input: BuildReceiptInput): Promise<BuiltReceipt> {
+  const { config, promptId, buyerWallet, txHash } = input;
+  const server = getRpcServer(config);
+
+  const tx = await server.getTransaction(txHash);
+  if (tx.status !== "SUCCESS") {
+    throw new Error(`Cannot issue a receipt for a transaction with status "${tx.status}".`);
+  }
+  if (!("ledger" in tx) || typeof tx.ledger !== "number") {
+    throw new Error("Transaction result is missing ledger information.");
+  }
+
+  const events = await server.getEvents({
+    startLedger: tx.ledger,
+    filters: [{ type: "contract", contractIds: [config.promptHashContractId] }],
+    limit: 200,
+  });
+
+  const buyerLower = buyerWallet.toLowerCase();
+  const matchIndex = events.events
+    .filter((event) => event.txHash === txHash)
+    .findIndex((event) => {
+      const topic = scValToNative(event.topic[0]);
+      if (typeof topic !== "string" || !PURCHASE_EVENT_TOPICS.has(topic)) return false;
+      const data = scValToNative(event.value) as Record<string, unknown>;
+      const eventPromptId = data.prompt_id !== undefined ? String(data.prompt_id) : undefined;
+      const eventBuyer = data.buyer !== undefined ? String(data.buyer).toLowerCase() : undefined;
+      return eventPromptId === promptId && eventBuyer === buyerLower;
+    });
+
+  if (matchIndex === -1) {
+    throw new Error(
+      "No matching PromptPurchased/LicenseTransferred event found for this transaction.",
+    );
+  }
+
+  const sameTxEvents = events.events.filter((event) => event.txHash === txHash);
+  const event = sameTxEvents[matchIndex];
+  const topic = scValToNative(event.topic[0]) as string;
+  const data = scValToNative(event.value) as Record<string, unknown>;
+  const createdAt =
+    "createdAt" in tx && typeof (tx as { createdAt?: number }).createdAt === "number"
+      ? new Date((tx as { createdAt: number }).createdAt * 1000).toISOString()
+      : new Date().toISOString();
+
+  const receipt = {
+    version: 1 as const,
+    network: {
+      passphrase: config.networkPassphrase,
+      rpcUrl: config.rpcUrl,
+    },
+    contract: { id: config.promptHashContractId },
+    prompt: {
+      id: promptId,
+      revision: typeof data.revision === "number" ? data.revision : 0,
+    },
+    buyer: buyerWallet,
+    asset: { contractId: config.nativeAssetContractId },
+    amount: {
+      stroops: String(data.price_stroops ?? data.resale_price ?? "0"),
+    },
+    transaction: {
+      hash: txHash,
+      ledger: tx.ledger,
+      createdAt,
+    },
+    event: { topic, index: matchIndex },
+    issuedAt: new Date().toISOString(),
+  };
+
+  const { publicKey, privateKey } = getReceiptSigningKeys();
+  await sodium.ready;
+  const message = sodium.from_string(canonicalizeReceipt(receipt));
+  const secretKeyBytes = sodium.from_base64(privateKey, sodium.base64_variants.ORIGINAL);
+  const signatureBytes = sodium.crypto_sign_detached(message, secretKeyBytes);
+
+  return {
+    receipt,
+    signature: sodium.to_base64(signatureBytes, sodium.base64_variants.ORIGINAL),
+    signerPublicKey: publicKey,
+  };
+}


### PR DESCRIPTION
purchase receipts derived from finalized transaction and contract-event evidence (not the mutable Purchase DB row), with a standalone RPC-only verifier (@prompthash/sdk verifyReceipt) that catches tampering, wrong-network, orphaned/failed transactions, and reports live entitlement (transfers/refunds/expiry) as a non-authoritative secondary signal.
an upgrade preflight gate (scripts/preflight_upgrade.py) that diffs the contract's trait functions, error codes, storage-key/record shapes, and events against a checked-in baseline, blocking breaking changes unless acknowledged in contracts/prompt-hash/MIGRATION.md. Wired into scripts/upgrade.sh (env/network validation + signed deployment manifest) and a CI self-check job. Rollback/forward-fix procedures documented in docs/operations/contract-upgrades.md.


Closes #436
Closes #435
Closes #437
Closes #439

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added signed, independently verifiable purchase receipts based on Stellar transaction data.
  * Added SDK support for receipt generation, canonicalization, and verification.
  * Added an API endpoint for retrieving purchase receipts.
* **Documentation**
  * Documented receipt retrieval and verification.
  * Added guidance for contract upgrade preflight checks and rollback procedures.
* **Chores**
  * Added automated upgrade compatibility checks and deployment manifest handling.
  * Added receipt-signing configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->