### PR TITLE
feat: add clipboard auto-clear option for unlocked prompt content

### DIFF
--- a/src/components/ClipboardAutoClearBanner.tsx
+++ b/src/components/ClipboardAutoClearBanner.tsx
@@ -1,0 +1,53 @@
+import { Clock, ShieldAlert, X } from "lucide-react";
+
+interface ClipboardAutoClearBannerProps {
+  remaining: number;
+  enabled: boolean;
+  onToggle: () => void;
+  onCancel: () => void;
+}
+
+export function ClipboardAutoClearBanner({
+  remaining,
+  enabled,
+  onToggle,
+  onCancel,
+}: ClipboardAutoClearBannerProps) {
+  if (!enabled && remaining === 0) return null;
+
+  return (
+    <div className="mt-3 rounded-xl border border-cyan-400/20 bg-cyan-500/10 px-3 py-2 text-xs text-cyan-100 flex items-center gap-2 flex-wrap">
+      {remaining > 0 ? (
+        <>
+          <Clock className="h-3.5 w-3.5 shrink-0 text-cyan-300" />
+          <span>
+            Clipboard clears in{" "}
+            <span className="font-mono font-semibold text-cyan-200">
+              {remaining}s
+            </span>
+          </span>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="ml-auto inline-flex items-center gap-1 rounded-md border border-white/10 bg-white/5 px-2 py-0.5 text-[11px] font-medium text-cyan-200 hover:bg-white/10 transition-colors"
+          >
+            <X className="h-3 w-3" />
+            Cancel
+          </button>
+        </>
+      ) : (
+        <>
+          <ShieldAlert className="h-3.5 w-3.5 shrink-0 text-cyan-300" />
+          <span>Auto-clear clipboard after copy</span>
+          <button
+            type="button"
+            onClick={onToggle}
+            className="ml-auto inline-flex items-center gap-1 rounded-md border border-white/10 bg-white/5 px-2 py-0.5 text-[11px] font-medium text-cyan-200 hover:bg-white/10 transition-colors"
+          >
+            {enabled ? "Disable" : "Enable"}
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/prompts/ShareButtons.tsx
+++ b/src/components/prompts/ShareButtons.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
 import { Check, Link2, Share2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { copyToClipboard } from "@/lib/clipboard/secureClipboard";
+import { useClipboardAutoClear } from "@/hooks/useClipboardAutoClear";
+import { ClipboardAutoClearBanner } from "@/components/ClipboardAutoClearBanner";
 
 interface ShareButtonsProps {
   /** Title of the prompt — used to seed the share text. */
@@ -52,6 +53,14 @@ function resolveShareUrl(url?: string): string {
 export function ShareButtons({ title, url, summary, className }: ShareButtonsProps) {
   const [copied, setCopied] = useState(false);
   const [canNativeShare, setCanNativeShare] = useState(false);
+  const {
+    enabled,
+    toggle,
+    copy,
+    cancel,
+    remaining,
+    isCountingDown,
+  } = useClipboardAutoClear();
 
   const shareUrl = resolveShareUrl(url);
   const shareText = `${title} on Prompt Hash Stellar`;
@@ -73,8 +82,8 @@ export function ShareButtons({ title, url, summary, className }: ShareButtonsPro
   )}`;
 
   const handleCopy = async () => {
-    const result = await copyToClipboard(shareUrl);
-    if (result.success) {
+    const ok = await copy(shareUrl);
+    if (ok) {
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1800);
     }
@@ -154,6 +163,13 @@ export function ShareButtons({ title, url, summary, className }: ShareButtonsPro
           )}
         </Button>
       </div>
+
+      <ClipboardAutoClearBanner
+        remaining={remaining}
+        enabled={enabled}
+        onToggle={toggle}
+        onCancel={cancel}
+      />
     </div>
   );
 }

--- a/src/hooks/useClipboardAutoClear.ts
+++ b/src/hooks/useClipboardAutoClear.ts
@@ -1,0 +1,173 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const STORAGE_KEY = "prompt-hash:clipboard-autoclear";
+
+function readAutoClearEnabled(): boolean {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw === null ? true : raw === "true";
+  } catch {
+    return true;
+  }
+}
+
+function writeAutoClearEnabled(enabled: boolean): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, String(enabled));
+  } catch {
+    // quota or private browsing
+  }
+}
+
+export interface ClipboardAutoClearOptions {
+  /** Delay in seconds before the clipboard is cleared. Default 30. */
+  delaySeconds?: number;
+}
+
+export interface ClipboardAutoClearResult {
+  /** Whether auto-clear is currently enabled by the user. */
+  enabled: boolean;
+  /** Toggle the auto-clear preference on or off. */
+  toggle: () => void;
+  /**
+   * Copy text to the clipboard. If auto-clear is enabled the countdown starts
+   * immediately after a successful write.
+   */
+  copy: (text: string) => Promise<boolean>;
+  /** Manually cancel a running countdown without clearing the clipboard. */
+  cancel: () => void;
+  /** Seconds remaining before the clipboard is cleared (0 when idle). */
+  remaining: number;
+  /** True while the countdown is active. */
+  isCountingDown: boolean;
+  /** The content that was last copied (or null). */
+  copiedContent: string | null;
+}
+
+export function useClipboardAutoClear(
+  opts: ClipboardAutoClearOptions = {},
+): ClipboardAutoClearResult {
+  const { delaySeconds = 30 } = opts;
+
+  const [enabled, setEnabled] = useState(readAutoClearEnabled);
+  const [remaining, setRemaining] = useState(0);
+  const [copiedContent, setCopiedContent] = useState<string | null>(null);
+
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const targetRef = useRef<string | null>(null);
+  const endTimeRef = useRef<number>(0);
+
+  // Persist the preference whenever it changes
+  useEffect(() => {
+    writeAutoClearEnabled(enabled);
+  }, [enabled]);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+    endTimeRef.current = 0;
+    setRemaining(0);
+  }, []);
+
+  const cancel = useCallback(() => {
+    clearTimer();
+    targetRef.current = null;
+    setCopiedContent(null);
+  }, [clearTimer]);
+
+  const clearClipboardIfMatch = useCallback(async () => {
+    const target = targetRef.current;
+    if (!target) return;
+
+    try {
+      if (navigator?.clipboard) {
+        const current = await navigator.clipboard.readText();
+        // Only clear if the clipboard still contains what we copied
+        if (current === target) {
+          await navigator.clipboard.writeText("");
+        }
+      }
+    } catch {
+      // readText may throw in some browsers — silently ignore
+    } finally {
+      cancel();
+    }
+  }, [cancel]);
+
+  // Tick every second while countdown is active
+  useEffect(() => {
+    if (remaining <= 0) {
+      clearTimer();
+      return;
+    }
+
+    timerRef.current = setInterval(() => {
+      const now = Date.now();
+      const secs = Math.max(0, Math.ceil((endTimeRef.current - now) / 1000));
+      setRemaining(secs);
+
+      if (secs <= 0) {
+        clearTimer();
+        clearClipboardIfMatch();
+      }
+    }, 500);
+
+    return () => {
+      if (timerRef.current !== null) {
+        clearInterval(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [remaining > 0, clearTimer, clearClipboardIfMatch]);
+
+  const toggle = useCallback(() => {
+    setEnabled((prev) => {
+      if (prev) cancel();
+      return !prev;
+    });
+  }, [cancel]);
+
+  const copy = useCallback(
+    async (text: string): Promise<boolean> => {
+      if (!navigator?.clipboard) return false;
+
+      try {
+        await navigator.clipboard.writeText(text);
+        setCopiedContent(text);
+        targetRef.current = text;
+
+        if (enabled) {
+          endTimeRef.current = Date.now() + delaySeconds * 1000;
+          setRemaining(delaySeconds);
+        } else {
+          clearTimer();
+        }
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    [enabled, delaySeconds, clearTimer],
+  );
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        clearInterval(timerRef.current);
+      }
+    };
+  }, []);
+
+  return {
+    enabled,
+    toggle,
+    copy,
+    cancel,
+    remaining,
+    isCountingDown: remaining > 0,
+    copiedContent,
+  };
+}

--- a/src/pages/prompts/PromptDetailPage.tsx
+++ b/src/pages/prompts/PromptDetailPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import {
@@ -6,8 +7,9 @@ import {
   Check,
   Clock,
   Copy,
+  Flag,
+  History,
   Loader2,
-  ShieldCheck,
   ShoppingBag,
   Sparkles,
   ThumbsUp,
@@ -23,6 +25,12 @@ import { formatPriceLabel } from "@/lib/stellar/format";
 import { usePageMeta } from "@/lib/seo/usePageMeta";
 import { buildCreatorReputation } from "@/lib/reputation/creatorReputation";
 import { CreatorVerifiedBadge } from "@/components/reputation/CreatorReputationBadge";
+import { useWallet } from "@/hooks/useWallet";
+import { useClipboardAutoClear } from "@/hooks/useClipboardAutoClear";
+import { ClipboardAutoClearBanner } from "@/components/ClipboardAutoClearBanner";
+import { MarkdownContent } from "@/components/MarkdownContent";
+import { UserAvatar } from "@/components/UserAvatar";
+import { ReportDialog } from "@/components/prompts/ReportDialog";
 
 const FALLBACK_IMAGE = "/images/codeguru.png";
 
@@ -37,6 +45,14 @@ export default function PromptDetailPage() {
   const { address } = useWallet();
   const [copied, setCopied] = useState(false);
   const [showReportDialog, setShowReportDialog] = useState(false);
+  const {
+    enabled: autoClearEnabled,
+    toggle: toggleAutoClear,
+    copy,
+    cancel: cancelAutoClear,
+    remaining,
+    isCountingDown,
+  } = useClipboardAutoClear();
 
   const {
     data: prompt,
@@ -83,8 +99,8 @@ export default function PromptDetailPage() {
   const handleCopyLink = async () => {
     const link =
       typeof window !== "undefined" ? window.location.href : `/prompts/${id}`;
-    const result = await copyToClipboard(link);
-    if (result.success) {
+    const ok = await copy(link);
+    if (ok) {
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1800);
     }
@@ -260,6 +276,12 @@ export default function PromptDetailPage() {
                     </>
                   )}
                 </Button>
+                <ClipboardAutoClearBanner
+                  remaining={remaining}
+                  enabled={autoClearEnabled}
+                  onToggle={toggleAutoClear}
+                  onCancel={cancelAutoClear}
+                />
                 <Button
                   variant="ghost"
                   onClick={() => setShowReportDialog(true)}


### PR DESCRIPTION
Closes #477 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional clipboard auto-clear setting after copying, with a customizable countdown.
  * Added controls to enable, disable, or cancel automatic clipboard clearing.
  * Added countdown feedback showing when copied content will be removed.
  * Applied auto-clear functionality to copied share links and prompt content.
  * Clipboard contents are cleared only when they still match the copied content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->