### PR TITLE
Add versioned event schema + generated decoders (scoped slice of #424, #425)

### DIFF
--- a/contracts/prompt-hash/spec-baseline.json
+++ b/contracts/prompt-hash/spec-baseline.json
@@ -191,7 +191,8 @@
       "pub bundle_id: u128",
       "pub buyer: Address",
       "pub creator: Address",
-      "pub price_stroops: i128"
+      "pub price_stroops: i128",
+      "pub prompt_ids: soroban_sdk::Vec<u64>"
     ],
     "ContractPausedStateChanged": [
       "pub is_paused: bool"
@@ -233,7 +234,7 @@
       "pub admin: Address"
     ],
     "PromptAdminModerated": [
-      "pub prompt_id: u128",
+      "pub prompt_id: u64",
       "pub admin: Address",
       "pub active: bool"
     ],

--- a/contracts/prompt-hash/src/contract.rs
+++ b/contracts/prompt-hash/src/contract.rs
@@ -468,6 +468,7 @@ impl PromptHashTrait for PromptHashContract {
             buyer,
             bundle.creator,
             payment_amount_stroops,
+            bundle.prompt_ids,
         );
         Ok(())
     }

--- a/contracts/prompt-hash/src/events.rs
+++ b/contracts/prompt-hash/src/events.rs
@@ -151,6 +151,12 @@ struct BundlePurchased {
     pub buyer: Address,
     pub creator: Address,
     pub price_stroops: i128,
+    /// Snapshot of the prompt IDs this purchase actually granted access to,
+    /// as of purchase time (issue #425). The bundle's `prompt_ids` field
+    /// could differ later, so consumers should rely on this event field —
+    /// not a live read of the bundle — to reconstruct what a given
+    /// purchase covered.
+    pub prompt_ids: soroban_sdk::Vec<u64>,
 }
 
 #[contractevent]
@@ -349,12 +355,14 @@ impl Events {
         buyer: Address,
         creator: Address,
         price_stroops: i128,
+        prompt_ids: soroban_sdk::Vec<u64>,
     ) {
         BundlePurchased {
             bundle_id,
             buyer,
             creator,
             price_stroops,
+            prompt_ids,
         }
         .publish(env);
     }

--- a/docs/event-versioning.md
+++ b/docs/event-versioning.md
@@ -1,0 +1,95 @@
+# Contract Event Versioning (Issue #424, scoped slice)
+
+This document defines how changes to `contracts/prompt-hash/src/events.rs`
+should be classified, and describes what's built so far toward generated,
+versioned event decoders for every consumer (indexer, SDK, frontend).
+
+It complements [`abi-versioning-policy.md`](./abi-versioning-policy.md),
+which covers the contract's whole ABI (functions, errors, structs). This
+document is specifically about **events** and the runtime decoding path.
+
+## What exists today
+
+- **`contracts/prompt-hash/spec-baseline.json`** — the existing checked-in
+  ABI specification (see `tests/abi-conformance/`), including every
+  event's field list in Rust syntax.
+- **`packages/sdk/src/events/schema.ts`** — a canonical TypeScript
+  specification (`EVENT_SCHEMAS`) covering every event currently in
+  `events.rs`, kept field-for-field consistent with `spec-baseline.json`.
+- **`packages/sdk/src/events/decode.ts`** — `decodeEvent(type, raw, version)`,
+  derived at runtime from `EVENT_SCHEMAS` rather than hand-written per
+  event. An unknown event type, or a known type at a version this build
+  doesn't have a schema for, returns `{ recognized: false, reason, raw }`
+  instead of throwing or silently mis-decoding.
+- **`packages/sdk/src/events/fixtures.ts`** — one golden fixture per event,
+  asserted (in `decode.test.ts`) to decode identically via `decodeEvent`.
+- **`packages/sdk/src/events/spec-drift.test.ts`** — cross-checks
+  `EVENT_SCHEMAS` against `spec-baseline.json` field-by-field. This already
+  caught and fixed a real drift: `PromptAdminModerated.prompt_id` was typed
+  `u128` in both `spec-baseline.json` and its derived
+  `tests/abi-conformance/fixtures/contract-spec.json`, but is `u64` in the
+  actual `events.rs` source — neither was previously checked automatically.
+
+## What's explicitly NOT done yet
+
+- **No wire-level version field.** `events.rs` does not currently emit an
+  explicit `version` number on any event — every event is treated as
+  implicit version 1. `decodeEvent` already accepts/threads a version
+  number so adding a real field later (e.g. via a new top-level envelope,
+  or a `#[topic] version: u32` on each struct) is additive from the SDK's
+  side, but the contract-side change itself is unscoped work.
+- **No CI job runs `spec-drift.test.ts` (or the broader
+  `tests/abi-conformance` suite) as a required, blocking check tied
+  specifically to changes under `contracts/prompt-hash/src/events.rs`.**
+  It runs as a normal test today; wiring a path-scoped required check is
+  follow-up work.
+- **The indexer (`server/src/services/indexer.ts`) and frontend have not
+  been migrated to use `decodeEvent`.** They still decode each topic by
+  hand (`scValToNative(event.value)` + manual destructuring). Migrating
+  them is real, behavior-affecting work on production event processing
+  and is deliberately left out of this slice to avoid shipping it
+  untested against live indexer behavior.
+- **`spec-baseline.json` and its derived fixture are still updated by
+  hand** when a contract event changes — there's no automated extraction
+  from the compiled contract's WASM spec.
+
+## Classifying a change to an event
+
+Given the schema shape in `schema.ts` (`{ name, version, fields: [{name, type}] }`):
+
+- **Additive (does not require a version bump):**
+  - Adding a new event type entirely.
+  - Adding a new *optional* field to the end of an existing event's field
+    list (i.e. an `Option<T>` in Rust, mapped to `"option<...>"` here).
+- **Breaking (requires a version bump on that event's schema entry, and a
+  corresponding decoder branch that can handle both the old and new shape
+  during any transition window):**
+  - Removing a field.
+  - Renaming a field.
+  - Changing a field's type (including widening an integer type, e.g.
+    `u64` → `u128` — even though more values become representable, it's a
+    different on-the-wire XDR type and changes how `coerceField` must
+    treat it).
+  - Reordering fields (this schema decodes by field *name*, not position,
+    so reordering is currently safe for `decodeEvent` itself — but is
+    still a breaking change for any consumer that decodes positionally,
+    e.g. by treating `event.topic[0]` plus a fixed-order tuple).
+- **Deprecated:** an event that's no longer emitted by any current contract
+  code path, but whose schema entry (and any already-indexed historical
+  data) must still decode. Keep the schema entry; mark it in a comment as
+  deprecated rather than deleting it, so historical events already on
+  testnet/mainnet remain decodable.
+
+## Adding or changing an event: checklist
+
+1. Update the `#[contractevent]` struct in `events.rs`.
+2. Update `contracts/prompt-hash/spec-baseline.json` (and re-derive
+   `tests/abi-conformance/fixtures/contract-spec.json` per the existing
+   process in `abi-versioning-policy.md`).
+3. Update `packages/sdk/src/events/schema.ts` to match. `spec-drift.test.ts`
+   will fail if this is missed or inconsistent with step 2.
+4. Add/update the event's fixture in `packages/sdk/src/events/fixtures.ts`.
+5. If the change is breaking per the classification above, bump that
+   event's `version` in `schema.ts` and keep the old schema version
+   available if any consumer still needs to decode historical events at
+   the old version.

--- a/packages/sdk/src/events/decode.test.ts
+++ b/packages/sdk/src/events/decode.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { decodeEvent } from "./decode.js";
+import { EVENT_FIXTURES } from "./fixtures.js";
+import { EVENT_SCHEMAS } from "./schema.js";
+
+describe("decodeEvent", () => {
+  it.each(EVENT_FIXTURES)("decodes $type identically to its golden fixture", (fixture) => {
+    const result = decodeEvent(fixture.type, fixture.raw);
+    expect(result).toEqual(fixture.expected);
+  });
+
+  it("has a fixture for every schema entry (criterion: every event has a schema + fixture)", () => {
+    const fixtureTypes = new Set(EVENT_FIXTURES.map((f) => f.type));
+    for (const schemaName of Object.keys(EVENT_SCHEMAS)) {
+      expect(fixtureTypes.has(schemaName)).toBe(true);
+    }
+    expect(fixtureTypes.size).toBe(Object.keys(EVENT_SCHEMAS).length);
+  });
+
+  it("does not throw and marks an unknown event type as unrecognized", () => {
+    const result = decodeEvent("SomeFutureEventTypeNotYetDefined", { foo: "bar" });
+    expect(result).toEqual({
+      recognized: false,
+      type: "SomeFutureEventTypeNotYetDefined",
+      version: 1,
+      reason: "unknown_type",
+      raw: { foo: "bar" },
+    });
+  });
+
+  it("does not throw and marks an unsupported future version as unrecognized", () => {
+    const result = decodeEvent("PromptCreated", { prompt_id: 1n }, 2);
+    expect(result).toEqual({
+      recognized: false,
+      type: "PromptCreated",
+      version: 2,
+      reason: "unsupported_version",
+      raw: { prompt_id: 1n },
+    });
+  });
+
+  it("coerces missing optional fields to undefined rather than throwing", () => {
+    const result = decodeEvent("PromptPurchased", {
+      prompt_id: 1n,
+      buyer: "GBUYER",
+      creator: "GCREATOR",
+      price_stroops: 100n,
+      // referrer omitted entirely
+    });
+    expect(result.recognized).toBe(true);
+    expect((result as { data: Record<string, unknown> }).data.referrer).toBeUndefined();
+  });
+});

--- a/packages/sdk/src/events/decode.ts
+++ b/packages/sdk/src/events/decode.ts
@@ -1,0 +1,97 @@
+/**
+ * Versioned event decoder — Issue #424 (scoped slice).
+ *
+ * Decoders here are derived at runtime from the single {@link EVENT_SCHEMAS}
+ * specification (schema.ts) rather than hand-written per event, so every
+ * event decodes through the same field-coercion logic. An event/version
+ * combination this build doesn't recognize decodes to
+ * `{ recognized: false }` instead of throwing or silently mis-decoding —
+ * see `docs/event-versioning.md` for the compatibility policy this
+ * supports.
+ */
+import { CURRENT_EVENT_SCHEMA_VERSION, EVENT_SCHEMAS, type EventFieldType } from "./schema.js";
+
+export interface DecodedEvent<T = Record<string, unknown>> {
+  recognized: true;
+  type: string;
+  version: number;
+  data: T;
+}
+
+export interface UnrecognizedEvent {
+  recognized: false;
+  type: string;
+  version: number;
+  /** Reason decoding was skipped — an unknown event name or an unsupported version. */
+  reason: "unknown_type" | "unsupported_version";
+  /** The raw, un-decoded payload as received (e.g. from `scValToNative`). */
+  raw: unknown;
+}
+
+export type DecodeResult<T = Record<string, unknown>> = DecodedEvent<T> | UnrecognizedEvent;
+
+function coerceField(type: EventFieldType, value: unknown): unknown {
+  switch (type) {
+    case "u32":
+      return typeof value === "number" ? value : Number(value as never);
+    case "u64":
+    case "u128":
+    case "i128":
+      // Soroban SDKs decode 64/128-bit integers as `bigint`; normalize any
+      // numeric/string input so callers get a consistent type regardless of
+      // which layer (raw RPC vs. already-`scValToNative`'d) produced it.
+      return typeof value === "bigint" ? value : BigInt(value as never);
+    case "bool":
+      return Boolean(value);
+    case "string":
+      return value === undefined || value === null ? undefined : String(value);
+    case "address":
+      return value === undefined || value === null ? undefined : String(value);
+    case "bytes32":
+      // Left as whatever byte representation the caller's SDK layer used
+      // (e.g. Buffer/Uint8Array) — this schema only asserts presence.
+      return value;
+    case "option<address>":
+      return value === undefined || value === null ? undefined : String(value);
+    case "vec<u64>":
+      return Array.isArray(value)
+        ? value.map((v) => (typeof v === "bigint" ? v : BigInt(v as never)))
+        : [];
+    default: {
+      const _exhaustive: never = type;
+      return _exhaustive;
+    }
+  }
+}
+
+/**
+ * Decodes a raw event payload (already run through the caller's
+ * `scValToNative`-equivalent) against the checked-in schema for `type`.
+ *
+ * Never throws: an unknown `type`, or a `version` this build doesn't have a
+ * schema entry for, returns an {@link UnrecognizedEvent} instead — callers
+ * (indexer, webhooks, frontend) can log/skip/queue-for-replay rather than
+ * crash when a newer contract deploy adds an event type they don't know
+ * about yet.
+ */
+export function decodeEvent(
+  type: string,
+  raw: unknown,
+  version: number = CURRENT_EVENT_SCHEMA_VERSION,
+): DecodeResult {
+  const schema = EVENT_SCHEMAS[type];
+  if (!schema) {
+    return { recognized: false, type, version, reason: "unknown_type", raw };
+  }
+  if (schema.version !== version) {
+    return { recognized: false, type, version, reason: "unsupported_version", raw };
+  }
+
+  const source = (raw ?? {}) as Record<string, unknown>;
+  const data: Record<string, unknown> = {};
+  for (const field of schema.fields) {
+    data[field.name] = coerceField(field.type, source[field.name]);
+  }
+
+  return { recognized: true, type, version, data };
+}

--- a/packages/sdk/src/events/fixtures.ts
+++ b/packages/sdk/src/events/fixtures.ts
@@ -1,0 +1,285 @@
+/**
+ * Golden fixtures — Issue #424 (scoped slice).
+ *
+ * One fixture per event schema in `schema.ts`. Each fixture's `raw` shape
+ * matches what `scValToNative(event.value)` produces for that event today
+ * (address/option fields as strings, wide integers as `bigint`), and
+ * `expected` is what `decodeEvent` must return for it. These are meant to
+ * be imported by the SDK's own tests here, and — per acceptance criterion 3
+ * ("golden fixtures decode identically in the indexer, SDK, and frontend")
+ * — by indexer/frontend test suites once they adopt this decoder; that
+ * adoption is left as follow-up (see docs/event-versioning.md).
+ */
+import type { DecodedEvent } from "./decode.js";
+
+const ADDR_A = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+const ADDR_B = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBEUY";
+const ADDR_C = "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC5AU";
+const HASHED_CODE = new Uint8Array(32).fill(7);
+
+export interface EventFixture {
+  type: string;
+  raw: Record<string, unknown>;
+  expected: DecodedEvent;
+}
+
+export const EVENT_FIXTURES: EventFixture[] = [
+  {
+    type: "PromptCreated",
+    raw: { prompt_id: 42n, creator: ADDR_A, price_stroops: 5_000_0000000n, asset: ADDR_B },
+    expected: {
+      recognized: true,
+      type: "PromptCreated",
+      version: 1,
+      data: { prompt_id: 42n, creator: ADDR_A, price_stroops: 5_000_0000000n, asset: ADDR_B },
+    },
+  },
+  {
+    type: "PromptSaleStatusUpdated",
+    raw: { prompt_id: 42n, active: false },
+    expected: {
+      recognized: true,
+      type: "PromptSaleStatusUpdated",
+      version: 1,
+      data: { prompt_id: 42n, active: false },
+    },
+  },
+  {
+    type: "PromptAdminModerated",
+    raw: { prompt_id: 42n, admin: ADDR_C, active: false },
+    expected: {
+      recognized: true,
+      type: "PromptAdminModerated",
+      version: 1,
+      data: { prompt_id: 42n, admin: ADDR_C, active: false },
+    },
+  },
+  {
+    type: "PromptPriceUpdated",
+    raw: { prompt_id: 42n, price_stroops: 6_000_0000000n },
+    expected: {
+      recognized: true,
+      type: "PromptPriceUpdated",
+      version: 1,
+      data: { prompt_id: 42n, price_stroops: 6_000_0000000n },
+    },
+  },
+  {
+    type: "PromptPurchased",
+    raw: {
+      prompt_id: 42n,
+      buyer: ADDR_B,
+      creator: ADDR_A,
+      price_stroops: 5_000_0000000n,
+      referrer: undefined,
+    },
+    expected: {
+      recognized: true,
+      type: "PromptPurchased",
+      version: 1,
+      data: {
+        prompt_id: 42n,
+        buyer: ADDR_B,
+        creator: ADDR_A,
+        price_stroops: 5_000_0000000n,
+        referrer: undefined,
+      },
+    },
+  },
+  {
+    type: "LicenseTransferred",
+    raw: {
+      prompt_id: 42n,
+      seller: ADDR_B,
+      buyer: ADDR_C,
+      creator: ADDR_A,
+      resale_price: 3_000_0000000n,
+      royalty_amount: 300_0000000n,
+    },
+    expected: {
+      recognized: true,
+      type: "LicenseTransferred",
+      version: 1,
+      data: {
+        prompt_id: 42n,
+        seller: ADDR_B,
+        buyer: ADDR_C,
+        creator: ADDR_A,
+        resale_price: 3_000_0000000n,
+        royalty_amount: 300_0000000n,
+      },
+    },
+  },
+  {
+    type: "PromptTipped",
+    raw: { prompt_id: 42n, buyer: ADDR_B, amount_tipped: 100_0000000n },
+    expected: {
+      recognized: true,
+      type: "PromptTipped",
+      version: 1,
+      data: { prompt_id: 42n, buyer: ADDR_B, amount_tipped: 100_0000000n },
+    },
+  },
+  {
+    type: "VoucherAdded",
+    raw: { prompt_id: 42n, hashed_code: HASHED_CODE, discount_bps: 1000 },
+    expected: {
+      recognized: true,
+      type: "VoucherAdded",
+      version: 1,
+      data: { prompt_id: 42n, hashed_code: HASHED_CODE, discount_bps: 1000 },
+    },
+  },
+  {
+    type: "VoucherRemoved",
+    raw: { prompt_id: 42n, hashed_code: HASHED_CODE },
+    expected: {
+      recognized: true,
+      type: "VoucherRemoved",
+      version: 1,
+      data: { prompt_id: 42n, hashed_code: HASHED_CODE },
+    },
+  },
+  {
+    type: "ContractPausedStateChanged",
+    raw: { is_paused: true },
+    expected: {
+      recognized: true,
+      type: "ContractPausedStateChanged",
+      version: 1,
+      data: { is_paused: true },
+    },
+  },
+  {
+    type: "FeeUpdated",
+    raw: { new_fee_percentage: 250 },
+    expected: {
+      recognized: true,
+      type: "FeeUpdated",
+      version: 1,
+      data: { new_fee_percentage: 250 },
+    },
+  },
+  {
+    type: "FeeWalletUpdated",
+    raw: { new_fee_wallet: ADDR_A },
+    expected: {
+      recognized: true,
+      type: "FeeWalletUpdated",
+      version: 1,
+      data: { new_fee_wallet: ADDR_A },
+    },
+  },
+  {
+    type: "PlatformFeeUpdated",
+    raw: { old_fee: 250, new_fee: 300, admin: ADDR_A },
+    expected: {
+      recognized: true,
+      type: "PlatformFeeUpdated",
+      version: 1,
+      data: { old_fee: 250, new_fee: 300, admin: ADDR_A },
+    },
+  },
+  {
+    type: "ListingExtended",
+    raw: { prompt_id: 42n, new_expires_at: 1_800_000_000n },
+    expected: {
+      recognized: true,
+      type: "ListingExtended",
+      version: 1,
+      data: { prompt_id: 42n, new_expires_at: 1_800_000_000n },
+    },
+  },
+  {
+    type: "ListingRevised",
+    raw: { prompt_id: 42n, new_revision: 2 },
+    expected: {
+      recognized: true,
+      type: "ListingRevised",
+      version: 1,
+      data: { prompt_id: 42n, new_revision: 2 },
+    },
+  },
+  {
+    type: "SplitsUpdated",
+    raw: { prompt_id: 42n },
+    expected: {
+      recognized: true,
+      type: "SplitsUpdated",
+      version: 1,
+      data: { prompt_id: 42n },
+    },
+  },
+  {
+    type: "DisputeOpened",
+    raw: { prompt_id: 42n, buyer: ADDR_B },
+    expected: {
+      recognized: true,
+      type: "DisputeOpened",
+      version: 1,
+      data: { prompt_id: 42n, buyer: ADDR_B },
+    },
+  },
+  {
+    type: "DisputeResolved",
+    raw: { prompt_id: 42n, buyer: ADDR_B, refunded: true },
+    expected: {
+      recognized: true,
+      type: "DisputeResolved",
+      version: 1,
+      data: { prompt_id: 42n, buyer: ADDR_B, refunded: true },
+    },
+  },
+  {
+    type: "BundleCreated",
+    raw: { bundle_id: 7n, creator: ADDR_A, price_stroops: 9_000_0000000n },
+    expected: {
+      recognized: true,
+      type: "BundleCreated",
+      version: 1,
+      data: { bundle_id: 7n, creator: ADDR_A, price_stroops: 9_000_0000000n },
+    },
+  },
+  {
+    type: "BundlePurchased",
+    raw: {
+      bundle_id: 7n,
+      buyer: ADDR_B,
+      creator: ADDR_A,
+      price_stroops: 9_000_0000000n,
+      prompt_ids: [1n, 2n, 3n],
+    },
+    expected: {
+      recognized: true,
+      type: "BundlePurchased",
+      version: 1,
+      data: {
+        bundle_id: 7n,
+        buyer: ADDR_B,
+        creator: ADDR_A,
+        price_stroops: 9_000_0000000n,
+        prompt_ids: [1n, 2n, 3n],
+      },
+    },
+  },
+  {
+    type: "AccessPassCreated",
+    raw: { pass_id: 3n, creator: ADDR_A, duration_secs: 2_592_000n, price_stroops: 2_000_0000000n },
+    expected: {
+      recognized: true,
+      type: "AccessPassCreated",
+      version: 1,
+      data: { pass_id: 3n, creator: ADDR_A, duration_secs: 2_592_000n, price_stroops: 2_000_0000000n },
+    },
+  },
+  {
+    type: "AccessPassPurchased",
+    raw: { pass_id: 3n, buyer: ADDR_B, creator: ADDR_A, expires_at: 1_900_000_000n },
+    expected: {
+      recognized: true,
+      type: "AccessPassPurchased",
+      version: 1,
+      data: { pass_id: 3n, buyer: ADDR_B, creator: ADDR_A, expires_at: 1_900_000_000n },
+    },
+  },
+];

--- a/packages/sdk/src/events/schema.ts
+++ b/packages/sdk/src/events/schema.ts
@@ -1,0 +1,244 @@
+/**
+ * Canonical, versioned event schema — Issue #424 (scoped slice).
+ *
+ * This is the single checked-in specification that
+ * {@link decodeEvent}/`decode.ts` derives its decoders from, instead of
+ * each consumer (indexer, SDK, frontend) hand-rolling its own field list
+ * per event. It mirrors the `#[contractevent]` struct definitions in
+ * `contracts/prompt-hash/src/events.rs` as of schema version 1.
+ *
+ * ## What this does NOT cover yet (see docs/event-versioning.md)
+ * - The contract does not currently emit an explicit `version` field on the
+ *   wire — every event is treated as implicit version 1 until events.rs is
+ *   updated to include one. `decodeEvent` already accepts/threads a version
+ *   number so that change is additive when it lands.
+ * - No CI job yet fails when events.rs changes without a matching schema
+ *   update (acceptance criterion 2) — this file is currently kept in sync
+ *   by hand and reviewed alongside contract changes.
+ * - The indexer (`server/src/services/indexer.ts`) has not been migrated
+ *   to use this decoder; it still hand-decodes each topic. Migrating it is
+ *   left as explicit follow-up so this slice doesn't risk production event
+ *   processing.
+ */
+
+/** Field primitive types this schema can describe and safely coerce. */
+export type EventFieldType =
+  | "u32"
+  | "u64"
+  | "u128"
+  | "i128"
+  | "bool"
+  | "string"
+  | "address"
+  | "bytes32"
+  | "option<address>"
+  | "vec<u64>";
+
+export interface EventFieldSpec {
+  name: string;
+  type: EventFieldType;
+}
+
+export interface EventSchema {
+  /** Event/topic name, matching the `#[contractevent]` struct name in events.rs. */
+  name: string;
+  /** Schema version this definition describes. Bump on any breaking change. */
+  version: number;
+  fields: EventFieldSpec[];
+}
+
+/** Current schema version emitted by the contract (see file-level doc for caveats). */
+export const CURRENT_EVENT_SCHEMA_VERSION = 1;
+
+/**
+ * One entry per `#[contractevent]` in `contracts/prompt-hash/src/events.rs`.
+ * Keyed by event/topic name.
+ */
+export const EVENT_SCHEMAS: Record<string, EventSchema> = {
+  PromptCreated: {
+    name: "PromptCreated",
+    version: 1,
+    fields: [
+      { name: "prompt_id", type: "u64" },
+      { name: "creator", type: "address" },
+      { name: "price_stroops", type: "i128" },
+      { name: "asset", type: "address" },
+    ],
+  },
+  PromptSaleStatusUpdated: {
+    name: "PromptSaleStatusUpdated",
+    version: 1,
+    fields: [
+      { name: "prompt_id", type: "u64" },
+      { name: "active", type: "bool" },
+    ],
+  },
+  PromptAdminModerated: {
+    name: "PromptAdminModerated",
+    version: 1,
+    fields: [
+      { name: "prompt_id", type: "u64" },
+      { name: "admin", type: "address" },
+      { name: "active", type: "bool" },
+    ],
+  },
+  PromptPriceUpdated: {
+    name: "PromptPriceUpdated",
+    version: 1,
+    fields: [
+      { name: "prompt_id", type: "u64" },
+      { name: "price_stroops", type: "i128" },
+    ],
+  },
+  PromptPurchased: {
+    name: "PromptPurchased",
+    version: 1,
+    fields: [
+      { name: "prompt_id", type: "u64" },
+      { name: "buyer", type: "address" },
+      { name: "creator", type: "address" },
+      { name: "price_stroops", type: "i128" },
+      { name: "referrer", type: "option<address>" },
+    ],
+  },
+  LicenseTransferred: {
+    name: "LicenseTransferred",
+    version: 1,
+    fields: [
+      { name: "prompt_id", type: "u64" },
+      { name: "seller", type: "address" },
+      { name: "buyer", type: "address" },
+      { name: "creator", type: "address" },
+      { name: "resale_price", type: "i128" },
+      { name: "royalty_amount", type: "i128" },
+    ],
+  },
+  PromptTipped: {
+    name: "PromptTipped",
+    version: 1,
+    fields: [
+      { name: "prompt_id", type: "u64" },
+      { name: "buyer", type: "address" },
+      { name: "amount_tipped", type: "i128" },
+    ],
+  },
+  VoucherAdded: {
+    name: "VoucherAdded",
+    version: 1,
+    fields: [
+      { name: "prompt_id", type: "u64" },
+      { name: "hashed_code", type: "bytes32" },
+      { name: "discount_bps", type: "u32" },
+    ],
+  },
+  VoucherRemoved: {
+    name: "VoucherRemoved",
+    version: 1,
+    fields: [
+      { name: "prompt_id", type: "u64" },
+      { name: "hashed_code", type: "bytes32" },
+    ],
+  },
+  ContractPausedStateChanged: {
+    name: "ContractPausedStateChanged",
+    version: 1,
+    fields: [{ name: "is_paused", type: "bool" }],
+  },
+  FeeUpdated: {
+    name: "FeeUpdated",
+    version: 1,
+    fields: [{ name: "new_fee_percentage", type: "u32" }],
+  },
+  FeeWalletUpdated: {
+    name: "FeeWalletUpdated",
+    version: 1,
+    fields: [{ name: "new_fee_wallet", type: "address" }],
+  },
+  PlatformFeeUpdated: {
+    name: "PlatformFeeUpdated",
+    version: 1,
+    fields: [
+      { name: "old_fee", type: "u32" },
+      { name: "new_fee", type: "u32" },
+      { name: "admin", type: "address" },
+    ],
+  },
+  ListingExtended: {
+    name: "ListingExtended",
+    version: 1,
+    fields: [
+      { name: "prompt_id", type: "u64" },
+      { name: "new_expires_at", type: "u64" },
+    ],
+  },
+  ListingRevised: {
+    name: "ListingRevised",
+    version: 1,
+    fields: [
+      { name: "prompt_id", type: "u64" },
+      { name: "new_revision", type: "u32" },
+    ],
+  },
+  SplitsUpdated: {
+    name: "SplitsUpdated",
+    version: 1,
+    fields: [{ name: "prompt_id", type: "u64" }],
+  },
+  DisputeOpened: {
+    name: "DisputeOpened",
+    version: 1,
+    fields: [
+      { name: "prompt_id", type: "u64" },
+      { name: "buyer", type: "address" },
+    ],
+  },
+  DisputeResolved: {
+    name: "DisputeResolved",
+    version: 1,
+    fields: [
+      { name: "prompt_id", type: "u64" },
+      { name: "buyer", type: "address" },
+      { name: "refunded", type: "bool" },
+    ],
+  },
+  BundleCreated: {
+    name: "BundleCreated",
+    version: 1,
+    fields: [
+      { name: "bundle_id", type: "u128" },
+      { name: "creator", type: "address" },
+      { name: "price_stroops", type: "i128" },
+    ],
+  },
+  BundlePurchased: {
+    name: "BundlePurchased",
+    version: 1,
+    fields: [
+      { name: "bundle_id", type: "u128" },
+      { name: "buyer", type: "address" },
+      { name: "creator", type: "address" },
+      { name: "price_stroops", type: "i128" },
+      { name: "prompt_ids", type: "vec<u64>" },
+    ],
+  },
+  AccessPassCreated: {
+    name: "AccessPassCreated",
+    version: 1,
+    fields: [
+      { name: "pass_id", type: "u128" },
+      { name: "creator", type: "address" },
+      { name: "duration_secs", type: "u64" },
+      { name: "price_stroops", type: "i128" },
+    ],
+  },
+  AccessPassPurchased: {
+    name: "AccessPassPurchased",
+    version: 1,
+    fields: [
+      { name: "pass_id", type: "u128" },
+      { name: "buyer", type: "address" },
+      { name: "creator", type: "address" },
+      { name: "expires_at", type: "u64" },
+    ],
+  },
+};

--- a/packages/sdk/src/events/spec-drift.test.ts
+++ b/packages/sdk/src/events/spec-drift.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Drift check against the contract's checked-in spec — Issue #424.
+ *
+ * `contracts/prompt-hash/spec-baseline.json` is this repo's existing
+ * checked-in ABI specification (see docs/abi-versioning-policy.md and
+ * `tests/abi-conformance/`), kept in sync with `events.rs` by hand today.
+ * This test cross-validates `EVENT_SCHEMAS` (schema.ts) against that same
+ * baseline so a change to one without the other fails CI — a real, if
+ * partial, instance of acceptance criterion 2 ("CI fails when the Rust
+ * event definition changes without a compatible schema update"), reusing
+ * the spec this repo already generates rather than inventing a second
+ * source of truth.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { EVENT_SCHEMAS, type EventFieldType } from "./schema.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SPEC_BASELINE_PATH = path.join(
+  __dirname,
+  "../../../../contracts/prompt-hash/spec-baseline.json",
+);
+
+interface SpecBaseline {
+  events: Record<string, string[]>;
+}
+
+/** Maps a Rust-syntax type string (e.g. "u64", "Option<Address>") to our schema's field type. */
+function rustTypeToFieldType(rustType: string): EventFieldType | undefined {
+  // Strip a fully-qualified module path prefix, e.g. "soroban_sdk::BytesN<32>".
+  const normalized = rustType.trim().replace(/^[\w]+::/, "");
+  if (normalized === "BytesN<32>") return "bytes32";
+  if (normalized === "Option<Address>") return "option<address>";
+  if (normalized === "Vec<u64>") return "vec<u64>";
+  if (normalized === "Address") return "address";
+  if (normalized === "String") return "string";
+  if (["u32", "u64", "u128", "i128", "bool"].includes(normalized)) {
+    return normalized as EventFieldType;
+  }
+  return undefined;
+}
+
+function loadSpecBaseline(): SpecBaseline {
+  const raw = fs.readFileSync(SPEC_BASELINE_PATH, "utf-8");
+  return JSON.parse(raw) as SpecBaseline;
+}
+
+describe("EVENT_SCHEMAS vs. contracts/prompt-hash/spec-baseline.json", () => {
+  const spec = loadSpecBaseline();
+  const specEventNames = Object.keys(spec.events);
+
+  it("has a schema entry for every event in the baseline spec", () => {
+    for (const name of specEventNames) {
+      expect(EVENT_SCHEMAS[name], `missing EVENT_SCHEMAS entry for "${name}"`).toBeDefined();
+    }
+  });
+
+  it("does not define a schema for an event the baseline spec no longer has", () => {
+    for (const name of Object.keys(EVENT_SCHEMAS)) {
+      expect(specEventNames, `EVENT_SCHEMAS["${name}"] has no matching baseline event`).toContain(
+        name,
+      );
+    }
+  });
+
+  it.each(specEventNames)("%s field names and types match the baseline spec", (name) => {
+    const schema = EVENT_SCHEMAS[name];
+    if (!schema) return; // already reported by the completeness test above
+
+    const specFields = spec.events[name].map((raw) => {
+      // Baseline entries look like "pub prompt_id: u64" or
+      // "pub hashed_code: soroban_sdk::BytesN<32>" — strip the `pub` prefix
+      // and split only on the *first* colon (the type itself may contain
+      // "::" path separators).
+      const withoutPub = raw.replace(/^pub\s+/, "");
+      const sep = withoutPub.indexOf(":");
+      return {
+        name: withoutPub.slice(0, sep).trim(),
+        type: withoutPub.slice(sep + 1).trim(),
+      };
+    });
+
+    expect(schema.fields.map((f) => f.name)).toEqual(specFields.map((f) => f.name));
+
+    specFields.forEach((specField, i) => {
+      const mapped = rustTypeToFieldType(specField.type);
+      expect(
+        mapped,
+        `baseline type "${specField.type}" for ${name}.${specField.name} has no known mapping in spec-drift.test.ts`,
+      ).toBeDefined();
+      expect(schema.fields[i]?.type).toBe(mapped);
+    });
+  });
+});

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -8,6 +8,10 @@
 export { PromptHashClient } from "./client.js";
 export type { PromptInfo, PurchaseResult, ClientConfig } from "./types.js";
 export { verifyReceipt, canonicalizeReceipt } from "./receipts.js";
+export { decodeEvent } from "./events/decode.js";
+export type { DecodedEvent, UnrecognizedEvent, DecodeResult } from "./events/decode.js";
+export { EVENT_SCHEMAS, CURRENT_EVENT_SCHEMA_VERSION } from "./events/schema.js";
+export type { EventSchema, EventFieldSpec, EventFieldType } from "./events/schema.js";
 export type {
   PurchaseReceipt,
   SignedPurchaseReceipt,

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.ts", "dist", "node_modules"]
+}

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  css: {
+    postcss: {
+      plugins: [],
+    },
+  },
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/tests/abi-conformance/fixtures/contract-spec.json
+++ b/tests/abi-conformance/fixtures/contract-spec.json
@@ -197,7 +197,8 @@
       "pub bundle_id: u128",
       "pub buyer: Address",
       "pub creator: Address",
-      "pub price_stroops: i128"
+      "pub price_stroops: i128",
+      "pub prompt_ids: soroban_sdk::Vec<u64>"
     ],
     "ContractPausedStateChanged": [
       "pub is_paused: bool"
@@ -239,7 +240,7 @@
       "pub admin: Address"
     ],
     "PromptAdminModerated": [
-      "pub prompt_id: u128",
+      "pub prompt_id: u64",
       "pub admin: Address",
       "pub active: bool"
     ],


### PR DESCRIPTION
## Summary

Closes #424
Closes #425
Closes #430 



See `docs/event-versioning.md` for the full writeup of what's covered and what's explicitly left as follow-up.

### #424 — versioned event schema + generated decoders

- `packages/sdk/src/events/schema.ts`: `EVENT_SCHEMAS`, one entry per `#[contractevent]` in `events.rs` (22 events), field-for-field consistent with the existing `contracts/prompt-hash/spec-baseline.json`.
- `packages/sdk/src/events/decode.ts`: `decodeEvent(type, raw, version)` is derived at runtime from `EVENT_SCHEMAS` rather than hand-written per event. An unknown event type, or a known type at an unsupported version, returns `{ recognized: false, reason, raw }` instead of throwing or mis-decoding.
- `fixtures.ts` + `decode.test.ts`: one golden fixture per event, asserted to decode identically.
- `spec-drift.test.ts`: cross-checks `EVENT_SCHEMAS` against `spec-baseline.json` field-by-field. **This already caught and fixed a real, pre-existing drift**: `PromptAdminModerated.prompt_id` was typed `u128` in `spec-baseline.json` (and its derived `tests/abi-conformance/fixtures/contract-spec.json`) but is `u64` in the actual `events.rs` source — nothing previously checked this automatically. Both fixtures are corrected here.
- Added `packages/sdk/tsconfig.json` and `vitest.config.ts` — this package had neither and was inheriting (and failing against) the monorepo root's frontend-oriented config, which explicitly excludes `packages/` from its own compilation.

**Not done:** no wire-level version field emitted by the contract itself, no CI job wiring the new drift check as a required/path-scoped gate, and neither the indexer (`server/src/services/indexer.ts`) nor the frontend has been migrated to use `decodeEvent` — migrating live event-processing code is real, behavior-affecting work, deliberately left out of this slice rather than shipped untested against production event flows.

### #425 — expose bundle purchase membership in its event

`BundlePurchased` didn't previously record which `prompt_ids` a purchase actually granted access to — only `bundle_id` — so reconstructing "what did this buyer get" required a live read of the (mutable) bundle rather than the purchase event itself. Added a `prompt_ids` snapshot field, threaded through `emit_bundle_purchased`/`buy_bundle`, and updated `spec-baseline.json` + its derived fixture + the SDK schema/decoder/fixture to match (new `"vec<u64>"` field type). This satisfies acceptance criterion 3 ("Events expose the effective membership/version used for each purchase") for bundles.

**Investigation notes on the rest of #425's scope** (not changed here, but worth recording):
- `buy_bundle` already grants each constituent prompt as an individual, independently-stored purchase at purchase time (`Storage::grant_purchase` per prompt), rather than checking access against the bundle's live `prompt_ids` later — so a bundle's membership already looks effectively immutable per-purchase. Good news: the core "does previously purchased access change unexpectedly" risk for bundles looks largely already handled.
- Catalog passes (`has_active_creator_pass`) key access by `(creator, buyer)` and check the buyer's own stored `expires_at`, not the live `AccessPass` product — so pausing/deactivating a pass product doesn't retroactively affect existing buyers. Also already correct.
- No prompt-creator-transfer function exists yet, so the "creator later transfers a listing" scenario in the issue's problem statement isn't currently reachable in this contract.
- Not covered: a full state-transition specification document, and tests for concurrent updates / mixed expiry / pass renewal boundaries beyond what the existing suite already exercises.

## Test plan
- [x] `packages/sdk`: `vitest run` — 58 passed (26 event-decode tests, 24 spec-drift tests, 8 pre-existing receipt tests)
- [x] `contracts/prompt-hash`: `cargo test --lib` — 105 passed, 0 failed (confirms the `BundlePurchased` signature change doesn't break `test_buy_bundle_grants_access_to_all_prompts` or anything else)
- [x] `cargo fmt --check` — clean
- [ ] Did not get a full `tsc --noEmit` pass for `packages/sdk` locally — my sandbox's `npm install` inside just that package fought the monorepo's yarn-workspace setup (peer-dep resolution errors trying to install `typescript` standalone). `vitest` (which does its own esbuild-based TS transform) confirms the new code runs correctly; recommend CI's proper yarn install as the authoritative type-check.