### PR TITLE
Enforce supply limits, pass lifecycle, dispute windows, and admin auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,11 @@ jobs:
 
       - name: Build WASM
         run: cargo build --release --target wasm32v1-none
+        env:
+          # soroban-sdk 27's spec-shaking feature otherwise requires building
+          # through `stellar contract build` (stellar-cli v25.2.0+); this is
+          # the same flag that CLI sets internally.
+          SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2: "1"
 
   # ── TypeScript frontend ───────────────────────────────────────────────────
   frontend:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.89.0
+          toolchain: 1.91.0
           targets: wasm32v1-none
           components: rustfmt, clippy
 
@@ -55,6 +55,11 @@ jobs:
 
       - name: Build release Wasm artifacts
         run: cargo build --workspace --release --target wasm32v1-none --locked
+        env:
+          # soroban-sdk 27's spec-shaking feature otherwise requires building
+          # through `stellar contract build` (stellar-cli v25.2.0+); this is
+          # the same flag that CLI sets internally.
+          SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2: "1"
 
       - name: Upgrade preflight self-check (#435)
         run: python3 scripts/preflight_upgrade.py check --self-check

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: wasm32-unknown-unknown
+          targets: wasm32v1-none
 
       - name: Cache cargo registry
         uses: actions/cache@v6
@@ -80,18 +80,22 @@ jobs:
             ${{ runner.os }}-cargo-build-target-
 
       - name: Build contract
-        run: cargo build --release -p prompt-hash --target wasm32-unknown-unknown
+        run: cargo build --release -p prompt-hash --target wasm32v1-none
         env:
           CARGO_TERM_COLOR: always
+          # soroban-sdk 27's spec-shaking feature otherwise requires building
+          # through `stellar contract build` (stellar-cli v25.2.0+); this is
+          # the same flag that CLI sets internally.
+          SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2: "1"
 
       - name: List WASM artifacts
-        run: ls -lah target/wasm32-unknown-unknown/release/*.wasm
+        run: ls -lah target/wasm32v1-none/release/*.wasm
 
       - name: Upload WASM artifacts
         uses: actions/upload-artifact@v7
         with:
           name: contract-wasm-${{ github.sha }}
-          path: target/wasm32-unknown-unknown/release/*.wasm
+          path: target/wasm32v1-none/release/*.wasm
           retention-days: 30
           if-no-files-found: warn
 

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -41,6 +41,11 @@ jobs:
 
       - name: Build WASM artifact
         run: cargo build --release --target wasm32v1-none
+        env:
+          # soroban-sdk 27's spec-shaking feature otherwise requires building
+          # through `stellar contract build` (stellar-cli v25.2.0+); this is
+          # the same flag that CLI sets internally.
+          SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2: "1"
 
       - name: Attest WASM provenance
         uses: actions/attest-build-provenance@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,9 +997,12 @@ dependencies = [
 
 [[package]]
 name = "prompt-hash"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "soroban-sdk",
+ "stellar-access",
+ "stellar-macros",
+ "stellar-tokens",
 ]
 
 [[package]]
@@ -1326,6 +1329,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "soroban-poseidon"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b241822373adc51c23d5412e412b3b91b0d6b6bba146584946391aa32667820d"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "soroban-sdk"
 version = "27.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1440,6 +1452,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "stellar-access"
+version = "0.7.1"
+source = "git+https://github.com/OpenZeppelin/stellar-contracts?rev=56d6e5b91aed828051163cebd92dab6c3ca2fa92#56d6e5b91aed828051163cebd92dab6c3ca2fa92"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "stellar-contract-utils"
+version = "0.7.1"
+source = "git+https://github.com/OpenZeppelin/stellar-contracts?rev=56d6e5b91aed828051163cebd92dab6c3ca2fa92#56d6e5b91aed828051163cebd92dab6c3ca2fa92"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "stellar-governance"
+version = "0.7.1"
+source = "git+https://github.com/OpenZeppelin/stellar-contracts?rev=56d6e5b91aed828051163cebd92dab6c3ca2fa92#56d6e5b91aed828051163cebd92dab6c3ca2fa92"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "stellar-macros"
+version = "0.7.1"
+source = "git+https://github.com/OpenZeppelin/stellar-contracts?rev=56d6e5b91aed828051163cebd92dab6c3ca2fa92#56d6e5b91aed828051163cebd92dab6c3ca2fa92"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "stellar-strkey"
 version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1458,6 +1504,17 @@ dependencies = [
  "crate-git-revision 0.0.6",
  "data-encoding",
  "heapless",
+]
+
+[[package]]
+name = "stellar-tokens"
+version = "0.7.1"
+source = "git+https://github.com/OpenZeppelin/stellar-contracts?rev=56d6e5b91aed828051163cebd92dab6c3ca2fa92#56d6e5b91aed828051163cebd92dab6c3ca2fa92"
+dependencies = [
+ "soroban-poseidon",
+ "soroban-sdk",
+ "stellar-contract-utils",
+ "stellar-governance",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,12 @@ version = "27.0.2"
 
 [workspace.dependencies.stellar-access]
 git = "https://github.com/OpenZeppelin/stellar-contracts"
-tag = "v0.5.1"
+# v0.5.1 (and every published release through v0.8.0-rc.3) pins soroban-sdk
+# <= 26.x, which conflicts with the soroban-sdk 27.0.2 used across this
+# workspace and pulls in a second soroban-env-common version. Pin to the
+# main-branch commit that first tracks soroban-sdk 27.0.2 until OpenZeppelin
+# cuts a matching release.
+rev = "56d6e5b91aed828051163cebd92dab6c3ca2fa92"
 
 [workspace.dependencies.stellar-default-impl-macro]
 git = "https://github.com/OpenZeppelin/stellar-contracts"
@@ -26,7 +31,7 @@ tag = "v0.3.0"
 
 [workspace.dependencies.stellar-macros]
 git = "https://github.com/OpenZeppelin/stellar-contracts"
-tag = "v0.5.1"
+rev = "56d6e5b91aed828051163cebd92dab6c3ca2fa92"
 
 [workspace.dependencies.stellar-non-fungible]
 git = "https://github.com/OpenZeppelin/stellar-contracts"
@@ -42,7 +47,7 @@ tag = "v0.3.0"
 
 [workspace.dependencies.stellar-tokens]
 git = "https://github.com/OpenZeppelin/stellar-contracts"
-tag = "v0.5.1"
+rev = "56d6e5b91aed828051163cebd92dab6c3ca2fa92"
 
 [profile.release]
 opt-level = "z"

--- a/api/auth/rotateSecret.ts
+++ b/api/auth/rotateSecret.ts
@@ -8,6 +8,8 @@
 
 import { randomBytes } from "crypto";
 import { isPlaceholder } from "../../src/lib/validation/envValidator";
+import { AdminTokenError, verifyAdminToken } from "../../server/src/services/adminToken";
+import { recordAuditEvent } from "../../server/src/services/auditTrail";
 
 interface SecretRotationConfig {
   currentSecret: string;
@@ -139,6 +141,14 @@ export function cleanupExpiredSecrets(): void {
   }
 }
 
+const ROTATE_SECRET_SCOPE = "secrets:rotate";
+
+function activeAdminSecrets(): string[] {
+  return [process.env.ADMIN_TOKEN_SECRET, process.env.ADMIN_TOKEN_SECRET_PREVIOUS].filter(
+    (value): value is string => Boolean(value) && value.length >= 16,
+  );
+}
+
 // HTTP endpoint handler for manual rotation
 export default async function handler(req: any, res: any) {
   if (req.method !== "POST") {
@@ -146,14 +156,49 @@ export default async function handler(req: any, res: any) {
     return;
   }
 
-  // Authentication check - only allow authorized operators
-  const authHeader = req.headers.authorization;
-  const adminToken = process.env.ADMIN_ROTATION_TOKEN;
-  
-  if (!adminToken || authHeader !== `Bearer ${adminToken}`) {
+  // Authentication check — only an admin token carrying the
+  // "secrets:rotate" scope may rotate the challenge token secret (#542).
+  // Signature, issuer, audience, expiry, role, and scope are all verified;
+  // presence of *some* bearer token is no longer sufficient.
+  const secrets = activeAdminSecrets();
+  const authHeader = req.headers.authorization as string | undefined;
+  const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7).trim() : undefined;
+  const clientIp = String(req.headers["x-forwarded-for"] || req.socket?.remoteAddress || "unknown");
+
+  if (secrets.length === 0 || !token) {
     res.status(401).json({ error: "Unauthorized" });
     return;
   }
+
+  try {
+    verifyAdminToken(secrets, token, {
+      audience: process.env.ADMIN_TOKEN_AUDIENCE || "prompt-hash-admin",
+      requiredScope: ROTATE_SECRET_SCOPE,
+    });
+  } catch (err) {
+    const code = err instanceof AdminTokenError ? err.code : "unknown_error";
+    void recordAuditEvent({
+      action: "admin_auth_denied",
+      result: "blocked",
+      promptId: null,
+      walletAddress: null,
+      requestId: null,
+      clientIp,
+      reason: `scope=${ROTATE_SECRET_SCOPE} route=POST /auth/rotateSecret error=${code}`,
+    });
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+
+  void recordAuditEvent({
+    action: "admin_auth_success",
+    result: "success",
+    promptId: null,
+    walletAddress: null,
+    requestId: null,
+    clientIp,
+    reason: `scope=${ROTATE_SECRET_SCOPE} route=POST /auth/rotateSecret`,
+  });
 
   try {
     const newConfig = rotateSecret();

--- a/contracts/prompt-hash/Cargo.toml
+++ b/contracts/prompt-hash/Cargo.toml
@@ -1,17 +1,20 @@
 [package]
 name = "prompt-hash"
-version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+version.workspace = true
 
 [lib]
 crate-type = ["cdylib"]
+doctest = false
 
 [dependencies]
-soroban-sdk = "22.0.0"
+soroban-sdk = { workspace = true }
+stellar-tokens = { workspace = true }
+stellar-macros = { workspace = true }
+stellar-access = { workspace = true }
 
 [dev-dependencies]
-soroban-sdk = { version = "22.0.0", features = ["testutils"] }
-
-[features]
-testutils = ["soroban-sdk/testutils"]
-
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/prompt-hash/MIGRATION.md
+++ b/contracts/prompt-hash/MIGRATION.md
@@ -17,6 +17,56 @@ git add contracts/prompt-hash/spec-baseline.json contracts/prompt-hash/MIGRATION
 
 ## Log
 
+### 2026-07-29 — catch up baseline after long-unmerged interface drift
+
+`spec-baseline.json` was last regenerated at commit `f46aae1` ("Add
+versioned event schema..."). Every PR merged since then that touched the
+contract's public interface shipped without ever re-running
+`generate-baseline`, so this preflight check has been silently failing
+(or simply not run) for a long stretch of `main`'s history — none of the
+changes below originate in this PR specifically; they accumulated across
+many prior merges (the prompt sale-status enum from #485/#486, u64 prompt
+IDs, the `encrypted_payload` rename, versioned events, etc.) plus the
+genuinely new interface surface this PR adds for #538/#539/#541/#542
+(access-pass `status`/`max_supply`, pass lifecycle methods, and the
+admin-auth-adjacent signature tweaks). Acknowledging the full accumulated
+list here and regenerating the baseline is a one-time catch-up so future
+PRs are checked against the current, correct interface instead of a
+multi-month-old snapshot.
+
+ACK-BREAKING: function `admin_set_prompt_sale_status` signature changed
+ACK-BREAKING: function `create_access_pass` signature changed
+ACK-BREAKING: function `create_bundle` signature changed
+ACK-BREAKING: function `set_prompt_sale_status` signature changed
+ACK-BREAKING: `AccessPass`: `pub active: bool` was removed or changed shape
+ACK-BREAKING: `AccessPass`: `pub sales_count: u64` was removed or changed shape
+ACK-BREAKING: `Bundle`: `pub prompt_ids: Vec<u128>` was removed or changed shape
+ACK-BREAKING: `InstanceDataKey`: `VoucherKey(u128` was removed or changed shape
+ACK-BREAKING: `InstanceDataKey`: `BytesN<32>)` was removed or changed shape
+ACK-BREAKING: `InstanceDataKey`: `ListingRevision(u128` was removed or changed shape
+ACK-BREAKING: `InstanceDataKey`: `u32)` was removed or changed shape
+ACK-BREAKING: `InstanceDataKey`: `PurchaseDispute(u128` was removed or changed shape
+ACK-BREAKING: `InstanceDataKey`: `Address)` was removed or changed shape
+ACK-BREAKING: `InstanceDataKey`: `Bundle(u128)` was removed or changed shape
+ACK-BREAKING: `InstanceDataKey`: `BundleCounter` was removed or changed shape
+ACK-BREAKING: `InstanceDataKey`: `CreatorBundles(Address)` was removed or changed shape
+ACK-BREAKING: `InstanceDataKey`: `AccessPass(u128)` was removed or changed shape
+ACK-BREAKING: `InstanceDataKey`: `AccessPassCounter` was removed or changed shape
+ACK-BREAKING: `InstanceDataKey`: `CreatorAccessPasses(Address)` was removed or changed shape
+ACK-BREAKING: `InstanceDataKey`: `CatalogPass(Address` was removed or changed shape
+ACK-BREAKING: `Prompt`: `pub encrypted_prompt: String` was removed or changed shape
+ACK-BREAKING: `Prompt`: `pub active: bool` was removed or changed shape
+ACK-BREAKING: event `PromptAdminModerated` field list changed
+ACK-BREAKING: event `PromptSaleStatusUpdated` field list changed
+
+Migration: this is a pre-launch contract with no live mainnet deployment
+and no real on-chain state to migrate — `set_prompt_max_supply` (#538),
+the access-pass lifecycle/renewal fields (#539), and the escrow
+`dispute_deadline`/permissionless-settlement fields (#541) are additive
+on top of already-changed storage shapes from prior merges. Any testnet
+instance deployed against an older interface must be redeployed fresh
+rather than upgraded in place.
+
 <!--
 Example:
 

--- a/contracts/prompt-hash/spec-baseline.json
+++ b/contracts/prompt-hash/spec-baseline.json
@@ -7,14 +7,23 @@
       "pub duration_secs: u64",
       "pub price_stroops: i128",
       "pub asset: Address",
-      "pub active: bool",
-      "pub sales_count: u64"
+      "pub status: PromptSaleStatus",
+      "pub sales_count: u32",
+      "pub max_supply: u32"
+    ],
+    "AcquisitionKind": [
+      "DirectPurchase",
+      "Lease",
+      "Bundle",
+      "AccessPass",
+      "BulkCheckout",
+      "ResaleFill"
     ],
     "Bundle": [
       "pub id: u128",
       "pub creator: Address",
       "pub title: String",
-      "pub prompt_ids: Vec<u128>",
+      "pub prompt_ids: Vec<u64>",
       "pub price_stroops: i128",
       "pub asset: Address",
       "pub active: bool",
@@ -27,6 +36,48 @@
       "pub pass_id: u128",
       "pub expires_at: u64"
     ],
+    "DataKey": [
+      "Prompt(u64)",
+      "CreatorPrompts(Address)",
+      "BuyerPrompts(Address)",
+      "CategoryPrompts(String)",
+      "// Index: category \u2192 Vec<prompt_ids> TagPrompts(String)",
+      "// Index: tag \u2192 Vec<prompt_ids> ActivePrompts",
+      "// Index: all active \u2192 Vec<prompt_ids> AllPrompts",
+      "// Index: all \u2192 Vec<prompt_ids> Purchase(u64",
+      "Address)",
+      "PurchaseEscrow(u64",
+      "Address)",
+      "// Settlement tracking for refunds (#420) VoucherKey(u64",
+      "BytesN<32>)",
+      "NonceConsumed(u64",
+      "BytesN<32>)",
+      "ListingRevision(u64",
+      "u32)",
+      "PurchaseDispute(u64",
+      "Address)",
+      "Bundle(u128)",
+      "BundleCounter",
+      "CreatorBundles(Address)",
+      "AccessPass(u128)",
+      "AccessPassCounter",
+      "CreatorAccessPasses(Address)",
+      "CatalogPass(Address",
+      "Address)",
+      "QuoteNonceConsumed(Address",
+      "BytesN<32>)",
+      "Settlement(u128)",
+      "EntitlementPointer(u64",
+      "Address)",
+      "BuyerSettlements(u64",
+      "Address)",
+      "SettlementEscrow(u128)",
+      "SettlementDispute(u128)",
+      "ResaleOrder(BytesN<32>)",
+      "ResaleOrderNonce(Address",
+      "BytesN<32>)",
+      "GovernanceProposal(BytesN<32>)"
+    ],
     "DisputeReason": [
       "InvalidEncryptedPayload",
       "MissingMetadata",
@@ -37,6 +88,21 @@
       "Refunded",
       "Rejected"
     ],
+    "GovernanceAction": [
+      "Upgrade(BytesN<32>)",
+      "SetFeeWallet(Address)",
+      "SetFeePercentage(u32)",
+      "SetReferralPercentage(u32)"
+    ],
+    "GovernanceProposal": [
+      "pub action: GovernanceAction",
+      "pub proposer: Address",
+      "pub proposed_at_ledger: u32",
+      "pub executable_at_ledger: u32",
+      "pub expiry_ledger: u32",
+      "pub expected_state_hash: BytesN<32>",
+      "pub nonce: BytesN<32>"
+    ],
     "InstanceDataKey": [
       "PromptCounter",
       "FeePercentage",
@@ -45,20 +111,8 @@
       "Reentrancy",
       "ReferralPercentage",
       "IsPaused",
-      "VoucherKey(u128",
-      "BytesN<32>)",
-      "ListingRevision(u128",
-      "u32)",
-      "PurchaseDispute(u128",
-      "Address)",
-      "Bundle(u128)",
-      "BundleCounter",
-      "CreatorBundles(Address)",
-      "AccessPass(u128)",
-      "AccessPassCounter",
-      "CreatorAccessPasses(Address)",
-      "CatalogPass(Address",
-      "Address)"
+      "SettlementCounter",
+      "GovernanceDelayLedgers"
     ],
     "ListingConfig": [
       "pub price: i128",
@@ -78,6 +132,19 @@
       "pub price_stroops: i128",
       "pub revised_at: u64"
     ],
+    "PayoutPlan": [
+      "pub creator: Address",
+      "pub fee_wallet: Address",
+      "pub fee_amount: i128",
+      "pub referrer: Option<Address>",
+      "pub referral_amount: i128",
+      "pub splits: Vec<PayoutSplit>",
+      "pub creator_amount: i128"
+    ],
+    "PayoutSplit": [
+      "pub recipient: Address",
+      "pub amount: i128"
+    ],
     "PricingConfig": [
       "pub price: i128",
       "pub asset: Address"
@@ -89,19 +156,25 @@
       "pub title: String",
       "pub category: String",
       "pub preview_text: String",
-      "pub encrypted_prompt: String",
+      "pub encrypted_payload: String",
       "pub encryption_iv: String",
       "pub wrapped_key: String",
       "pub content_hash: BytesN<32>",
       "pub price_stroops: i128",
       "pub asset: Address",
-      "pub active: bool",
+      "pub status: PromptSaleStatus",
       "pub sales_count: u64",
       "pub max_supply: u64",
       "pub expires_at: u64",
       "pub splits: Vec<Split>",
       "pub revision: u32",
       "pub tags: Vec<String>"
+    ],
+    "PromptSaleStatus": [
+      "Draft",
+      "Active",
+      "Paused",
+      "Retired"
     ],
     "Purchase": [
       "pub prompt_id: u64",
@@ -121,6 +194,84 @@
       "pub resolved_at: u64",
       "pub status: DisputeStatus"
     ],
+    "PurchaseEscrow": [
+      "pub prompt_id: u64",
+      "pub buyer: Address",
+      "pub amount: i128",
+      "pub status: SettlementStatus",
+      "pub created_at: u64",
+      "pub settled_at: u64",
+      "// 0 if not yet settled pub dispute_deadline: u64",
+      "pub asset: Address",
+      "pub referrer: Option<Address>",
+      "pub creator_amount: i128",
+      "pub fee_amount: i128",
+      "pub referral_amount: i128",
+      "pub payout_plan: PayoutPlan"
+    ],
+    "QuoteCommitment": [
+      "pub network_id: BytesN<32>",
+      "pub contract_id: BytesN<32>",
+      "pub buyer: Address",
+      "pub kind: AcquisitionKind",
+      "pub acquisition_id: u128",
+      "pub asset: Address",
+      "pub terms_hash: BytesN<32>",
+      "pub max_charge: i128",
+      "pub tip_amount: i128",
+      "pub not_before_ledger: u32",
+      "pub expiry_ledger: u32",
+      "pub nonce: BytesN<32>"
+    ],
+    "ResaleOrder": [
+      "pub network_id: BytesN<32>",
+      "pub contract_id: BytesN<32>",
+      "pub seller: Address",
+      "pub prompt_id: u64",
+      "pub settlement_id: u128",
+      "pub asset: Address",
+      "pub price: i128",
+      "pub min_proceeds: i128",
+      "pub buyer: Option<Address>",
+      "pub royalty_bps: u32",
+      "pub expiry_ledger: u32",
+      "pub nonce: BytesN<32>",
+      "pub status: ResaleOrderStatus"
+    ],
+    "ResaleOrderStatus": [
+      "Open",
+      "Filled",
+      "Cancelled"
+    ],
+    "SettlementRecord": [
+      "pub settlement_id: u128",
+      "pub prompt_id: u64",
+      "pub buyer: Address",
+      "pub kind: AcquisitionKind",
+      "pub amount: i128",
+      "pub asset: Address",
+      "pub status: SettlementStatus",
+      "pub created_at: u64",
+      "pub settled_at: u64",
+      "pub supersedes: Option<u128>",
+      "pub payout_plan: PayoutPlan"
+    ],
+    "SettlementStatus": [
+      "Pending",
+      "// Purchase received",
+      "awaiting settlement Settled",
+      "// Payment distributed successfully Refunded",
+      "// Purchase refunded atomically"
+    ],
+    "SignedDiscountAuthorization": [
+      "pub prompt_id: u64",
+      "pub buyer: Address",
+      "pub discount_bps: u32",
+      "pub nonce: BytesN<32>",
+      "pub expiry_ledger: u32",
+      "pub network_id: BytesN<32>",
+      "pub contract_id: BytesN<32>"
+    ],
     "Split": [
       "pub recipient: Address",
       "pub bps: u32"
@@ -128,24 +279,45 @@
   },
   "errors": {
     "AccessPassNotFound": "40",
+    "AlreadyInitialized": "45",
     "AlreadyPurchased": "5",
     "ArithmeticOverflow": "17",
+    "AuthorizationBuyerMismatch": "51",
+    "AuthorizationDomainMismatch": "53",
+    "AuthorizationExpired": "48",
+    "AuthorizationNonceConsumed": "49",
+    "AuthorizationNotYetValid": "54",
+    "AuthorizationPromptMismatch": "52",
+    "BulkPurchaseTooLarge": "42",
     "BundleNotFound": "39",
     "ContractIsPaused": "19",
     "CreatorCannotBuy": "3",
     "DisputeAlreadyOpen": "35",
     "DisputeNotFound": "36",
     "DisputeResolved": "37",
+    "DisputeWindowClosed": "85",
+    "DisputeWindowNotElapsed": "86",
+    "DuplicatePromptId": "43",
+    "DuplicateSettlementSubmission": "67",
     "DuplicateSplitRecipient": "32",
     "FeeExceedsMaximum": "34",
     "FeeWalletNotSet": "15",
+    "GovernanceDelayNotElapsed": "79",
+    "GovernanceNonceConsumed": "82",
+    "GovernanceProposalExists": "78",
+    "GovernanceProposalExpired": "80",
+    "GovernanceProposalNotFound": "77",
+    "GovernanceStateMismatch": "81",
     "InvalidAccessDuration": "41",
     "InvalidAsset": "26",
+    "InvalidAuthorizationSignature": "50",
     "InvalidBundle": "38",
     "InvalidCategoryLength": "9",
+    "InvalidCursor": "46",
     "InvalidDiscountPercentage": "24",
     "InvalidEncryptedPromptLength": "11",
     "InvalidFeePercentage": "7",
+    "InvalidGovernanceDelay": "83",
     "InvalidImageUrlLength": "13",
     "InvalidIvLength": "14",
     "InvalidLicenseTransfer": "30",
@@ -153,20 +325,44 @@
     "InvalidPreviewLength": "10",
     "InvalidPrice": "6",
     "InvalidReferralPercentage": "23",
+    "InvalidResaleOrderSignature": "76",
     "InvalidSplits": "27",
+    "InvalidStatusTransition": "44",
     "InvalidTitleLength": "8",
+    "InvalidTtlPolicy": "47",
     "InvalidVoucher": "22",
     "InvalidWrappedKeyLength": "12",
     "LicenseNotFound": "29",
     "ListingExpired": "28",
+    "MaxSupplyBelowCommitted": "84",
     "MaxSupplyReached": "25",
     "PromptInactive": "4",
     "PromptNotFound": "2",
+    "QuoteAcquisitionMismatch": "59",
+    "QuoteAssetMismatch": "60",
+    "QuoteChargeExceeded": "62",
+    "QuoteDomainMismatch": "58",
+    "QuoteExpired": "55",
+    "QuoteNonceConsumed": "57",
+    "QuoteNotYetValid": "56",
+    "QuoteTermsChanged": "61",
     "ReentrancyGuard": "18",
     "ReferrerCannotBeBuyerOrCreator": "20",
+    "ResaleOrderBuyerMismatch": "72",
+    "ResaleOrderCancelled": "70",
+    "ResaleOrderDomainMismatch": "73",
+    "ResaleOrderExpired": "69",
+    "ResaleOrderNonceConsumed": "71",
+    "ResaleOrderNotFound": "68",
+    "ResaleOrderOwnershipChanged": "74",
+    "ResaleProceedsBelowMinimum": "75",
     "RevisionFieldsUnchanged": "31",
+    "SettlementAlreadyFinalized": "65",
+    "SettlementEntitlementMismatch": "66",
+    "SettlementNotFound": "64",
     "TooManySplits": "33",
     "Unauthorized": "1",
+    "UnauthorizedTip": "63",
     "XlmAddressNotSet": "16"
   },
   "events": {
@@ -176,11 +372,19 @@
       "pub duration_secs: u64",
       "pub price_stroops: i128"
     ],
+    "AccessPassPriceUpdated": [
+      "pub pass_id: u128",
+      "pub price_stroops: i128"
+    ],
     "AccessPassPurchased": [
       "pub pass_id: u128",
       "pub buyer: Address",
       "pub creator: Address",
       "pub expires_at: u64"
+    ],
+    "AccessPassStatusUpdated": [
+      "pub pass_id: u128",
+      "pub status: PromptSaleStatus"
     ],
     "BundleCreated": [
       "pub bundle_id: u128",
@@ -196,6 +400,11 @@
     ],
     "ContractPausedStateChanged": [
       "pub is_paused: bool"
+    ],
+    "DiscountApplied": [
+      "pub prompt_id: u64",
+      "pub buyer: Address",
+      "pub discount_bps: u32"
     ],
     "DisputeOpened": [
       "pub prompt_id: u64",
@@ -236,13 +445,17 @@
     "PromptAdminModerated": [
       "pub prompt_id: u64",
       "pub admin: Address",
-      "pub active: bool"
+      "pub status: PromptSaleStatus"
     ],
     "PromptCreated": [
       "pub prompt_id: u64",
       "pub creator: Address",
       "pub price_stroops: i128",
       "pub asset: Address"
+    ],
+    "PromptMaxSupplyUpdated": [
+      "pub prompt_id: u64",
+      "pub max_supply: u64"
     ],
     "PromptPriceUpdated": [
       "pub prompt_id: u64",
@@ -257,12 +470,23 @@
     ],
     "PromptSaleStatusUpdated": [
       "pub prompt_id: u64",
-      "pub active: bool"
+      "pub status: PromptSaleStatus"
     ],
     "PromptTipped": [
       "pub prompt_id: u64",
       "pub buyer: Address",
       "pub amount_tipped: i128"
+    ],
+    "SignedDiscountAdded": [
+      "pub prompt_id: u64",
+      "pub creator: Address",
+      "pub discount_bps: u32",
+      "pub nonce: BytesN<32>"
+    ],
+    "SignedDiscountRevoked": [
+      "pub prompt_id: u64",
+      "pub creator: Address",
+      "pub nonce: BytesN<32>"
     ],
     "SplitsUpdated": [
       "pub prompt_id: u64"
@@ -279,24 +503,29 @@
   },
   "functions": {
     "__constructor": "fn __constructor( env: Env, admin: Address, fee_wallet: Address, xlm_sac: Address, ) -> Result<(), Error>",
+    "add_signed_discount_auth": "fn add_signed_discount_auth( env: Env, creator: Address, authorization: SignedDiscountAuthorization, signature: BytesN<64>, ) -> Result<(), Error>",
     "add_voucher": "fn add_voucher( env: Env, creator: Address, prompt_id: u64, hashed_code: BytesN<32>, discount_bps: u32, ) -> Result<(), Error>",
-    "admin_set_prompt_sale_status": "fn admin_set_prompt_sale_status( env: Env, admin: Address, prompt_id: u128, active: bool, ) -> Result<(), Error>",
+    "admin_set_prompt_sale_status": "fn admin_set_prompt_sale_status( env: Env, admin: Address, prompt_id: u64, status: PromptSaleStatus, ) -> Result<(), Error>",
     "buy_access_pass": "fn buy_access_pass( env: Env, buyer: Address, pass_id: u128, payment_amount_stroops: i128, ) -> Result<(), Error>",
     "buy_bundle": "fn buy_bundle( env: Env, buyer: Address, bundle_id: u128, payment_amount_stroops: i128, ) -> Result<(), Error>",
     "buy_prompt": "fn buy_prompt( env: Env, buyer: Address, prompt_id: u64, referrer: Option<Address>, payment_amount_stroops: i128, voucher: Option<Bytes>, ) -> Result<(), Error>",
+    "buy_prompt_with_auth": "fn buy_prompt_with_auth( env: Env, buyer: Address, prompt_id: u64, referrer: Option<Address>, payment_amount_stroops: i128, authorization: SignedDiscountAuthorization, creator_sig: BytesN<64>, ) -> Result<(), Error>",
     "buy_prompts_bulk": "fn buy_prompts_bulk( env: Env, buyer: Address, prompt_ids: Vec<u64>, payment_amounts: Vec<i128>, referrer: Option<Address>, ) -> Result<(), Error>",
-    "create_access_pass": "fn create_access_pass( env: Env, creator: Address, title: String, duration_secs: u64, price_stroops: i128, asset: Address, ) -> Result<u128, Error>",
-    "create_bundle": "fn create_bundle( env: Env, creator: Address, title: String, prompt_ids: Vec<u128>, price_stroops: i128, asset: Address, expires_at: u64, ) -> Result<u128, Error>",
+    "create_access_pass": "fn create_access_pass( env: Env, creator: Address, title: String, duration_secs: u64, price_stroops: i128, asset: Address, max_supply: u32, ) -> Result<u128, Error>",
+    "create_bundle": "fn create_bundle( env: Env, creator: Address, title: String, prompt_ids: Vec<u64>, price_stroops: i128, asset: Address, expires_at: u64, ) -> Result<u128, Error>",
     "create_prompt": "fn create_prompt( env: Env, creator: Address, image_url: String, title: String, category: String, preview_text: String, encrypted_prompt: String, encryption_iv: String, wrapped_key: String, content_hash: BytesN<32>, listing: ListingConfig, ) -> Result<u64, Error>",
     "extend_all_ttl": "fn extend_all_ttl(env: Env) -> Result<(), Error>",
     "extend_listing": "fn extend_listing( env: Env, creator: Address, prompt_id: u64, new_expires_at: u64, ) -> Result<(), Error>",
     "extend_ttl": "fn extend_ttl(env: Env, key: DataKey) -> Result<(), Error>",
     "get_access_pass": "fn get_access_pass(env: Env, pass_id: u128) -> Result<AccessPass, Error>",
     "get_access_passes_by_creator": "fn get_access_passes_by_creator(env: Env, creator: Address) -> Result<Vec<AccessPass>, Error>",
+    "get_active_prompts_paginated": "fn get_active_prompts_paginated( env: Env, cursor: Option<String>, limit: u64, ) -> Result<(Vec<Prompt>, Option<String>), Error>",
     "get_all_prompts": "fn get_all_prompts(env: Env) -> Result<Vec<Prompt>, Error>",
+    "get_all_prompts_paginated": "fn get_all_prompts_paginated( env: Env, cursor: Option<String>, limit: u64, ) -> Result<(Vec<Prompt>, Option<String>), Error>",
     "get_bundle": "fn get_bundle(env: Env, bundle_id: u128) -> Result<Bundle, Error>",
     "get_bundles_by_creator": "fn get_bundles_by_creator(env: Env, creator: Address) -> Result<Vec<Bundle>, Error>",
     "get_dispute": "fn get_dispute(env: Env, prompt_id: u64, buyer: Address) -> Result<PurchaseDispute, Error>",
+    "get_expiry_risk_metrics": "fn get_expiry_risk_metrics(env: Env) -> Result<Vec<(String, String)>, Error>",
     "get_fee_percentage": "fn get_fee_percentage(env: Env) -> u32",
     "get_fee_wallet": "fn get_fee_wallet(env: Env) -> Option<Address>",
     "get_listing_revision": "fn get_listing_revision( env: Env, prompt_id: u64, revision: u32, ) -> Result<ListingRevisionRecord, Error>",
@@ -304,9 +533,12 @@
     "get_prompt": "fn get_prompt(env: Env, prompt_id: u64) -> Result<Prompt, Error>",
     "get_prompts_by_buyer": "fn get_prompts_by_buyer(env: Env, buyer: Address) -> Result<Vec<Prompt>, Error>",
     "get_prompts_by_category": "fn get_prompts_by_category(env: Env, category: String) -> Result<Vec<Prompt>, Error>",
+    "get_prompts_by_category_page": "fn get_prompts_by_category_page( env: Env, category: String, cursor: Option<String>, limit: u64, ) -> Result<(Vec<Prompt>, Option<String>), Error>",
     "get_prompts_by_creator": "fn get_prompts_by_creator(env: Env, creator: Address) -> Result<Vec<Prompt>, Error>",
     "get_prompts_by_ids": "fn get_prompts_by_ids(env: Env, prompt_ids: Vec<u64>) -> Result<Vec<Prompt>, Error>",
     "get_prompts_by_tag": "fn get_prompts_by_tag(env: Env, tag: String) -> Result<Vec<Prompt>, Error>",
+    "get_prompts_by_tag_paginated": "fn get_prompts_by_tag_paginated( env: Env, tag: String, cursor: Option<String>, limit: u64, ) -> Result<(Vec<Prompt>, Option<String>), Error>",
+    "get_purchase_escrow": "fn get_purchase_escrow(env: Env, prompt_id: u64, buyer: Address) -> Option<PurchaseEscrow>",
     "get_referral_percentage": "fn get_referral_percentage(env: Env) -> u32",
     "get_xlm_sac": "fn get_xlm_sac(env: Env) -> Option<Address>",
     "has_access": "fn has_access(env: Env, user: Address, prompt_id: u64) -> Result<bool, Error>",
@@ -314,15 +546,20 @@
     "lease_prompt": "fn lease_prompt( env: Env, buyer: Address, prompt_id: u64, lease_duration_secs: u64, ) -> Result<(), Error>",
     "open_dispute": "fn open_dispute( env: Env, buyer: Address, prompt_id: u64, reason: DisputeReason, ) -> Result<(), Error>",
     "remove_voucher": "fn remove_voucher( env: Env, creator: Address, prompt_id: u64, hashed_code: BytesN<32>, ) -> Result<(), Error>",
+    "renew_critical_keys": "fn renew_critical_keys(env: Env, cursor: Option<u64>) -> Result<(u32, Option<u64>), Error>",
     "resolve_dispute": "fn resolve_dispute( env: Env, admin: Address, prompt_id: u64, buyer: Address, refund: bool, ) -> Result<(), Error>",
     "revise_listing": "fn revise_listing( env: Env, creator: Address, prompt_id: u64, title: String, category: String, preview_text: String, image_url: String, price_stroops: i128, ) -> Result<u32, Error>",
+    "revoke_discount_auth": "fn revoke_discount_auth( env: Env, creator: Address, prompt_id: u64, nonce: BytesN<32>, ) -> Result<(), Error>",
+    "set_access_pass_status": "fn set_access_pass_status( env: Env, creator: Address, pass_id: u128, status: PromptSaleStatus, ) -> Result<(), Error>",
     "set_fee_percentage": "fn set_fee_percentage(env: Env, new_fee_percentage: u32) -> Result<(), Error>",
     "set_fee_wallet": "fn set_fee_wallet(env: Env, new_fee_wallet: Address) -> Result<(), Error>",
     "set_pause_status": "fn set_pause_status(env: Env, paused: bool) -> Result<(), Error>",
     "set_prompt_max_supply": "fn set_prompt_max_supply( env: Env, creator: Address, prompt_id: u64, max_supply: u64, ) -> Result<(), Error>",
-    "set_prompt_sale_status": "fn set_prompt_sale_status( env: Env, creator: Address, prompt_id: u64, active: bool, ) -> Result<(), Error>",
+    "set_prompt_sale_status": "fn set_prompt_sale_status( env: Env, creator: Address, prompt_id: u64, status: PromptSaleStatus, ) -> Result<(), Error>",
     "set_referral_percentage": "fn set_referral_percentage(env: Env, new_referral_percentage: u32) -> Result<(), Error>",
+    "settle_purchase": "fn settle_purchase( env: Env, caller: Address, prompt_id: u64, buyer: Address, ) -> Result<(), Error>",
     "transfer_license": "fn transfer_license( env: Env, seller: Address, prompt_id: u64, new_buyer: Address, resale_price: i128, ) -> Result<(), Error>",
+    "update_access_pass_price": "fn update_access_pass_price( env: Env, creator: Address, pass_id: u128, price_stroops: i128, ) -> Result<(), Error>",
     "update_platform_fee": "fn update_platform_fee(env: Env, admin: Address, new_fee: u32) -> Result<(), Error>",
     "update_prompt_price": "fn update_prompt_price( env: Env, creator: Address, prompt_id: u64, price_stroops: i128, ) -> Result<(), Error>",
     "update_splits": "fn update_splits( env: Env, creator: Address, prompt_id: u64, new_splits: Vec<Split>, ) -> Result<(), Error>",

--- a/contracts/prompt-hash/src/contract.rs
+++ b/contracts/prompt-hash/src/contract.rs
@@ -1825,10 +1825,10 @@ fn execute_buy_with_required_price(
     // Escrow is created as Pending — the creator's share is held in
     // the contract until `settle_purchase` is called (#454).
     let now = env.ledger().timestamp();
-    let fee_wallet = InstanceStorage::get_fee_wallet(&env).ok_or(Error::FeeWalletNotSet)?;
+    let fee_wallet = InstanceStorage::get_fee_wallet(env).ok_or(Error::FeeWalletNotSet)?;
 
     // Snapshot the complete payout plan at purchase time (#562).
-    let mut payout_splits: Vec<super::types::PayoutSplit> = Vec::new(&env);
+    let mut payout_splits: Vec<super::types::PayoutSplit> = Vec::new(env);
     let mut split_total: i128 = 0;
     for i in 0..prompt.splits.len() {
         let split = prompt.splits.get(i).unwrap();

--- a/contracts/prompt-hash/src/contract.rs
+++ b/contracts/prompt-hash/src/contract.rs
@@ -7,7 +7,7 @@ use super::types::{
 };
 use soroban_sdk::{contract, contractimpl, crypto::Crypto, token, Address, Bytes, BytesN, Env, String, Vec};
 use stellar_access::ownable::{self as ownable, Ownable};
-use stellar_macros::{default_impl, only_owner};
+use stellar_macros::only_owner;
 
 const DEFAULT_FEE_BPS: u32 = 500;
 const ROYALTY_BPS: u32 = 500;
@@ -31,10 +31,15 @@ const MAX_PASS_DURATION_SECS: u64 = 31_536_000;
 // budget) so a caller cannot force an unbounded-cost simulation or transaction
 // just by passing an oversized vector (issue #438).
 const MAX_BULK_PURCHASE_SIZE: u32 = 20;
+// Window (from purchase) within which a buyer may open a dispute against a
+// pending escrow. After it elapses with no open dispute, settlement becomes
+// permissionless (#541).
+const DISPUTE_WINDOW_SECS: u64 = 3 * 24 * 60 * 60;
 
 #[contract]
 pub struct PromptHashContract;
 
+#[contractimpl]
 impl PromptHashTrait for PromptHashContract {
     fn __constructor(
         env: Env,
@@ -176,8 +181,15 @@ impl PromptHashTrait for PromptHashContract {
         ensure(!InstanceStorage::is_paused(&env), Error::ContractIsPaused)?;
         let mut prompt = Storage::require_prompt(&env, prompt_id)?;
         ensure(prompt.creator == creator, Error::Unauthorized)?;
+        // A cap can never be lowered below units already sold/leased — that
+        // would silently invalidate commitments already made to buyers (#538).
+        ensure(
+            max_supply == 0 || max_supply >= prompt.sales_count,
+            Error::MaxSupplyBelowCommitted,
+        )?;
         prompt.max_supply = max_supply;
         Storage::update_prompt(&env, &prompt);
+        Events::emit_prompt_max_supply_updated(&env, prompt_id, max_supply);
         Ok(())
     }
 
@@ -199,6 +211,7 @@ impl PromptHashTrait for PromptHashContract {
         Events::emit_prompt_price_updated(&env, prompt_id, price_stroops);
         Ok(())
     }
+
     fn buy_prompt(
         env: Env,
         buyer: Address,
@@ -337,6 +350,9 @@ impl PromptHashTrait for PromptHashContract {
             ensure(prompt.expires_at >= now, Error::ListingExpired)?;
         }
 
+        // Leases consume the same supply pool as direct sales (#538).
+        let reserved_sales_count = reserve_supply(prompt.sales_count, prompt.max_supply)?;
+
         InstanceStorage::set_reentrancy_guard(&env)?;
 
         let fee_wallet = InstanceStorage::get_fee_wallet(&env).ok_or(Error::FeeWalletNotSet)?;
@@ -373,10 +389,7 @@ impl PromptHashTrait for PromptHashContract {
             asset_client.transfer(&this_contract, &fee_wallet, &fee_amount);
         }
 
-        prompt.sales_count = prompt
-            .sales_count
-            .checked_add(1)
-            .ok_or(Error::ArithmeticOverflow)?;
+        prompt.sales_count = reserved_sales_count;
         let expires_at = now
             .checked_add(lease_duration_secs)
             .ok_or(Error::ArithmeticOverflow)?;
@@ -400,6 +413,8 @@ impl PromptHashTrait for PromptHashContract {
             status: SettlementStatus::Settled,
             created_at: now,
             settled_at: now,
+            // Lease funds settle immediately — there is no pending window.
+            dispute_deadline: now,
             creator_amount: seller_amount,
             fee_amount,
             referral_amount: 0,
@@ -547,17 +562,8 @@ impl PromptHashTrait for PromptHashContract {
                 ensure(prompt.expires_at >= now, Error::ListingExpired)?;
             }
             if !Storage::has_active_purchase(&env, prompt.id, &buyer, now) {
-                if prompt.max_supply > 0 {
-                    ensure(
-                        prompt.sales_count < prompt.max_supply,
-                        Error::MaxSupplyReached,
-                    )?;
-                }
                 needs_access = true;
-                prompt.sales_count = prompt
-                    .sales_count
-                    .checked_add(1)
-                    .ok_or(Error::ArithmeticOverflow)?;
+                prompt.sales_count = reserve_supply(prompt.sales_count, prompt.max_supply)?;
             }
             prompts.push_back(prompt);
         }
@@ -709,6 +715,7 @@ impl PromptHashTrait for PromptHashContract {
         duration_secs: u64,
         price_stroops: i128,
         asset: Address,
+        max_supply: u32,
     ) -> Result<u128, Error> {
         creator.require_auth();
         ensure(!InstanceStorage::is_paused(&env), Error::ContractIsPaused)?;
@@ -728,14 +735,55 @@ impl PromptHashTrait for PromptHashContract {
             duration_secs,
             price_stroops,
             asset,
-            active: true,
+            status: PromptSaleStatus::Active,
             sales_count: 0,
+            max_supply,
         };
 
         Storage::save_access_pass(&env, &access_pass)?;
         Storage::add_access_pass_to_creator(&env, &creator, pass_id);
         Events::emit_access_pass_created(&env, pass_id, creator, duration_secs, price_stroops);
         Ok(pass_id)
+    }
+
+    fn set_access_pass_status(
+        env: Env,
+        creator: Address,
+        pass_id: u128,
+        status: PromptSaleStatus,
+    ) -> Result<(), Error> {
+        creator.require_auth();
+        ensure(!InstanceStorage::is_paused(&env), Error::ContractIsPaused)?;
+        let mut access_pass = Storage::require_access_pass(&env, pass_id)?;
+        ensure(access_pass.creator == creator, Error::Unauthorized)?;
+        ensure(
+            access_pass.status != PromptSaleStatus::Retired,
+            Error::InvalidStatusTransition,
+        )?;
+        ensure(access_pass.status != status, Error::InvalidStatusTransition)?;
+
+        access_pass.status = status.clone();
+        Storage::update_access_pass(&env, &access_pass);
+        Events::emit_access_pass_status_updated(&env, pass_id, status);
+        Ok(())
+    }
+
+    fn update_access_pass_price(
+        env: Env,
+        creator: Address,
+        pass_id: u128,
+        price_stroops: i128,
+    ) -> Result<(), Error> {
+        creator.require_auth();
+        ensure(!InstanceStorage::is_paused(&env), Error::ContractIsPaused)?;
+        ensure(price_stroops > 0, Error::InvalidPrice)?;
+        let mut access_pass = Storage::require_access_pass(&env, pass_id)?;
+        ensure(access_pass.creator == creator, Error::Unauthorized)?;
+
+        access_pass.price_stroops = price_stroops;
+        Storage::update_access_pass(&env, &access_pass);
+        Events::emit_access_pass_price_updated(&env, pass_id, price_stroops);
+        Ok(())
     }
 
     fn buy_access_pass(
@@ -749,16 +797,19 @@ impl PromptHashTrait for PromptHashContract {
         let mut access_pass = Storage::require_access_pass(&env, pass_id)?;
         let now = env.ledger().timestamp();
 
-        ensure(access_pass.active, Error::PromptInactive)?;
+        ensure(
+            access_pass.status == PromptSaleStatus::Active,
+            Error::PromptInactive,
+        )?;
         ensure(access_pass.creator != buyer, Error::CreatorCannotBuy)?;
         ensure(
             payment_amount_stroops >= access_pass.price_stroops,
             Error::InvalidPaymentAmount,
         )?;
-        ensure(
-            !Storage::has_active_creator_pass(&env, &access_pass.creator, &buyer, now),
-            Error::AlreadyPurchased,
-        )?;
+
+        // Each purchase reserves one unit of this pass's own supply, on top
+        // of whatever other passes this creator has sold (#538).
+        access_pass.sales_count = reserve_pass_supply(access_pass.sales_count, access_pass.max_supply)?;
 
         InstanceStorage::set_reentrancy_guard(&env)?;
 
@@ -796,7 +847,15 @@ impl PromptHashTrait for PromptHashContract {
             asset_client.transfer(&this_contract, &access_pass.creator, &creator_amount);
         }
 
-        let expires_at = now
+        // Renewing before the current grant expires extends it forward from
+        // the existing expiry rather than from `now`, so the buyer never
+        // loses paid-for time or is double-charged for an overlapping
+        // period (#539).
+        let existing = Storage::get_catalog_pass_purchase(&env, &access_pass.creator, &buyer);
+        let base = existing
+            .map(|p| if p.expires_at > now { p.expires_at } else { now })
+            .unwrap_or(now);
+        let expires_at = base
             .checked_add(access_pass.duration_secs)
             .ok_or(Error::ArithmeticOverflow)?;
         let catalog_pass = CatalogPassPurchase {
@@ -807,7 +866,9 @@ impl PromptHashTrait for PromptHashContract {
         };
         Storage::save_catalog_pass_purchase(&env, &catalog_pass);
 
-        // Create escrow with payout plan for unified dispute/settlement (#564)
+        // Create escrow with payout plan for unified dispute/settlement (#564).
+        // sales_count was already advanced by reserve_pass_supply above (#538)
+        // — do not increment it again here.
         let payout_plan = super::types::PayoutPlan {
             creator: access_pass.creator.clone(),
             fee_wallet: fee_wallet.clone(),
@@ -826,17 +887,14 @@ impl PromptHashTrait for PromptHashContract {
             status: SettlementStatus::Settled,
             created_at: now,
             settled_at: now,
+            // Access-pass funds settle immediately — there is no pending window (#541).
+            dispute_deadline: now,
             creator_amount,
             fee_amount,
             referral_amount: 0,
             payout_plan,
         };
         Storage::save_purchase_escrow(&env, &escrow);
-
-        access_pass.sales_count = access_pass
-            .sales_count
-            .checked_add(1)
-            .ok_or(Error::ArithmeticOverflow)?;
         Storage::update_access_pass(&env, &access_pass);
         InstanceStorage::clear_reentrancy_guard(&env);
         Events::emit_access_pass_purchased(&env, pass_id, buyer, access_pass.creator, expires_at);
@@ -1165,6 +1223,18 @@ impl PromptHashTrait for PromptHashContract {
         ensure(!InstanceStorage::is_paused(&env), Error::ContractIsPaused)?;
         let now = env.ledger().timestamp();
         Storage::require_purchase(&env, prompt_id, &buyer)?;
+        // Purchases with a pending escrow (direct/bulk buys) may only be
+        // disputed within the purchase-relative window; once it closes the
+        // escrow is eligible for permissionless settlement (#541). Purchases
+        // without a pending escrow (leases, bundles, passes) are unaffected.
+        if let Some(escrow) = Storage::get_purchase_escrow(&env, prompt_id, &buyer) {
+            if escrow.status == SettlementStatus::Pending {
+                ensure(now <= escrow.dispute_deadline, Error::DisputeWindowClosed)?;
+            } else {
+                // Already settled or refunded — nothing left to dispute.
+                return Err(Error::DisputeWindowClosed);
+            }
+        }
         if let Some(dispute) = Storage::get_dispute(&env, prompt_id, &buyer) {
             ensure(
                 dispute.status != DisputeStatus::Open,
@@ -1194,7 +1264,7 @@ impl PromptHashTrait for PromptHashContract {
         admin.require_auth();
         let owner = ownable::get_owner(&env).ok_or(Error::Unauthorized)?;
         ensure(owner == admin, Error::Unauthorized)?;
-        let prompt = Storage::require_prompt(&env, prompt_id)?;
+        let mut prompt = Storage::require_prompt(&env, prompt_id)?;
         let purchase = Storage::require_purchase(&env, prompt_id, &buyer)?;
         let mut dispute = Storage::require_dispute(&env, prompt_id, &buyer)?;
         ensure(
@@ -1218,6 +1288,11 @@ impl PromptHashTrait for PromptHashContract {
             Storage::remove_prompt_from_buyer(&env, &buyer, prompt_id);
             dispute.status = DisputeStatus::Refunded;
 
+            // Release the reserved supply unit back to the pool so another
+            // buyer can acquire it (#538).
+            prompt.sales_count = prompt.sales_count.saturating_sub(1);
+            Storage::update_prompt(&env, &prompt);
+
             // Update the escrow record so the settlement admin knows
             // the funds were already returned to the buyer.
             if let Some(mut escrow) = Storage::get_purchase_escrow(&env, prompt_id, &buyer) {
@@ -1233,10 +1308,13 @@ impl PromptHashTrait for PromptHashContract {
         Ok(())
     }
 
-    /// Release escrowed funds after the dispute window closes (#454).
-    /// The contract owner (admin) or the prompt creator can settle.
-    /// This distributes the held payment using the immutable payout plan
-    /// snapshotted at purchase time (#562), not the current listing state.
+    /// Release escrowed funds using the immutable payout plan snapshotted at
+    /// purchase time (#562), not the current listing state. The contract
+    /// owner (admin) or the prompt creator may settle at any time; any
+    /// other caller may settle only once the purchase-relative dispute
+    /// window has closed with no open dispute, guaranteeing every escrow
+    /// has a bounded path to Released even if the admin/creator never
+    /// act (#454/#541).
     fn settle_purchase(
         env: Env,
         caller: Address,
@@ -1246,15 +1324,29 @@ impl PromptHashTrait for PromptHashContract {
         caller.require_auth();
         let owner = ownable::get_owner(&env).ok_or(Error::Unauthorized)?;
         let prompt = Storage::require_prompt(&env, prompt_id)?;
-        ensure(
-            caller == owner || caller == prompt.creator,
-            Error::Unauthorized,
-        )?;
 
-        let mut escrow = Storage::require_purchase_escrow(&env, &prompt_id, &buyer)?;
+        let mut escrow = Storage::require_purchase_escrow(&env, prompt_id, &buyer)?;
         ensure(escrow.status == SettlementStatus::Pending, Error::DisputeResolved)?;
 
+        // An open dispute must be resolved via `resolve_dispute`, not
+        // settled — this holds even for the admin/creator fast path (#541).
+        if let Some(dispute) = Storage::get_dispute(&env, prompt_id, &buyer) {
+            ensure(
+                dispute.status != DisputeStatus::Open,
+                Error::DisputeAlreadyOpen,
+            )?;
+        }
+
         let now = env.ledger().timestamp();
+        let is_privileged = caller == owner || caller == prompt.creator;
+        if !is_privileged {
+            // Permissionless fallback: once the dispute window has closed
+            // with no open dispute, anyone may finalize the escrow — this
+            // guarantees a bounded path to Released even if the admin or
+            // creator never act (#541).
+            ensure(now > escrow.dispute_deadline, Error::DisputeWindowNotElapsed)?;
+        }
+
         let this_contract = env.current_contract_address();
         let asset_client = token::StellarAssetClient::new(&env, &escrow.asset);
 
@@ -1314,6 +1406,10 @@ impl PromptHashTrait for PromptHashContract {
 
     fn get_prompts_by_creator(env: Env, creator: Address) -> Result<Vec<Prompt>, Error> {
         Ok(Storage::get_prompts_by_creator(&env, &creator))
+    }
+
+    fn get_prompts_by_buyer(env: Env, buyer: Address) -> Result<Vec<Prompt>, Error> {
+        Ok(Storage::get_prompts_by_buyer(&env, &buyer))
     }
 
     #[only_owner]
@@ -1534,8 +1630,7 @@ impl PromptHashTrait for PromptHashContract {
     }
 }
 
-#[default_impl]
-#[contractimpl]
+#[contractimpl(contracttrait)]
 impl Ownable for PromptHashContract {}
 
 fn execute_buy(
@@ -1560,12 +1655,7 @@ fn execute_buy(
         ensure(prompt.expires_at >= now, Error::ListingExpired)?;
     }
 
-    if prompt.max_supply > 0 {
-        ensure(
-            prompt.sales_count < prompt.max_supply,
-            Error::MaxSupplyReached,
-        )?;
-    }
+    let reserved_sales_count = reserve_supply(prompt.sales_count, prompt.max_supply)?;
 
     let mut required_price = prompt.price_stroops;
     if let Some(code) = voucher {
@@ -1673,13 +1763,10 @@ fn execute_buy_with_required_price(
     );
 
     // All funds are held in the contract.  No distribution occurs
-    // here — `settle_purchase` (admin) releases them to the creator,
-    // fee wallet, referrer, and split recipients, or a dispute
-    // refund returns them to the buyer.
-    prompt.sales_count = prompt
-        .sales_count
-        .checked_add(1)
-        .ok_or(Error::ArithmeticOverflow)?;
+    // here — `settle_purchase` releases them to the creator, fee wallet,
+    // referrer, and split recipients, or a dispute refund returns them
+    // to the buyer.
+    prompt.sales_count = reserved_sales_count;
     Storage::update_prompt(env, &prompt);
     Storage::grant_purchase(
         env,
@@ -1733,6 +1820,9 @@ fn execute_buy_with_required_price(
         status: SettlementStatus::Pending,
         created_at: now,
         settled_at: 0,
+        dispute_deadline: now
+            .checked_add(DISPUTE_WINDOW_SECS)
+            .ok_or(Error::ArithmeticOverflow)?,
         creator_amount,
         fee_amount,
         referral_amount,
@@ -1761,6 +1851,31 @@ fn execute_buy_with_required_price(
     }
 
     Ok(())
+}
+
+// ─── Supply accounting ─────────────────────────────────────────────────────
+//
+// Every acquisition path that grants a new unit of access (direct purchase,
+// bulk purchase, lease, bundle) must reserve supply through these helpers so
+// `max_supply` means the same thing everywhere (#538). Resale
+// (`transfer_license`) intentionally does not call these — it moves an
+// already-reserved unit between owners rather than minting a new one.
+
+/// Atomically check-and-reserve one unit of a prompt's capped supply.
+/// `max_supply == 0` means unlimited.
+fn reserve_supply(sales_count: u64, max_supply: u64) -> Result<u64, Error> {
+    if max_supply > 0 {
+        ensure(sales_count < max_supply, Error::MaxSupplyReached)?;
+    }
+    sales_count.checked_add(1).ok_or(Error::ArithmeticOverflow)
+}
+
+/// Same as [`reserve_supply`] for access passes, whose counters are `u32`.
+fn reserve_pass_supply(sales_count: u32, max_supply: u32) -> Result<u32, Error> {
+    if max_supply > 0 {
+        ensure(sales_count < max_supply, Error::MaxSupplyReached)?;
+    }
+    sales_count.checked_add(1).ok_or(Error::ArithmeticOverflow)
 }
 
 // ─── Validation helpers ───────────────────────────────────────────────────────
@@ -1886,3 +2001,10 @@ fn validate_len(value: &String, max_len: u32, error: Error) -> Result<(), Error>
     ensure(!value.is_empty() && value.len() <= max_len, error)
 }
 
+fn ensure(condition: bool, error: Error) -> Result<(), Error> {
+    if condition {
+        Ok(())
+    } else {
+        Err(error)
+    }
+}

--- a/contracts/prompt-hash/src/contract.rs
+++ b/contracts/prompt-hash/src/contract.rs
@@ -5,7 +5,7 @@ use super::types::{
     ListingConfig, ListingRevisionRecord, Prompt, PromptHashTrait, PromptSaleStatus,
     PurchaseDispute, PurchaseEscrow, SettlementStatus, SignedDiscountAuthorization, Split,
 };
-use soroban_sdk::{contract, contractimpl, crypto::Crypto, token, Address, Bytes, BytesN, Env, String, Vec};
+use soroban_sdk::{contract, contractimpl, token, Address, Bytes, BytesN, Env, String, Vec};
 use stellar_access::ownable::{self as ownable, Ownable};
 use stellar_macros::only_owner;
 
@@ -248,7 +248,7 @@ impl PromptHashTrait for PromptHashContract {
         let now = env.ledger().sequence();
 
         // 1. Verify domain separation (network_id + contract_id)
-        let contract_id = env.current_contract_id();
+        let contract_id = current_contract_id_hash(&env);
         let network_id = env.ledger().network_id();
         ensure(
             authorization.network_id == network_id,
@@ -277,25 +277,25 @@ impl PromptHashTrait for PromptHashContract {
             Error::AuthorizationExpired,
         )?;
 
-        // 5. Verify nonce not yet consumed (replay protection)
-        let nonce_hash = env.crypto().sha256(&authorization.nonce.to_xdr(&env));
-        ensure(
-            !Storage::is_nonce_consumed(&env, prompt_id, &nonce_hash),
-            Error::AuthorizationNonceConsumed,
-        )?;
+        // 5. Verify the creator registered this exact authorization on-chain
+        // (`add_signed_discount_auth`, gated by `creator.require_auth()`) and
+        // it has not already been redeemed or revoked. Soroban's SDK
+        // explicitly discourages deriving a raw Ed25519 key from an Address
+        // for custom signature verification (the master key may not be a
+        // current signer), so registration is authenticated via the
+        // contract's native auth framework instead of `ed25519_verify`.
+        let registration_key =
+            DataKey::NonceConsumed(prompt_id, authorization.nonce.clone());
+        let stored: SignedDiscountAuthorization = env
+            .storage()
+            .persistent()
+            .get(&registration_key)
+            .ok_or(Error::AuthorizationNonceConsumed)?;
+        ensure(stored == authorization, Error::InvalidAuthorizationSignature)?;
 
-        // 6. Verify creator signature
-        let auth_hash = authorization.hash(&env);
-        let creator_pub_key = prompt.creator.clone();
-        let valid_sig = env.crypto().ed25519_verify(
-            &creator_pub_key,
-            &auth_hash,
-            &creator_sig,
-        );
-        ensure(valid_sig, Error::InvalidAuthorizationSignature)?;
-
-        // 7. Consume the nonce atomically
-        Storage::try_consume_nonce(&env, prompt_id, &nonce_hash);
+        // 6. Consume the nonce atomically so it cannot be redeemed twice.
+        env.storage().persistent().remove(&registration_key);
+        let _ = creator_sig;
 
         // 8. Execute buy with discount
         let discount_amount = prompt
@@ -680,6 +680,8 @@ impl PromptHashTrait for PromptHashContract {
             status: SettlementStatus::Settled,
             created_at: now,
             settled_at: now,
+            // Bundle funds settle immediately — there is no pending window (#541).
+            dispute_deadline: now,
             creator_amount,
             fee_amount,
             referral_amount: 0,
@@ -1106,7 +1108,7 @@ impl PromptHashTrait for PromptHashContract {
         
         let next_cursor = if !prompts.is_empty() {
             let last_id = prompts.last().ok_or(Error::PromptNotFound)?.id;
-            Some(encode_cursor(last_id, IndexType::All).to_string())
+            Some(encode_cursor(&env, last_id, IndexType::All))
         } else {
             None
         };
@@ -1114,7 +1116,7 @@ impl PromptHashTrait for PromptHashContract {
         Ok((prompts, next_cursor))
     }
 
-    fn get_prompts_by_category_paginated(
+    fn get_prompts_by_category_page(
         env: Env,
         category: String,
         cursor: Option<String>,
@@ -1136,7 +1138,7 @@ impl PromptHashTrait for PromptHashContract {
         
         let next_cursor = if !prompts.is_empty() {
             let last_id = prompts.last().ok_or(Error::PromptNotFound)?.id;
-            Some(encode_cursor(last_id, IndexType::Category).to_string())
+            Some(encode_cursor(&env, last_id, IndexType::Category))
         } else {
             None
         };
@@ -1166,7 +1168,7 @@ impl PromptHashTrait for PromptHashContract {
         
         let next_cursor = if !prompts.is_empty() {
             let last_id = prompts.last().ok_or(Error::PromptNotFound)?.id;
-            Some(encode_cursor(last_id, IndexType::Tag).to_string())
+            Some(encode_cursor(&env, last_id, IndexType::Tag))
         } else {
             None
         };
@@ -1193,7 +1195,7 @@ impl PromptHashTrait for PromptHashContract {
         
         let next_cursor = if !prompts.is_empty() {
             let last_id = prompts.last().ok_or(Error::PromptNotFound)?.id;
-            Some(encode_cursor(last_id, IndexType::Active).to_string())
+            Some(encode_cursor(&env, last_id, IndexType::Active))
         } else {
             None
         };
@@ -1507,7 +1509,7 @@ impl PromptHashTrait for PromptHashContract {
         ensure(prompt.creator == creator, Error::Unauthorized)?;
 
         // Verify domain separation
-        let contract_id = env.current_contract_id();
+        let contract_id = current_contract_id_hash(&env);
         let network_id = env.ledger().network_id();
         ensure(
             authorization.network_id == network_id,
@@ -1525,23 +1527,27 @@ impl PromptHashTrait for PromptHashContract {
             Error::AuthorizationExpired,
         )?;
 
-        // Verify nonce not already consumed (in case of re-submission)
-        let nonce_hash = env.crypto().sha256(&authorization.nonce.to_xdr(&env));
+        // Verify nonce not already registered (in case of re-submission)
+        let registration_key =
+            DataKey::NonceConsumed(authorization.prompt_id, authorization.nonce.clone());
         ensure(
-            !Storage::is_nonce_consumed(&env, authorization.prompt_id, &nonce_hash),
+            !env.storage().persistent().has(&registration_key),
             Error::AuthorizationNonceConsumed,
         )?;
 
-        // Verify the signature is valid from the creator
-        let auth_hash = authorization.hash(&env);
-        let valid_sig = env.crypto().ed25519_verify(&creator, &auth_hash, &signature);
-        ensure(valid_sig, Error::InvalidAuthorizationSignature)?;
+        // `creator.require_auth()` above is the actual authentication for
+        // this registration. Soroban's SDK explicitly discourages deriving
+        // a raw Ed25519 key from an Address for custom signature
+        // verification (the master key may not be a current signer), so
+        // `signature` is accepted for client-side record-keeping parity
+        // with `buy_prompt_with_auth` but is not independently re-verified.
+        let _ = signature;
 
-        // Store the authorization for later verification during buy_prompt_with_auth
-        env.storage().persistent().set(
-            &DataKey::NonceConsumed(authorization.prompt_id, nonce_hash),
-            &authorization,
-        );
+        // Store the authorization for later redemption during buy_prompt_with_auth
+        env.storage()
+            .persistent()
+            .set(&registration_key, &authorization);
+        Storage::extend_key_ttl(&env, &registration_key);
 
         Events::emit_signed_discount_added(
             &env,
@@ -1563,11 +1569,10 @@ impl PromptHashTrait for PromptHashContract {
         let prompt = Storage::require_prompt(&env, prompt_id)?;
         ensure(prompt.creator == creator, Error::Unauthorized)?;
 
-        // Consume the nonce to prevent future use
-        let nonce_hash = env.crypto().sha256(&nonce.to_xdr(&env));
-        env.storage()
-            .persistent()
-            .set(&DataKey::NonceConsumed(prompt_id, nonce_hash), &true);
+        // Remove the registered authorization (if any) so it can no longer
+        // be redeemed via `buy_prompt_with_auth`.
+        let registration_key = DataKey::NonceConsumed(prompt_id, nonce.clone());
+        env.storage().persistent().remove(&registration_key);
 
         Events::emit_signed_discount_revoked(&env, prompt_id, creator, nonce);
         Ok(())
@@ -1641,7 +1646,7 @@ fn execute_buy(
     payment_amount_stroops: i128,
     voucher: Option<Bytes>,
 ) -> Result<(), Error> {
-    let mut prompt = Storage::require_prompt(env, prompt_id)?;
+    let prompt = Storage::require_prompt(env, prompt_id)?;
     let now = env.ledger().timestamp();
 
     ensure(prompt.status == PromptSaleStatus::Active, Error::PromptInactive)?;
@@ -1655,7 +1660,11 @@ fn execute_buy(
         ensure(prompt.expires_at >= now, Error::ListingExpired)?;
     }
 
-    let reserved_sales_count = reserve_supply(prompt.sales_count, prompt.max_supply)?;
+    // Fail fast before spending gas on voucher validation; the actual
+    // reservation is (re)computed against a fresh fetch in
+    // `execute_buy_with_required_price`, which is also reachable directly
+    // from `buy_prompt_with_auth`.
+    reserve_supply(prompt.sales_count, prompt.max_supply)?;
 
     let mut required_price = prompt.price_stroops;
     if let Some(code) = voucher {
@@ -1702,6 +1711,7 @@ fn execute_buy_with_required_price(
     required_price: i128,
 ) -> Result<(), Error> {
     let mut prompt = Storage::require_prompt(env, prompt_id)?;
+    let reserved_sales_count = reserve_supply(prompt.sales_count, prompt.max_supply)?;
 
     InstanceStorage::set_reentrancy_guard(env)?;
 
@@ -2007,4 +2017,14 @@ fn ensure(condition: bool, error: Error) -> Result<(), Error> {
     } else {
         Err(error)
     }
+}
+
+/// A stable per-contract domain-separation value for signed authorizations
+/// (#540/#565). There is no plain-build API for a contract's raw identity
+/// hash, so this hashes the current contract address's string encoding —
+/// available without enabling the SDK's `hazmat-address` feature.
+fn current_contract_id_hash(env: &Env) -> BytesN<32> {
+    env.crypto()
+        .sha256(&env.current_contract_address().to_string().to_bytes())
+        .to_bytes()
 }

--- a/contracts/prompt-hash/src/contract.rs
+++ b/contracts/prompt-hash/src/contract.rs
@@ -141,7 +141,10 @@ impl PromptHashTrait for PromptHashContract {
         let mut prompt = Storage::require_prompt(&env, prompt_id)?;
         ensure(prompt.creator == creator, Error::Unauthorized)?;
 
-        ensure(prompt.status != PromptSaleStatus::Retired, Error::InvalidStatusTransition)?;
+        ensure(
+            prompt.status != PromptSaleStatus::Retired,
+            Error::InvalidStatusTransition,
+        )?;
         ensure(prompt.status != status, Error::InvalidStatusTransition)?;
 
         prompt.status = status.clone();
@@ -162,7 +165,10 @@ impl PromptHashTrait for PromptHashContract {
         ensure(owner == admin, Error::Unauthorized)?;
 
         let mut prompt = Storage::require_prompt(&env, prompt_id)?;
-        ensure(prompt.status != PromptSaleStatus::Retired, Error::InvalidStatusTransition)?;
+        ensure(
+            prompt.status != PromptSaleStatus::Retired,
+            Error::InvalidStatusTransition,
+        )?;
         ensure(prompt.status != status, Error::InvalidStatusTransition)?;
 
         prompt.status = status.clone();
@@ -284,14 +290,16 @@ impl PromptHashTrait for PromptHashContract {
         // for custom signature verification (the master key may not be a
         // current signer), so registration is authenticated via the
         // contract's native auth framework instead of `ed25519_verify`.
-        let registration_key =
-            DataKey::NonceConsumed(prompt_id, authorization.nonce.clone());
+        let registration_key = DataKey::NonceConsumed(prompt_id, authorization.nonce.clone());
         let stored: SignedDiscountAuthorization = env
             .storage()
             .persistent()
             .get(&registration_key)
             .ok_or(Error::AuthorizationNonceConsumed)?;
-        ensure(stored == authorization, Error::InvalidAuthorizationSignature)?;
+        ensure(
+            stored == authorization,
+            Error::InvalidAuthorizationSignature,
+        )?;
 
         // 6. Consume the nonce atomically so it cannot be redeemed twice.
         env.storage().persistent().remove(&registration_key);
@@ -338,7 +346,10 @@ impl PromptHashTrait for PromptHashContract {
         let mut prompt = Storage::require_prompt(&env, prompt_id)?;
         let now = env.ledger().timestamp();
 
-        ensure(prompt.status == PromptSaleStatus::Active, Error::PromptInactive)?;
+        ensure(
+            prompt.status == PromptSaleStatus::Active,
+            Error::PromptInactive,
+        )?;
         ensure(prompt.creator != buyer, Error::CreatorCannotBuy)?;
         ensure(lease_duration_secs > 0, Error::InvalidPrice)?;
         ensure(
@@ -498,7 +509,10 @@ impl PromptHashTrait for PromptHashContract {
         for index in 0..prompt_ids.len() {
             let prompt = Storage::require_prompt(&env, prompt_ids.get(index).unwrap())?;
             ensure(prompt.creator == creator, Error::Unauthorized)?;
-            ensure(prompt.status == PromptSaleStatus::Active, Error::PromptInactive)?;
+            ensure(
+                prompt.status == PromptSaleStatus::Active,
+                Error::PromptInactive,
+            )?;
             ensure(prompt.asset == asset, Error::InvalidAsset)?;
             if prompt.expires_at != 0 {
                 ensure(prompt.expires_at >= now, Error::ListingExpired)?;
@@ -556,7 +570,10 @@ impl PromptHashTrait for PromptHashContract {
         for index in 0..bundle.prompt_ids.len() {
             let mut prompt = Storage::require_prompt(&env, bundle.prompt_ids.get(index).unwrap())?;
             ensure(prompt.creator == bundle.creator, Error::Unauthorized)?;
-            ensure(prompt.status == PromptSaleStatus::Active, Error::PromptInactive)?;
+            ensure(
+                prompt.status == PromptSaleStatus::Active,
+                Error::PromptInactive,
+            )?;
             ensure(prompt.asset == bundle.asset, Error::InvalidAsset)?;
             if prompt.expires_at != 0 {
                 ensure(prompt.expires_at >= now, Error::ListingExpired)?;
@@ -811,7 +828,8 @@ impl PromptHashTrait for PromptHashContract {
 
         // Each purchase reserves one unit of this pass's own supply, on top
         // of whatever other passes this creator has sold (#538).
-        access_pass.sales_count = reserve_pass_supply(access_pass.sales_count, access_pass.max_supply)?;
+        access_pass.sales_count =
+            reserve_pass_supply(access_pass.sales_count, access_pass.max_supply)?;
 
         InstanceStorage::set_reentrancy_guard(&env)?;
 
@@ -855,7 +873,13 @@ impl PromptHashTrait for PromptHashContract {
         // period (#539).
         let existing = Storage::get_catalog_pass_purchase(&env, &access_pass.creator, &buyer);
         let base = existing
-            .map(|p| if p.expires_at > now { p.expires_at } else { now })
+            .map(|p| {
+                if p.expires_at > now {
+                    p.expires_at
+                } else {
+                    now
+                }
+            })
             .unwrap_or(now);
         let expires_at = base
             .checked_add(access_pass.duration_secs)
@@ -1105,7 +1129,7 @@ impl PromptHashTrait for PromptHashContract {
 
         let key = crate::types::DataKey::AllPrompts;
         let prompts = Storage::get_prompts_paginated(&env, &key, cursor_id, limit);
-        
+
         let next_cursor = if !prompts.is_empty() {
             let last_id = prompts.last().ok_or(Error::PromptNotFound)?.id;
             Some(encode_cursor(&env, last_id, IndexType::All))
@@ -1135,7 +1159,7 @@ impl PromptHashTrait for PromptHashContract {
 
         let key = crate::types::DataKey::CategoryPrompts(category);
         let prompts = Storage::get_prompts_paginated(&env, &key, cursor_id, limit);
-        
+
         let next_cursor = if !prompts.is_empty() {
             let last_id = prompts.last().ok_or(Error::PromptNotFound)?.id;
             Some(encode_cursor(&env, last_id, IndexType::Category))
@@ -1165,7 +1189,7 @@ impl PromptHashTrait for PromptHashContract {
 
         let key = crate::types::DataKey::TagPrompts(tag);
         let prompts = Storage::get_prompts_paginated(&env, &key, cursor_id, limit);
-        
+
         let next_cursor = if !prompts.is_empty() {
             let last_id = prompts.last().ok_or(Error::PromptNotFound)?.id;
             Some(encode_cursor(&env, last_id, IndexType::Tag))
@@ -1192,7 +1216,7 @@ impl PromptHashTrait for PromptHashContract {
 
         let key = crate::types::DataKey::ActivePrompts;
         let prompts = Storage::get_prompts_paginated(&env, &key, cursor_id, limit);
-        
+
         let next_cursor = if !prompts.is_empty() {
             let last_id = prompts.last().ok_or(Error::PromptNotFound)?.id;
             Some(encode_cursor(&env, last_id, IndexType::Active))
@@ -1328,7 +1352,10 @@ impl PromptHashTrait for PromptHashContract {
         let prompt = Storage::require_prompt(&env, prompt_id)?;
 
         let mut escrow = Storage::require_purchase_escrow(&env, prompt_id, &buyer)?;
-        ensure(escrow.status == SettlementStatus::Pending, Error::DisputeResolved)?;
+        ensure(
+            escrow.status == SettlementStatus::Pending,
+            Error::DisputeResolved,
+        )?;
 
         // An open dispute must be resolved via `resolve_dispute`, not
         // settled — this holds even for the admin/creator fast path (#541).
@@ -1346,7 +1373,10 @@ impl PromptHashTrait for PromptHashContract {
             // with no open dispute, anyone may finalize the escrow — this
             // guarantees a bounded path to Released even if the admin or
             // creator never act (#541).
-            ensure(now > escrow.dispute_deadline, Error::DisputeWindowNotElapsed)?;
+            ensure(
+                now > escrow.dispute_deadline,
+                Error::DisputeWindowNotElapsed,
+            )?;
         }
 
         let this_contract = env.current_contract_address();
@@ -1398,11 +1428,7 @@ impl PromptHashTrait for PromptHashContract {
         Storage::require_dispute(&env, prompt_id, &buyer)
     }
 
-    fn get_purchase_escrow(
-        env: Env,
-        prompt_id: u64,
-        buyer: Address,
-    ) -> Option<PurchaseEscrow> {
+    fn get_purchase_escrow(env: Env, prompt_id: u64, buyer: Address) -> Option<PurchaseEscrow> {
         Storage::get_purchase_escrow(&env, prompt_id, &buyer)
     }
 
@@ -1649,7 +1675,10 @@ fn execute_buy(
     let prompt = Storage::require_prompt(env, prompt_id)?;
     let now = env.ledger().timestamp();
 
-    ensure(prompt.status == PromptSaleStatus::Active, Error::PromptInactive)?;
+    ensure(
+        prompt.status == PromptSaleStatus::Active,
+        Error::PromptInactive,
+    )?;
     ensure(prompt.creator != *buyer, Error::CreatorCannotBuy)?;
     ensure(
         !Storage::has_active_purchase(env, prompt_id, buyer, now),
@@ -1696,7 +1725,14 @@ fn execute_buy(
         )?;
     }
 
-    execute_buy_with_required_price(env, buyer, prompt_id, referrer, payment_amount_stroops, required_price)
+    execute_buy_with_required_price(
+        env,
+        buyer,
+        prompt_id,
+        referrer,
+        payment_amount_stroops,
+        required_price,
+    )
 }
 
 /// Buy execution after all price and voucher validation is done.

--- a/contracts/prompt-hash/src/events.rs
+++ b/contracts/prompt-hash/src/events.rs
@@ -250,7 +250,12 @@ impl Events {
         PromptSaleStatusUpdated { prompt_id, status }.publish(env);
     }
 
-    pub fn emit_prompt_admin_moderated(env: &Env, prompt_id: u64, admin: Address, status: PromptSaleStatus) {
+    pub fn emit_prompt_admin_moderated(
+        env: &Env,
+        prompt_id: u64,
+        admin: Address,
+        status: PromptSaleStatus,
+    ) {
         PromptAdminModerated {
             prompt_id,
             admin,
@@ -357,12 +362,7 @@ impl Events {
         .publish(env);
     }
 
-    pub fn emit_discount_applied(
-        env: &Env,
-        prompt_id: u64,
-        buyer: Address,
-        discount_bps: u32,
-    ) {
+    pub fn emit_discount_applied(env: &Env, prompt_id: u64, buyer: Address, discount_bps: u32) {
         DiscountApplied {
             prompt_id,
             buyer,

--- a/contracts/prompt-hash/src/events.rs
+++ b/contracts/prompt-hash/src/events.rs
@@ -206,6 +206,27 @@ struct AccessPassPurchased {
     pub expires_at: u64,
 }
 
+#[contractevent]
+struct AccessPassStatusUpdated {
+    #[topic]
+    pub pass_id: u128,
+    pub status: PromptSaleStatus,
+}
+
+#[contractevent]
+struct AccessPassPriceUpdated {
+    #[topic]
+    pub pass_id: u128,
+    pub price_stroops: i128,
+}
+
+#[contractevent]
+struct PromptMaxSupplyUpdated {
+    #[topic]
+    pub prompt_id: u64,
+    pub max_supply: u64,
+}
+
 pub struct Events;
 
 impl Events {
@@ -226,21 +247,16 @@ impl Events {
     }
 
     pub fn emit_prompt_sale_status_updated(env: &Env, prompt_id: u64, status: PromptSaleStatus) {
-        env.events().publish(
-            (soroban_sdk::symbol_short!("STATUS"), prompt_id),
-            PromptSaleStatusUpdated { prompt_id, status },
-        );
+        PromptSaleStatusUpdated { prompt_id, status }.publish(env);
     }
 
     pub fn emit_prompt_admin_moderated(env: &Env, prompt_id: u64, admin: Address, status: PromptSaleStatus) {
-        env.events().publish(
-            (soroban_sdk::symbol_short!("MODERATED"), prompt_id),
-            PromptAdminModerated {
-                prompt_id,
-                admin,
-                status,
-            },
-        );
+        PromptAdminModerated {
+            prompt_id,
+            admin,
+            status,
+        }
+        .publish(env);
     }
 
     pub fn emit_prompt_price_updated(env: &Env, prompt_id: u64, price_stroops: i128) {
@@ -473,6 +489,26 @@ impl Events {
             buyer,
             creator,
             expires_at,
+        }
+        .publish(env);
+    }
+
+    pub fn emit_access_pass_status_updated(env: &Env, pass_id: u128, status: PromptSaleStatus) {
+        AccessPassStatusUpdated { pass_id, status }.publish(env);
+    }
+
+    pub fn emit_access_pass_price_updated(env: &Env, pass_id: u128, price_stroops: i128) {
+        AccessPassPriceUpdated {
+            pass_id,
+            price_stroops,
+        }
+        .publish(env);
+    }
+
+    pub fn emit_prompt_max_supply_updated(env: &Env, prompt_id: u64, max_supply: u64) {
+        PromptMaxSupplyUpdated {
+            prompt_id,
+            max_supply,
         }
         .publish(env);
     }

--- a/contracts/prompt-hash/src/lib.rs
+++ b/contracts/prompt-hash/src/lib.rs
@@ -12,6 +12,9 @@ mod ttl_policy;
 mod ttl_test;
 mod types;
 
+#[cfg(test)]
+mod mock_asset;
+
 pub use contract::PromptHashContract;
 pub use types::{DataKey, Error, Prompt};
 

--- a/contracts/prompt-hash/src/lib.rs
+++ b/contracts/prompt-hash/src/lib.rs
@@ -17,4 +17,3 @@ mod mock_asset;
 
 pub use contract::PromptHashContract;
 pub use types::{DataKey, Error, Prompt};
-

--- a/contracts/prompt-hash/src/mock_asset.rs
+++ b/contracts/prompt-hash/src/mock_asset.rs
@@ -1,6 +1,5 @@
-use soroban_sdk::{contract, contractimpl, Address, Env, String};
+use soroban_sdk::{contract, contractimpl, Address, Env, MuxedAddress, String};
 use stellar_access::ownable::{self as ownable, Ownable};
-use stellar_macros::default_impl;
 use stellar_tokens::fungible::{Base, FungibleToken};
 
 #[contract]
@@ -27,12 +26,10 @@ impl FungibleTokenContract {
     }
 }
 
-#[default_impl]
-#[contractimpl]
+#[contractimpl(contracttrait)]
 impl FungibleToken for FungibleTokenContract {
     type ContractType = Base;
 }
 
-#[default_impl]
-#[contractimpl]
+#[contractimpl(contracttrait)]
 impl Ownable for FungibleTokenContract {}

--- a/contracts/prompt-hash/src/pagination.rs
+++ b/contracts/prompt-hash/src/pagination.rs
@@ -1,7 +1,8 @@
 // Cursor pagination for bounded catalog queries.
 // Prevents full-catalog scans and respects Soroban resource limits.
 
-use soroban_sdk::{Env, Vec, String as SorobanString};
+use crate::types::Error;
+use soroban_sdk::{Env, String as SorobanString};
 
 pub const MAX_PAGE_SIZE: u64 = 50;
 
@@ -33,8 +34,14 @@ impl IndexType {
     }
 }
 
-/// Encode cursor to base64 string for API transmission
-pub fn encode_cursor(last_id: u64, index_type: IndexType) -> SorobanString {
+// Cursors are opaque to callers: 8 bytes of big-endian `last_id` followed by
+// a 1-byte index-type discriminant. `soroban_sdk::String` has no std-only
+// parsing available inside the contract runtime (only under testutils), so
+// the cursor is carried as raw bytes rather than a human-readable string.
+const CURSOR_LEN: usize = 9;
+
+/// Encode a cursor for API transmission.
+pub fn encode_cursor(env: &Env, last_id: u64, index_type: IndexType) -> SorobanString {
     let type_num = match index_type {
         IndexType::Creator => 0u8,
         IndexType::Category => 1u8,
@@ -42,30 +49,25 @@ pub fn encode_cursor(last_id: u64, index_type: IndexType) -> SorobanString {
         IndexType::Active => 3u8,
         IndexType::All => 4u8,
     };
-    // Simple encoding: "id:type" (e.g., "12345:0")
-    // In production, use proper base64, but this is readable for testing
-    format!("{}:{}", last_id, type_num).into()
+    let mut bytes = [0u8; CURSOR_LEN];
+    bytes[0..8].copy_from_slice(&last_id.to_be_bytes());
+    bytes[8] = type_num;
+    SorobanString::from_bytes(env, &bytes)
 }
 
-/// Decode cursor from base64 string
-pub fn decode_cursor(env: &Env, cursor: &SorobanString) -> Result<Cursor, crate::error::Error> {
-    use crate::error::Error;
-    let s = cursor.to_string();
-    let parts: Vec<&str> = s.split(':').collect();
-    if parts.len() != 2 {
+/// Decode a cursor previously produced by [`encode_cursor`].
+pub fn decode_cursor(_env: &Env, cursor: &SorobanString) -> Result<Cursor, Error> {
+    if cursor.len() as usize != CURSOR_LEN {
         return Err(Error::InvalidCursor);
     }
 
-    let last_id = parts[0].parse::<u64>().map_err(|_| Error::InvalidCursor)?;
-    let type_num = parts[1].parse::<u8>().map_err(|_| Error::InvalidCursor)?;
-    let index_type = IndexType::from_u8(type_num).ok_or(Error::InvalidCursor)?;
+    let mut buf = [0u8; CURSOR_LEN];
+    cursor.copy_into_slice(&mut buf);
+
+    let mut id_bytes = [0u8; 8];
+    id_bytes.copy_from_slice(&buf[0..8]);
+    let last_id = u64::from_be_bytes(id_bytes);
+    let index_type = IndexType::from_u8(buf[8]).ok_or(Error::InvalidCursor)?;
 
     Ok(Cursor { last_id, index_type })
 }
-
-/// Paginated result with cursor for next page
-pub struct PageResult<T> {
-    pub items: Vec<T>,
-    pub next_cursor: Option<SorobanString>, // None if end of results
-}
-

--- a/contracts/prompt-hash/src/pagination.rs
+++ b/contracts/prompt-hash/src/pagination.rs
@@ -69,5 +69,8 @@ pub fn decode_cursor(_env: &Env, cursor: &SorobanString) -> Result<Cursor, Error
     let last_id = u64::from_be_bytes(id_bytes);
     let index_type = IndexType::from_u8(buf[8]).ok_or(Error::InvalidCursor)?;
 
-    Ok(Cursor { last_id, index_type })
+    Ok(Cursor {
+        last_id,
+        index_type,
+    })
 }

--- a/contracts/prompt-hash/src/pagination_test.rs
+++ b/contracts/prompt-hash/src/pagination_test.rs
@@ -1,12 +1,13 @@
 #[cfg(test)]
 mod tests {
     use crate::pagination::{decode_cursor, encode_cursor, IndexType};
-    use soroban_sdk::String as SorobanString;
+    use soroban_sdk::Env;
 
     #[test]
-    fn test_encode_decode_cursor() {
+    fn test_encode_decode_cursor_round_trips_for_every_index_type() {
+        let env = Env::default();
         let id = 12345u64;
-        let types = vec![
+        let types = [
             IndexType::Creator,
             IndexType::Category,
             IndexType::Tag,
@@ -15,18 +16,20 @@ mod tests {
         ];
 
         for index_type in types {
-            let encoded = encode_cursor(id, index_type.clone());
-            // In production use real env, but for unit tests we skip decoding
-            assert!(!encoded.to_string().is_empty());
+            let encoded = encode_cursor(&env, id, index_type.clone());
+            let decoded = decode_cursor(&env, &encoded).unwrap();
+            assert_eq!(decoded.last_id, id);
+            assert!(decoded.index_type == index_type);
         }
     }
 
     #[test]
-    fn test_cursor_format() {
+    fn test_cursor_round_trips_last_id_and_type() {
+        let env = Env::default();
         let id = 999u64;
-        let cursor = encode_cursor(id, IndexType::Category);
-        let cursor_str = cursor.to_string();
-        assert!(cursor_str.contains("999"));
-        assert!(cursor_str.contains("1")); // Category type num
+        let cursor = encode_cursor(&env, id, IndexType::Category);
+        let decoded = decode_cursor(&env, &cursor).unwrap();
+        assert_eq!(decoded.last_id, 999);
+        assert!(decoded.index_type == IndexType::Category);
     }
 }

--- a/contracts/prompt-hash/src/storage.rs
+++ b/contracts/prompt-hash/src/storage.rs
@@ -549,6 +549,19 @@ impl Storage {
         Self::extend_key_ttl(env, &key);
     }
 
+    pub fn get_catalog_pass_purchase(
+        env: &Env,
+        creator: &Address,
+        buyer: &Address,
+    ) -> Option<CatalogPassPurchase> {
+        let key = DataKey::CatalogPass(creator.clone(), buyer.clone());
+        let purchase = env.storage().persistent().get(&key);
+        if env.storage().persistent().has(&key) {
+            Self::extend_key_ttl(env, &key);
+        }
+        purchase
+    }
+
     pub fn has_active_creator_pass(
         env: &Env,
         creator: &Address,

--- a/contracts/prompt-hash/src/storage.rs
+++ b/contracts/prompt-hash/src/storage.rs
@@ -731,7 +731,7 @@ impl Storage {
             .get(&key)
             .unwrap_or(Vec::new(env));
 
-        if !ids.contains(&prompt.id) {
+        if !ids.contains(prompt.id) {
             ids.push_back(prompt.id);
             env.storage().persistent().set(&key, &ids);
             Self::extend_key_ttl(env, &key);
@@ -748,7 +748,7 @@ impl Storage {
                 .get(&key)
                 .unwrap_or(Vec::new(env));
 
-            if !ids.contains(&prompt.id) {
+            if !ids.contains(prompt.id) {
                 ids.push_back(prompt.id);
                 env.storage().persistent().set(&key, &ids);
                 Self::extend_key_ttl(env, &key);
@@ -765,7 +765,7 @@ impl Storage {
             .persistent()
             .get(&all_key)
             .unwrap_or(Vec::new(env));
-        if !all_ids.contains(&prompt.id) {
+        if !all_ids.contains(prompt.id) {
             all_ids.push_back(prompt.id);
             env.storage().persistent().set(&all_key, &all_ids);
             Self::extend_key_ttl(env, &all_key);
@@ -779,7 +779,7 @@ impl Storage {
                 .persistent()
                 .get(&active_key)
                 .unwrap_or(Vec::new(env));
-            if !active_ids.contains(&prompt.id) {
+            if !active_ids.contains(prompt.id) {
                 active_ids.push_back(prompt.id);
                 env.storage().persistent().set(&active_key, &active_ids);
                 Self::extend_key_ttl(env, &active_key);

--- a/contracts/prompt-hash/src/storage.rs
+++ b/contracts/prompt-hash/src/storage.rs
@@ -2,7 +2,7 @@ use super::types::{
     AccessPass, Bundle, CatalogPassPurchase, DataKey, Error, InstanceDataKey,
     ListingRevisionRecord, Prompt, Purchase, PurchaseDispute, PurchaseEscrow,
 };
-use soroban_sdk::{token, Address, BytesN, Env, Vec};
+use soroban_sdk::{token, Address, BytesN, Env, String, Vec};
 
 pub const DAY_IN_LEDGERS: u32 = 17280;
 pub const PERSISTENT_BUMP_AMOUNT: u32 = 30 * DAY_IN_LEDGERS;
@@ -691,7 +691,7 @@ impl Storage {
     ) -> Vec<Prompt> {
         use crate::pagination::MAX_PAGE_SIZE;
 
-        let limit = std::cmp::min(limit, MAX_PAGE_SIZE);
+        let limit = if limit < MAX_PAGE_SIZE { limit } else { MAX_PAGE_SIZE };
         let ids: Vec<u64> = env
             .storage()
             .persistent()
@@ -699,13 +699,13 @@ impl Storage {
             .unwrap_or(Vec::new(env));
 
         let mut results = Vec::new(env);
-        let mut start_idx = 0usize;
+        let mut start_idx = 0u32;
 
         // Find start position if cursor provided
         if let Some(cursor_id) = cursor {
             for (i, id) in ids.iter().enumerate() {
                 if id == cursor_id {
-                    start_idx = i + 1;
+                    start_idx = i as u32 + 1;
                     break;
                 }
             }
@@ -791,64 +791,58 @@ impl Storage {
 
     // ====== TTL RENEWAL (BOUNDED BATCHES) ======
 
-    /// Renew all critical keys (purchases, escrow) in a bounded batch
-    /// Returns (renewed_count, next_cursor_if_more_work)
+    /// Renew the TTL of prompt records (and their listing revisions/creator
+    /// index) in a bounded batch. Returns (renewed_count, next_cursor_if_more_work).
     pub fn renew_critical_keys(
         env: &Env,
         cursor: Option<u64>,
     ) -> (u32, Option<u64>) {
         use crate::ttl_policy::MAX_RENEWAL_BATCH_SIZE;
 
+        let prompt_count = InstanceStorage::get_prompt_counter(env);
         let mut renewed_count = 0u32;
-        let mut start_from = cursor.unwrap_or(0);
+        let mut prompt_id = cursor.unwrap_or(0);
 
-        // Simplified MVP: check fixed batch of purchase keys
-        // Full impl would iterate all persistent keys with proper pagination
-        for prompt_id in start_from..start_from + MAX_RENEWAL_BATCH_SIZE as u64 {
+        while prompt_id < prompt_count {
             if renewed_count >= MAX_RENEWAL_BATCH_SIZE {
                 return (renewed_count, Some(prompt_id));
             }
 
-            let key = DataKey::Purchase(prompt_id as u64, Address::from_contract_id(env));
+            let key = DataKey::Prompt(prompt_id);
             if env.storage().persistent().has(&key) {
                 Self::extend_key_ttl(env, &key);
                 renewed_count += 1;
             }
+            prompt_id += 1;
         }
 
         (renewed_count, None) // All done
     }
 
-    /// Get expiry risk metrics for operator monitoring
+    /// Get expiry risk metrics for operator monitoring, sampled across the
+    /// TTL policy's own reference lifetimes for each tracked key family.
     pub fn compute_expiry_risks(env: &Env) -> Vec<(String, String)> {
-        use crate::ttl_policy::{compute_expiry_risk, get_ttl_for_key};
+        use crate::ttl_policy::{compute_expiry_risk, ONE_MONTH, ONE_YEAR};
 
         let mut risks = Vec::new(env);
-        let current_ledger = env.ledger().sequence();
+        let current_ledger = env.ledger().sequence() as u64;
 
-        // Check sample critical keys
-        let sample_keys = vec![
-            (DataKey::Purchase(1, Address::from_contract_id(env)), "Purchase"),
-            (DataKey::PurchaseEscrow(1, Address::from_contract_id(env)), "Escrow"),
-            (DataKey::CatalogPass(Address::from_contract_id(env), Address::from_contract_id(env)), "CatalogPass"),
+        let sample_ttls: [(&str, u32); 3] = [
+            ("Prompt", ONE_YEAR),
+            ("Purchase", ONE_YEAR + ONE_MONTH),
+            ("Dispute", ONE_MONTH),
         ];
 
-        for (key, label) in sample_keys {
-            let max_ttl = get_ttl_for_key(&key);
-            if max_ttl == u32::MAX {
-                continue;
-            }
-
-            // Conservative: assume mid-lifetime for risk assessment
+        for (label, max_ttl) in sample_ttls {
+            // Conservative: assume mid-lifetime for risk assessment.
             let last_extended = current_ledger.saturating_sub(max_ttl as u64 / 2);
             let risk = compute_expiry_risk(current_ledger, last_extended, max_ttl);
 
             if risk.critical_keys > 0 || risk.imminent_keys > 0 {
-                let status = format!(
-                    "critical={},imminent={},atrisk={}",
-                    risk.critical_keys, risk.imminent_keys, risk.at_risk_keys
-                );
-                risks.push_back((label.into(), status));
+                risks.push_back((
+                    String::from_str(env, label),
+                    String::from_str(env, "at_risk"),
+                ));
             }
         }
 

--- a/contracts/prompt-hash/src/storage.rs
+++ b/contracts/prompt-hash/src/storage.rs
@@ -109,15 +109,11 @@ impl InstanceStorage {
     /// rather than silently using wrong defaults.
     pub fn require_config_initialized(env: &Env) -> Result<(), Error> {
         ensure(
-            env.storage()
-                .instance()
-                .has(&InstanceDataKey::FeeWallet),
+            env.storage().instance().has(&InstanceDataKey::FeeWallet),
             Error::FeeWalletNotSet,
         )?;
         ensure(
-            env.storage()
-                .instance()
-                .has(&InstanceDataKey::XlmAddress),
+            env.storage().instance().has(&InstanceDataKey::XlmAddress),
             Error::XlmAddressNotSet,
         )
     }
@@ -130,7 +126,7 @@ pub struct Storage;
 impl Storage {
     pub fn extend_key_ttl(env: &Env, key: &DataKey) {
         use crate::ttl_policy::get_ttl_for_key;
-        
+
         if !env.storage().persistent().has(key) {
             return;
         }
@@ -140,11 +136,9 @@ impl Storage {
             return; // Instance keys don't get TTL management
         }
 
-        env.storage().persistent().extend_ttl(
-            key,
-            PERSISTENT_LIFETIME_THRESHOLD,
-            max_ttl,
-        );
+        env.storage()
+            .persistent()
+            .extend_ttl(key, PERSISTENT_LIFETIME_THRESHOLD, max_ttl);
     }
 
     pub fn save_prompt(env: &Env, prompt: &Prompt) -> Result<(), Error> {
@@ -154,12 +148,12 @@ impl Storage {
 
         let next_prompt_id = prompt.id.checked_add(1).ok_or(Error::ArithmeticOverflow)?;
         InstanceStorage::save_prompt_counter(env, next_prompt_id);
-        
+
         // Update all indexes for pagination
         Self::update_category_index(env, prompt);
         Self::update_tag_index(env, prompt);
         Self::update_status_indexes(env, prompt);
-        
+
         Ok(())
     }
 
@@ -372,7 +366,11 @@ impl Storage {
         Self::extend_key_ttl(env, &key);
     }
 
-    pub fn get_purchase_escrow(env: &Env, prompt_id: u64, buyer: &Address) -> Option<PurchaseEscrow> {
+    pub fn get_purchase_escrow(
+        env: &Env,
+        prompt_id: u64,
+        buyer: &Address,
+    ) -> Option<PurchaseEscrow> {
         let key = DataKey::PurchaseEscrow(prompt_id, buyer.clone());
         let escrow = env.storage().persistent().get(&key);
         if env.storage().persistent().has(&key) {
@@ -691,12 +689,12 @@ impl Storage {
     ) -> Vec<Prompt> {
         use crate::pagination::MAX_PAGE_SIZE;
 
-        let limit = if limit < MAX_PAGE_SIZE { limit } else { MAX_PAGE_SIZE };
-        let ids: Vec<u64> = env
-            .storage()
-            .persistent()
-            .get(key)
-            .unwrap_or(Vec::new(env));
+        let limit = if limit < MAX_PAGE_SIZE {
+            limit
+        } else {
+            MAX_PAGE_SIZE
+        };
+        let ids: Vec<u64> = env.storage().persistent().get(key).unwrap_or(Vec::new(env));
 
         let mut results = Vec::new(env);
         let mut start_idx = 0u32;
@@ -793,10 +791,7 @@ impl Storage {
 
     /// Renew the TTL of prompt records (and their listing revisions/creator
     /// index) in a bounded batch. Returns (renewed_count, next_cursor_if_more_work).
-    pub fn renew_critical_keys(
-        env: &Env,
-        cursor: Option<u64>,
-    ) -> (u32, Option<u64>) {
+    pub fn renew_critical_keys(env: &Env, cursor: Option<u64>) -> (u32, Option<u64>) {
         use crate::ttl_policy::MAX_RENEWAL_BATCH_SIZE;
 
         let prompt_count = InstanceStorage::get_prompt_counter(env);

--- a/contracts/prompt-hash/src/test.rs
+++ b/contracts/prompt-hash/src/test.rs
@@ -2,9 +2,9 @@
 
 extern crate std;
 
+use crate::contract::{PromptHashContract, PromptHashContractClient};
 use crate::mock_asset::FungibleTokenContract;
 use crate::types::{Error, ListingConfig, PromptSaleStatus, Split};
-use crate::contract::{PromptHashContract, PromptHashContractClient};
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
     token, Address, Bytes, BytesN, Env, String, Vec,
@@ -37,7 +37,15 @@ fn setup(env: &Env) -> PromptHashContext {
     }
 }
 
-fn setup_env() -> (Env, Address, Address, Address, Address, Address, PromptHashContractClient<'static>) {
+fn setup_env() -> (
+    Env,
+    Address,
+    Address,
+    Address,
+    Address,
+    Address,
+    PromptHashContractClient<'static>,
+) {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -46,14 +54,24 @@ fn setup_env() -> (Env, Address, Address, Address, Address, Address, PromptHashC
     let creator = Address::generate(&env);
     let buyer = Address::generate(&env);
 
-    let token_contract = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let token_contract = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
     let contract_id = env.register(
         PromptHashContract,
         (admin.clone(), fee_wallet.clone(), token_contract.clone()),
     );
     let client = PromptHashContractClient::new(&env, &contract_id);
 
-    (env, admin, fee_wallet, creator, buyer, token_contract, client)
+    (
+        env,
+        admin,
+        fee_wallet,
+        creator,
+        buyer,
+        token_contract,
+        client,
+    )
 }
 
 fn hash(env: &Env, byte: u8) -> BytesN<32> {
@@ -181,10 +199,7 @@ fn test_create_prompt_stores_encrypted_fields() {
     let prompt = client.get_prompt(&prompt_id);
     assert_eq!(prompt.id, prompt_id);
     assert_eq!(prompt.creator, creator);
-    assert_eq!(
-        prompt.preview_text,
-        String::from_str(&env, "preview")
-    );
+    assert_eq!(prompt.preview_text, String::from_str(&env, "preview"));
     assert_eq!(
         prompt.encrypted_payload,
         String::from_str(&env, "encrypted")
@@ -884,11 +899,29 @@ fn test_multiple_buyers_until_supply_exhausted() {
     fund_buyer(&xlm_client, &buyer3, &context.contract, price);
 
     // Two buyers can purchase
-    client.buy_prompt(&buyer1, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
-    client.buy_prompt(&buyer2, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
+    client.buy_prompt(
+        &buyer1,
+        &prompt_id,
+        &None::<Address>,
+        &price,
+        &None::<Bytes>,
+    );
+    client.buy_prompt(
+        &buyer2,
+        &prompt_id,
+        &None::<Address>,
+        &price,
+        &None::<Bytes>,
+    );
 
     // Third buyer cannot
-    let result = client.try_buy_prompt(&buyer3, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
+    let result = client.try_buy_prompt(
+        &buyer3,
+        &prompt_id,
+        &None::<Address>,
+        &price,
+        &None::<Bytes>,
+    );
     assert_eq!(result, Err(Ok(Error::MaxSupplyReached)));
 }
 
@@ -3933,13 +3966,26 @@ fn test_payout_invariant_fee_plus_creator_equals_payment() {
     let buyer = Address::generate(&env);
     let payment: i128 = 100_000;
 
-    let prompt_id = create_prompt(&env, &client, &creator, "Invariant Test", payment, &context.xlm);
+    let prompt_id = create_prompt(
+        &env,
+        &client,
+        &creator,
+        "Invariant Test",
+        payment,
+        &context.xlm,
+    );
     fund_buyer(&xlm_client, &buyer, &context.contract, payment);
 
     let creator_balance_before = xlm_client.balance(&creator);
     let fee_wallet_balance_before = xlm_client.balance(&context.fee_wallet);
 
-    client.buy_prompt(&buyer, &prompt_id, &None::<Address>, &payment, &None::<Bytes>);
+    client.buy_prompt(
+        &buyer,
+        &prompt_id,
+        &None::<Address>,
+        &payment,
+        &None::<Bytes>,
+    );
 
     client.settle_purchase(&context.admin, &prompt_id, &buyer);
 
@@ -3969,7 +4015,14 @@ fn test_payout_invariant_with_referral() {
     let referrer = Address::generate(&env);
     let payment: i128 = 100_000;
 
-    let prompt_id = create_prompt(&env, &client, &creator, "Referral Test", payment, &context.xlm);
+    let prompt_id = create_prompt(
+        &env,
+        &client,
+        &creator,
+        "Referral Test",
+        payment,
+        &context.xlm,
+    );
     fund_buyer(&xlm_client, &buyer, &context.contract, payment);
 
     let creator_balance_before = xlm_client.balance(&creator);
@@ -4041,7 +4094,13 @@ fn test_payout_invariant_with_splits() {
     let split_1_balance_before = xlm_client.balance(&split_recipient_1);
     let split_2_balance_before = xlm_client.balance(&split_recipient_2);
 
-    client.buy_prompt(&buyer, &prompt_id, &None::<Address>, &payment, &None::<Bytes>);
+    client.buy_prompt(
+        &buyer,
+        &prompt_id,
+        &None::<Address>,
+        &payment,
+        &None::<Bytes>,
+    );
 
     client.settle_purchase(&context.admin, &prompt_id, &buyer);
 
@@ -4087,7 +4146,13 @@ fn test_payout_invariant_with_tip() {
     let creator_balance_before = xlm_client.balance(&creator);
     let fee_wallet_balance_before = xlm_client.balance(&context.fee_wallet);
 
-    client.buy_prompt(&buyer, &prompt_id, &None::<Address>, &payment, &None::<Bytes>);
+    client.buy_prompt(
+        &buyer,
+        &prompt_id,
+        &None::<Address>,
+        &payment,
+        &None::<Bytes>,
+    );
 
     client.settle_purchase(&context.admin, &prompt_id, &buyer);
 
@@ -4130,7 +4195,10 @@ fn test_lease_respects_max_supply() {
     let res = client.try_lease_prompt(&buyer_two, &prompt_id, &600);
     match res {
         Err(Ok(Error::MaxSupplyReached)) => {}
-        other => panic!("expected MaxSupplyReached for capped lease, got {:?}", other),
+        other => panic!(
+            "expected MaxSupplyReached for capped lease, got {:?}",
+            other
+        ),
     }
 }
 
@@ -4148,8 +4216,20 @@ fn test_set_max_supply_below_committed_sales_rejected() {
 
     fund_buyer(&xlm_client, &buyer_one, &context.contract, price);
     fund_buyer(&xlm_client, &buyer_two, &context.contract, price);
-    client.buy_prompt(&buyer_one, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
-    client.buy_prompt(&buyer_two, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
+    client.buy_prompt(
+        &buyer_one,
+        &prompt_id,
+        &None::<Address>,
+        &price,
+        &None::<Bytes>,
+    );
+    client.buy_prompt(
+        &buyer_two,
+        &prompt_id,
+        &None::<Address>,
+        &price,
+        &None::<Bytes>,
+    );
 
     let res = client.try_set_prompt_max_supply(&creator, &prompt_id, &1);
     match res {
@@ -4176,12 +4256,24 @@ fn test_dispute_refund_releases_supply_for_resale() {
     client.set_prompt_max_supply(&creator, &prompt_id, &1);
 
     fund_buyer(&xlm_client, &buyer_one, &context.contract, price);
-    client.buy_prompt(&buyer_one, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
+    client.buy_prompt(
+        &buyer_one,
+        &prompt_id,
+        &None::<Address>,
+        &price,
+        &None::<Bytes>,
+    );
     assert_eq!(client.get_prompt(&prompt_id).sales_count, 1);
 
     // At capacity: a second buyer cannot acquire the unit.
     fund_buyer(&xlm_client, &buyer_two, &context.contract, price);
-    let blocked = client.try_buy_prompt(&buyer_two, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
+    let blocked = client.try_buy_prompt(
+        &buyer_two,
+        &prompt_id,
+        &None::<Address>,
+        &price,
+        &None::<Bytes>,
+    );
     assert_eq!(blocked, Err(Ok(Error::MaxSupplyReached)));
 
     // Refunding the disputed purchase releases the reserved unit.
@@ -4194,7 +4286,13 @@ fn test_dispute_refund_releases_supply_for_resale() {
     assert_eq!(client.get_prompt(&prompt_id).sales_count, 0);
 
     // Now the second buyer can acquire the freed unit.
-    client.buy_prompt(&buyer_two, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
+    client.buy_prompt(
+        &buyer_two,
+        &prompt_id,
+        &None::<Address>,
+        &price,
+        &None::<Bytes>,
+    );
     assert_eq!(client.get_prompt(&prompt_id).sales_count, 1);
 }
 
@@ -4213,7 +4311,13 @@ fn test_transfer_license_does_not_consume_or_free_supply() {
     client.set_prompt_max_supply(&creator, &prompt_id, &1);
 
     fund_buyer(&xlm_client, &seller, &context.contract, price);
-    client.buy_prompt(&seller, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
+    client.buy_prompt(
+        &seller,
+        &prompt_id,
+        &None::<Address>,
+        &price,
+        &None::<Bytes>,
+    );
     assert_eq!(client.get_prompt(&prompt_id).sales_count, 1);
 
     let resale_price = 3_000;
@@ -4225,7 +4329,13 @@ fn test_transfer_license_does_not_consume_or_free_supply() {
     // one nor frees the original slot for a fresh buyer.
     assert_eq!(client.get_prompt(&prompt_id).sales_count, 1);
     fund_buyer(&xlm_client, &stranger, &context.contract, price);
-    let res = client.try_buy_prompt(&stranger, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
+    let res = client.try_buy_prompt(
+        &stranger,
+        &prompt_id,
+        &None::<Address>,
+        &price,
+        &None::<Bytes>,
+    );
     assert_eq!(res, Err(Ok(Error::MaxSupplyReached)));
 }
 
@@ -4246,7 +4356,13 @@ fn test_bundle_purchase_respects_prompt_max_supply() {
 
     // Exhaust the capped prompt's only unit via a direct purchase first.
     fund_buyer(&xlm_client, &early_buyer, &context.contract, price);
-    client.buy_prompt(&early_buyer, &capped_prompt, &None::<Address>, &price, &None::<Bytes>);
+    client.buy_prompt(
+        &early_buyer,
+        &capped_prompt,
+        &None::<Address>,
+        &price,
+        &None::<Bytes>,
+    );
 
     let mut prompt_ids = Vec::new(&env);
     prompt_ids.push_back(capped_prompt);
@@ -4265,7 +4381,10 @@ fn test_bundle_purchase_respects_prompt_max_supply() {
     let res = client.try_buy_bundle(&bundle_buyer, &bundle_id, &bundle_price);
     match res {
         Err(Ok(Error::MaxSupplyReached)) => {}
-        other => panic!("expected MaxSupplyReached for capped prompt in bundle, got {:?}", other),
+        other => panic!(
+            "expected MaxSupplyReached for capped prompt in bundle, got {:?}",
+            other
+        ),
     }
 }
 
@@ -4296,7 +4415,10 @@ fn test_access_pass_respects_own_max_supply() {
     let res = client.try_buy_access_pass(&buyer_two, &pass_id, &price);
     match res {
         Err(Ok(Error::MaxSupplyReached)) => {}
-        other => panic!("expected MaxSupplyReached for capped access pass, got {:?}", other),
+        other => panic!(
+            "expected MaxSupplyReached for capped access pass, got {:?}",
+            other
+        ),
     }
 }
 
@@ -4425,7 +4547,10 @@ fn test_retired_access_pass_cannot_be_reactivated() {
     let res = client.try_set_access_pass_status(&creator, &pass_id, &PromptSaleStatus::Active);
     match res {
         Err(Ok(Error::InvalidStatusTransition)) => {}
-        other => panic!("expected InvalidStatusTransition reviving a retired pass, got {:?}", other),
+        other => panic!(
+            "expected InvalidStatusTransition reviving a retired pass, got {:?}",
+            other
+        ),
     }
 }
 
@@ -4482,7 +4607,10 @@ fn test_update_access_pass_price_applies_to_next_purchase() {
     let res = client.try_buy_access_pass(&buyer, &pass_id, &old_price);
     match res {
         Err(Ok(Error::InvalidPaymentAmount)) => {}
-        other => panic!("expected InvalidPaymentAmount at stale price, got {:?}", other),
+        other => panic!(
+            "expected InvalidPaymentAmount at stale price, got {:?}",
+            other
+        ),
     }
     client.buy_access_pass(&buyer, &pass_id, &new_price);
 }
@@ -4505,7 +4633,8 @@ fn test_dispute_cannot_open_after_window_closes() {
     client.buy_prompt(&buyer, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
 
     // Three days plus one second after purchase, the dispute window has closed.
-    env.ledger().with_mut(|ledger| ledger.timestamp = 1_000 + 3 * 24 * 60 * 60 + 1);
+    env.ledger()
+        .with_mut(|ledger| ledger.timestamp = 1_000 + 3 * 24 * 60 * 60 + 1);
     let res = client.try_open_dispute(
         &buyer,
         &prompt_id,
@@ -4532,7 +4661,8 @@ fn test_dispute_within_window_still_succeeds() {
     fund_buyer(&xlm_client, &buyer, &context.contract, price);
     client.buy_prompt(&buyer, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
 
-    env.ledger().with_mut(|ledger| ledger.timestamp = 1_000 + 3 * 24 * 60 * 60 - 1);
+    env.ledger()
+        .with_mut(|ledger| ledger.timestamp = 1_000 + 3 * 24 * 60 * 60 - 1);
     client.open_dispute(
         &buyer,
         &prompt_id,

--- a/contracts/prompt-hash/src/test.rs
+++ b/contracts/prompt-hash/src/test.rs
@@ -19,20 +19,21 @@ struct PromptHashContext {
 }
 
 fn setup(env: &Env) -> PromptHashContext {
-    let contract_id = env.register_contract(None, PromptHashContract);
-    let client = PromptHashContractClient::new(env, &contract_id);
+    env.mock_all_auths();
 
     let admin = Address::generate(env);
     let fee_wallet = Address::generate(env);
-
-    let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
-    client.initialize(&fee_wallet, &token_contract);
+    let xlm = env.register(FungibleTokenContract, (admin.clone(),));
+    let contract = env.register(
+        PromptHashContract,
+        (admin.clone(), fee_wallet.clone(), xlm.clone()),
+    );
 
     PromptHashContext {
         admin,
         fee_wallet,
-        xlm: token_contract,
-        contract: contract_id,
+        xlm,
+        contract,
     }
 }
 
@@ -40,32 +41,23 @@ fn setup_env() -> (Env, Address, Address, Address, Address, Address, PromptHashC
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register_contract(None, PromptHashContract);
-    let client = PromptHashContractClient::new(&env, &contract_id);
-
     let admin = Address::generate(&env);
     let fee_wallet = Address::generate(&env);
     let creator = Address::generate(&env);
     let buyer = Address::generate(&env);
 
     let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
-    client.initialize(&fee_wallet, &token_contract);
+    let contract_id = env.register(
+        PromptHashContract,
+        (admin.clone(), fee_wallet.clone(), token_contract.clone()),
+    );
+    let client = PromptHashContractClient::new(&env, &contract_id);
 
     (env, admin, fee_wallet, creator, buyer, token_contract, client)
 }
 
-fn create_native_token(env: &Env, admin: &Address) -> token::Client<'static> {
-    let sac = env.register_stellar_asset_contract_v2(admin.clone());
-    token::Client::new(env, &sac)
-}
-
-fn hash(env: &Env, n: u32) -> BytesN<32> {
-    let mut data = [0u8; 32];
-    data[0] = (n & 0xFF) as u8;
-    data[1] = ((n >> 8) & 0xFF) as u8;
-    data[2] = ((n >> 16) & 0xFF) as u8;
-    data[3] = ((n >> 24) & 0xFF) as u8;
-    BytesN::from_array(env, &data)
+fn hash(env: &Env, byte: u8) -> BytesN<32> {
+    BytesN::from_array(env, &[byte; 32])
 }
 
 /// Convenience helper: creates a prompt with no expiry and no splits.
@@ -171,13 +163,11 @@ fn create_prompt_with_splits(
 }
 
 #[test]
-fn test_create_prompt_with_max_supply() {
-    let (env, _admin, _fee_wallet, creator, _buyer, _token_contract, client) = setup_env();
+fn test_create_prompt_stores_encrypted_fields() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
 
-    let id = create_prompt_with_supply(&env, &client, &creator, 10, 100);
-    let prompt = client.get_prompt(&id);
-    assert_eq!(prompt.max_supply, 10);
-    assert_eq!(prompt.sales_count, 0);
     let creator = Address::generate(&env);
     let prompt_id = create_prompt(
         &env,
@@ -196,13 +186,13 @@ fn test_create_prompt_with_max_supply() {
         String::from_str(&env, "Generate a production-ready implementation plan.")
     );
     assert_eq!(
-        prompt.encrypted_prompt,
+        prompt.encrypted_payload,
         String::from_str(&env, "ciphertext")
     );
     assert_eq!(prompt.encryption_iv, String::from_str(&env, "iv"));
     assert_eq!(prompt.wrapped_key, String::from_str(&env, "wrapped-key"));
     assert_eq!(prompt.content_hash, hash(&env, 7));
-    assert!(prompt.active);
+    assert_eq!(prompt.status, PromptSaleStatus::Active);
     assert_eq!(prompt.sales_count, 0);
     assert_eq!(prompt.expires_at, 0);
     assert_eq!(prompt.splits.len(), 0);
@@ -213,11 +203,11 @@ fn test_create_prompt_with_max_supply() {
 }
 
 #[test]
-fn test_buy_prompt_within_max_supply_succeeds() {
-    let (env, admin, _fee_wallet, creator, buyer, _token_contract, client) = setup_env();
-    let token = create_native_token(&env, &admin);
+fn test_creator_can_pause_reactivate_and_update_price() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
 
-    let id = create_prompt_with_supply(&env, &client, &creator, 3, 1000);
     let creator = Address::generate(&env);
     let prompt_id = create_prompt(
         &env,
@@ -228,23 +218,22 @@ fn test_buy_prompt_within_max_supply_succeeds() {
         &context.xlm,
     );
 
-    token.mint(&buyer, &10000);
-    token.approve(&buyer, &client.address, &1000, &1000);
+    client.set_prompt_sale_status(&creator, &prompt_id, &PromptSaleStatus::Paused);
+    client.update_prompt_price(&creator, &prompt_id, &9_000);
+    client.set_prompt_sale_status(&creator, &prompt_id, &PromptSaleStatus::Active);
 
-    let result = client.buy_prompt(&buyer, &id);
-    assert!(result.is_ok());
-
-    let prompt = client.get_prompt(&id);
-    assert_eq!(prompt.sales_count, 1);
-    assert!(client.has_access(&buyer, &id));
+    let prompt = client.get_prompt(&prompt_id);
+    assert_eq!(prompt.price_stroops, 9_000);
+    assert_eq!(prompt.status, PromptSaleStatus::Active);
 }
 
 #[test]
-fn test_buy_prompt_reaches_exact_max_supply() {
-    let (env, admin, _fee_wallet, creator, buyer, _token_contract, client) = setup_env();
-    let token = create_native_token(&env, &admin);
+fn test_buy_prompt_grants_access_to_multiple_buyers_and_tracks_exact_fees() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
 
-    let id = create_prompt_with_supply(&env, &client, &creator, 2, 1000);
     let creator = Address::generate(&env);
     let buyer_one = Address::generate(&env);
     let buyer_two = Address::generate(&env);
@@ -257,14 +246,12 @@ fn test_buy_prompt_reaches_exact_max_supply() {
         &context.xlm,
     );
 
-    token.mint(&buyer, &10000);
-    token.approve(&buyer, &client.address, &10000, &1000);
+    fund_buyer(&xlm_client, &buyer_one, &context.contract, 100_000);
+    fund_buyer(&xlm_client, &buyer_two, &context.contract, 100_000);
 
-    // First purchase succeeds
-    client.buy_prompt(&buyer, &id).unwrap();
+    let seller_start = xlm_client.balance(&creator);
+    let fee_start = xlm_client.balance(&context.fee_wallet);
 
-    // Second purchase succeeds (exactly at max supply)
-    client.buy_prompt(&buyer, &id).unwrap();
     client.buy_prompt(
         &buyer_one,
         &prompt_id,
@@ -283,26 +270,21 @@ fn test_buy_prompt_reaches_exact_max_supply() {
     client.settle_purchase(&context.admin, &prompt_id, &buyer_one);
     client.settle_purchase(&context.admin, &prompt_id, &buyer_two);
 
-    let prompt = client.get_prompt(&id);
+    let prompt = client.get_prompt(&prompt_id);
     assert_eq!(prompt.sales_count, 2);
-}
+    assert!(client.has_access(&buyer_one, &prompt_id));
+    assert!(client.has_access(&buyer_two, &prompt_id));
 
-#[test]
-fn test_buy_prompt_exceeds_max_supply_fails() {
-    let (env, admin, _fee_wallet, creator, buyer, _token_contract, client) = setup_env();
-    let token = create_native_token(&env, &admin);
-
-    let id = create_prompt_with_supply(&env, &client, &creator, 1, 1000);
-
-    token.mint(&buyer, &10000);
-    token.approve(&buyer, &client.address, &10000, &1000);
-
-    // First purchase succeeds
-    client.buy_prompt(&buyer, &id).unwrap();
-
-    // Second purchase fails because max_supply = 1
-    let result = client.try_buy_prompt(&buyer, &id);
-    assert_eq!(result, Err(Ok(Error::MaxSupplyReached)));
+    let single_fee = 12_345 * 500 / 10_000;
+    let single_creator_amount = 12_345 - single_fee;
+    assert_eq!(
+        xlm_client.balance(&creator),
+        seller_start + (single_creator_amount * 2) as i128
+    );
+    assert_eq!(
+        xlm_client.balance(&context.fee_wallet),
+        fee_start + (single_fee * 2) as i128
+    );
 }
 
 #[test]
@@ -535,9 +517,9 @@ fn test_update_platform_fee_emits_event() {
     let client = PromptHashContractClient::new(&env, &context.contract);
 
     // Capture event count before
-    let before = env.events().all().len();
+    let before = env.events().all().events().len();
     client.update_platform_fee(&context.admin, &400u32);
-    let after = env.events().all().len();
+    let after = env.events().all().events().len();
     assert!(after > before, "expected at least one new event");
 }
 
@@ -573,33 +555,8 @@ fn test_has_access_is_true_for_creator_and_buyer_but_not_stranger() {
         &None::<Bytes>,
     );
 
-    let id = create_prompt_with_supply(&env, &client, &creator, 1, 1000);
-
-    token.mint(&buyer, &10000);
-    token.approve(&buyer, &client.address, &10000, &1000);
-
-    // First purchase succeeds
-    client.buy_prompt(&buyer, &id).unwrap();
-
-    // Second purchase fails because max_supply = 1
-    let result = client.try_buy_prompt(&buyer, &id);
-    assert_eq!(result, Err(Ok(Error::MaxSupplyReached)));
-}
-
-#[test]
-fn test_max_supply_zero_is_unlimited() {
-    let (env, admin, _fee_wallet, creator, buyer, _token_contract, client) = setup_env();
-    let token = create_native_token(&env, &admin);
-
-    let id = create_prompt_with_supply(&env, &client, &creator, 0, 1000);
-
-    token.mint(&buyer, &100000);
-    token.approve(&buyer, &client.address, &100000, &1000);
-
-    // Multiple purchases should all succeed
-    for _ in 0..5 {
-        client.buy_prompt(&buyer, &id).unwrap();
-    }
+    assert!(client.has_access(&buyer, &prompt_id));
+    assert!(!client.has_access(&stranger, &prompt_id));
 }
 
 #[test]
@@ -800,25 +757,6 @@ fn test_duplicate_purchase_returns_typed_error() {
 }
 
 #[test]
-fn test_max_supply_one_allows_exactly_one_purchase() {
-    let (env, admin, _fee_wallet, creator, buyer1, _token_contract, client) = setup_env();
-    let token = create_native_token(&env, &admin);
-
-    let id = create_prompt_with_supply(&env, &client, &creator, 1, 1000);
-
-    token.mint(&buyer1, &10000);
-    token.approve(&buyer1, &client.address, &10000, &1000);
-
-    // First buyer succeeds
-    client.buy_prompt(&buyer1, &id).unwrap();
-
-    // Any further purchase fails
-    let buyer2 = Address::generate(&env);
-    let result = client.try_buy_prompt(&buyer2, &id);
-    assert_eq!(result, Err(Ok(Error::MaxSupplyReached)));
-}
-
-#[test]
 fn test_creator_cannot_buy_own_prompt() {
     let env: Env = Default::default();
     let context = setup(&env);
@@ -905,22 +843,15 @@ fn test_buy_prompt_with_zero_fee() {
 
     fund_buyer(&xlm_client, &buyer, &context.contract, price);
 
-    let creator_start = xlm_client.balance(&creator);
+    let seller_start = xlm_client.balance(&creator);
     let fee_start = xlm_client.balance(&context.fee_wallet);
 
     client.buy_prompt(&buyer, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
 
     client.settle_purchase(&context.admin, &prompt_id, &buyer);
 
-    // With 0% fee, creator gets the full price
-    assert_eq!(
-        xlm_client.balance(&creator),
-        creator_start + price
-    );
-    assert_eq!(
-        xlm_client.balance(&context.fee_wallet),
-        fee_start
-    );
+    assert_eq!(xlm_client.balance(&creator), seller_start + price);
+    assert_eq!(xlm_client.balance(&context.fee_wallet), fee_start);
 }
 
 #[test]
@@ -962,11 +893,45 @@ fn test_multiple_buyers_until_supply_exhausted() {
 }
 
 #[test]
-fn test_supply_check_happens_before_payment() {
+fn test_buy_prompt_with_max_fee() {
     let env: Env = Default::default();
     let context = setup(&env);
     let client = PromptHashContractClient::new(&env, &context.contract);
     let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+
+    // Set fee to 100% (10,000 BPS)
+    client.set_fee_percentage(&10_000);
+
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let price = 10_000;
+    let prompt_id = create_prompt(
+        &env,
+        &client,
+        &creator,
+        "Max Fee Prompt",
+        price,
+        &context.xlm,
+    );
+
+    fund_buyer(&xlm_client, &buyer, &context.contract, price);
+
+    let seller_start = xlm_client.balance(&creator);
+    let fee_start = xlm_client.balance(&context.fee_wallet);
+
+    client.buy_prompt(&buyer, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
+
+    client.settle_purchase(&context.admin, &prompt_id, &buyer);
+
+    assert_eq!(xlm_client.balance(&creator), seller_start);
+    assert_eq!(xlm_client.balance(&context.fee_wallet), fee_start + price);
+}
+
+#[test]
+fn test_unauthorized_seller_actions_fail() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
 
     let creator = Address::generate(&env);
     let stranger = Address::generate(&env);
@@ -980,7 +945,8 @@ fn test_supply_check_happens_before_payment() {
     );
 
     // Try to update status as stranger
-    let status_res = client.try_set_prompt_sale_status(&stranger, &prompt_id, &PromptSaleStatus::Paused);
+    let status_res =
+        client.try_set_prompt_sale_status(&stranger, &prompt_id, &PromptSaleStatus::Paused);
     match status_res {
         Err(Ok(Error::Unauthorized)) => {}
         other => panic!("expected unauthorized for status update, got {:?}", other),
@@ -991,6 +957,29 @@ fn test_supply_check_happens_before_payment() {
     match price_res {
         Err(Ok(Error::Unauthorized)) => {}
         other => panic!("expected unauthorized for price update, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_buy_nonexistent_prompt_fails() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let buyer = Address::generate(&env);
+
+    let result = client.try_buy_prompt(
+        &buyer,
+        &999_999,
+        &None::<Address>,
+        &1_000i128,
+        &None::<Bytes>,
+    );
+    match result {
+        Err(Ok(Error::PromptNotFound)) => {}
+        other => panic!(
+            "expected PromptNotFound for nonexistent prompt, got {:?}",
+            other
+        ),
     }
 }
 
@@ -2716,6 +2705,12 @@ fn test_buy_prompts_bulk_rejects_batch_over_max_size() {
 #[test]
 fn test_buy_prompts_bulk_allows_exactly_max_size() {
     let env: Env = Default::default();
+    // A 20-prompt bulk purchase legitimately exceeds the default simulated
+    // mainnet footprint/resource limits; this only relaxes the local test
+    // harness limit, not the contract's own MAX_BULK_PURCHASE_SIZE bound
+    // under test.
+    env.cost_estimate().disable_resource_limits();
+    env.cost_estimate().budget().reset_unlimited();
     let context = setup(&env);
     let client = PromptHashContractClient::new(&env, &context.contract);
     let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
@@ -2840,6 +2835,7 @@ fn test_access_pass_grants_time_bound_catalog_access() {
         &2_000,
         &pass_price,
         &context.xlm,
+        &0u32,
     );
 
     client.buy_access_pass(&buyer, &pass_id, &pass_price);
@@ -4109,4 +4105,537 @@ fn test_payout_invariant_with_tip() {
     // Tip is part of the total payment
     assert_eq!(tip, payment - price);
     assert_eq!(creator_received + fee_received, payment);
+}
+
+// ─── Issue #538: Supply limits across sales, leases, bundles, passes, resale ──
+
+#[test]
+fn test_lease_respects_max_supply() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+    let creator = Address::generate(&env);
+    let buyer_one = Address::generate(&env);
+    let buyer_two = Address::generate(&env);
+    let prompt_id = create_prompt(&env, &client, &creator, "Leased Once", 10_000, &context.xlm);
+    client.set_prompt_max_supply(&creator, &prompt_id, &1);
+
+    fund_buyer(&xlm_client, &buyer_one, &context.contract, 100_000);
+    fund_buyer(&xlm_client, &buyer_two, &context.contract, 100_000);
+
+    client.lease_prompt(&buyer_one, &prompt_id, &600);
+    assert_eq!(client.get_prompt(&prompt_id).sales_count, 1);
+
+    let res = client.try_lease_prompt(&buyer_two, &prompt_id, &600);
+    match res {
+        Err(Ok(Error::MaxSupplyReached)) => {}
+        other => panic!("expected MaxSupplyReached for capped lease, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_set_max_supply_below_committed_sales_rejected() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+    let creator = Address::generate(&env);
+    let buyer_one = Address::generate(&env);
+    let buyer_two = Address::generate(&env);
+    let price = 5_000;
+    let prompt_id = create_prompt(&env, &client, &creator, "Uncapped", price, &context.xlm);
+
+    fund_buyer(&xlm_client, &buyer_one, &context.contract, price);
+    fund_buyer(&xlm_client, &buyer_two, &context.contract, price);
+    client.buy_prompt(&buyer_one, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
+    client.buy_prompt(&buyer_two, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
+
+    let res = client.try_set_prompt_max_supply(&creator, &prompt_id, &1);
+    match res {
+        Err(Ok(Error::MaxSupplyBelowCommitted)) => {}
+        other => panic!("expected MaxSupplyBelowCommitted, got {:?}", other),
+    }
+
+    // Equal to committed sales is allowed, as is resetting to unlimited.
+    client.set_prompt_max_supply(&creator, &prompt_id, &2);
+    client.set_prompt_max_supply(&creator, &prompt_id, &0);
+}
+
+#[test]
+fn test_dispute_refund_releases_supply_for_resale() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+    let creator = Address::generate(&env);
+    let buyer_one = Address::generate(&env);
+    let buyer_two = Address::generate(&env);
+    let price = 5_000;
+    let prompt_id = create_prompt(&env, &client, &creator, "One Unit", price, &context.xlm);
+    client.set_prompt_max_supply(&creator, &prompt_id, &1);
+
+    fund_buyer(&xlm_client, &buyer_one, &context.contract, price);
+    client.buy_prompt(&buyer_one, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
+    assert_eq!(client.get_prompt(&prompt_id).sales_count, 1);
+
+    // At capacity: a second buyer cannot acquire the unit.
+    fund_buyer(&xlm_client, &buyer_two, &context.contract, price);
+    let blocked = client.try_buy_prompt(&buyer_two, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
+    assert_eq!(blocked, Err(Ok(Error::MaxSupplyReached)));
+
+    // Refunding the disputed purchase releases the reserved unit.
+    client.open_dispute(
+        &buyer_one,
+        &prompt_id,
+        &crate::types::DisputeReason::FailedIntegrityVerification,
+    );
+    client.resolve_dispute(&context.admin, &prompt_id, &buyer_one, &true);
+    assert_eq!(client.get_prompt(&prompt_id).sales_count, 0);
+
+    // Now the second buyer can acquire the freed unit.
+    client.buy_prompt(&buyer_two, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
+    assert_eq!(client.get_prompt(&prompt_id).sales_count, 1);
+}
+
+#[test]
+fn test_transfer_license_does_not_consume_or_free_supply() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+    let creator = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let new_buyer = Address::generate(&env);
+    let stranger = Address::generate(&env);
+    let price = 5_000;
+    let prompt_id = create_prompt(&env, &client, &creator, "Resale Cap", price, &context.xlm);
+    client.set_prompt_max_supply(&creator, &prompt_id, &1);
+
+    fund_buyer(&xlm_client, &seller, &context.contract, price);
+    client.buy_prompt(&seller, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
+    assert_eq!(client.get_prompt(&prompt_id).sales_count, 1);
+
+    let resale_price = 3_000;
+    xlm_client.mint(&new_buyer, &resale_price);
+    xlm_client.approve(&new_buyer, &context.contract, &resale_price, &1_000);
+    client.transfer_license(&seller, &prompt_id, &new_buyer, &resale_price);
+
+    // Resale transfers an already-reserved unit; it neither consumes a new
+    // one nor frees the original slot for a fresh buyer.
+    assert_eq!(client.get_prompt(&prompt_id).sales_count, 1);
+    fund_buyer(&xlm_client, &stranger, &context.contract, price);
+    let res = client.try_buy_prompt(&stranger, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
+    assert_eq!(res, Err(Ok(Error::MaxSupplyReached)));
+}
+
+#[test]
+fn test_bundle_purchase_respects_prompt_max_supply() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+    let creator = Address::generate(&env);
+    let early_buyer = Address::generate(&env);
+    let bundle_buyer = Address::generate(&env);
+    let price = 4_000;
+
+    let capped_prompt = create_prompt(&env, &client, &creator, "Capped", price, &context.xlm);
+    client.set_prompt_max_supply(&creator, &capped_prompt, &1);
+    let open_prompt = create_prompt(&env, &client, &creator, "Open", price, &context.xlm);
+
+    // Exhaust the capped prompt's only unit via a direct purchase first.
+    fund_buyer(&xlm_client, &early_buyer, &context.contract, price);
+    client.buy_prompt(&early_buyer, &capped_prompt, &None::<Address>, &price, &None::<Bytes>);
+
+    let mut prompt_ids = Vec::new(&env);
+    prompt_ids.push_back(capped_prompt);
+    prompt_ids.push_back(open_prompt);
+    let bundle_price = 6_000;
+    let bundle_id = client.create_bundle(
+        &creator,
+        &String::from_str(&env, "Mixed Bundle"),
+        &prompt_ids,
+        &bundle_price,
+        &context.xlm,
+        &0u64,
+    );
+
+    fund_buyer(&xlm_client, &bundle_buyer, &context.contract, bundle_price);
+    let res = client.try_buy_bundle(&bundle_buyer, &bundle_id, &bundle_price);
+    match res {
+        Err(Ok(Error::MaxSupplyReached)) => {}
+        other => panic!("expected MaxSupplyReached for capped prompt in bundle, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_access_pass_respects_own_max_supply() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+    let creator = Address::generate(&env);
+    let buyer_one = Address::generate(&env);
+    let buyer_two = Address::generate(&env);
+    let price = 8_000;
+
+    let pass_id = client.create_access_pass(
+        &creator,
+        &String::from_str(&env, "Capped Pass"),
+        &1_000u64,
+        &price,
+        &context.xlm,
+        &1u32,
+    );
+
+    fund_buyer(&xlm_client, &buyer_one, &context.contract, price);
+    fund_buyer(&xlm_client, &buyer_two, &context.contract, price);
+
+    client.buy_access_pass(&buyer_one, &pass_id, &price);
+    let res = client.try_buy_access_pass(&buyer_two, &pass_id, &price);
+    match res {
+        Err(Ok(Error::MaxSupplyReached)) => {}
+        other => panic!("expected MaxSupplyReached for capped access pass, got {:?}", other),
+    }
+}
+
+// ─── Issue #539: Access pass lifecycle and renewal ────────────────────────────
+
+#[test]
+fn test_access_pass_renewal_before_expiry_extends_from_current_expiry() {
+    let env: Env = Default::default();
+    env.ledger().with_mut(|ledger| ledger.timestamp = 1_000);
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let prompt_id = create_prompt(&env, &client, &creator, "Catalog", 1_000, &context.xlm);
+    let price = 5_000;
+
+    let pass_id = client.create_access_pass(
+        &creator,
+        &String::from_str(&env, "Monthly"),
+        &1_000u64,
+        &price,
+        &context.xlm,
+        &0u32,
+    );
+    fund_buyer(&xlm_client, &buyer, &context.contract, price * 2);
+
+    // First purchase at t=1000 grants access through t=2000.
+    client.buy_access_pass(&buyer, &pass_id, &price);
+
+    // Renewing early (t=1500, still active) must extend from the existing
+    // expiry (2000 + 1000 = 3000), not from `now` (which would only reach
+    // 2500 and incorrectly shorten/overlap the remaining period) (#539).
+    env.ledger().with_mut(|ledger| ledger.timestamp = 1_500);
+    client.buy_access_pass(&buyer, &pass_id, &price);
+
+    env.ledger().with_mut(|ledger| ledger.timestamp = 2_999);
+    assert!(client.has_access(&buyer, &prompt_id));
+    env.ledger().with_mut(|ledger| ledger.timestamp = 3_001);
+    assert!(!client.has_access(&buyer, &prompt_id));
+}
+
+#[test]
+fn test_access_pass_renewal_after_expiry_starts_from_now() {
+    let env: Env = Default::default();
+    env.ledger().with_mut(|ledger| ledger.timestamp = 1_000);
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let prompt_id = create_prompt(&env, &client, &creator, "Catalog", 1_000, &context.xlm);
+    let price = 5_000;
+
+    let pass_id = client.create_access_pass(
+        &creator,
+        &String::from_str(&env, "Monthly"),
+        &500u64,
+        &price,
+        &context.xlm,
+        &0u32,
+    );
+    fund_buyer(&xlm_client, &buyer, &context.contract, price * 2);
+
+    client.buy_access_pass(&buyer, &pass_id, &price); // expires at 1_500
+
+    // Buying again after the grant has already lapsed starts a fresh period
+    // from `now`, not from the stale past expiry.
+    env.ledger().with_mut(|ledger| ledger.timestamp = 2_000);
+    client.buy_access_pass(&buyer, &pass_id, &price); // expires at 2_500
+
+    env.ledger().with_mut(|ledger| ledger.timestamp = 2_499);
+    assert!(client.has_access(&buyer, &prompt_id));
+    env.ledger().with_mut(|ledger| ledger.timestamp = 2_501);
+    assert!(!client.has_access(&buyer, &prompt_id));
+}
+
+#[test]
+fn test_paused_access_pass_cannot_be_purchased_but_can_be_reactivated() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let price = 5_000;
+
+    let pass_id = client.create_access_pass(
+        &creator,
+        &String::from_str(&env, "Toggle"),
+        &1_000u64,
+        &price,
+        &context.xlm,
+        &0u32,
+    );
+    fund_buyer(&xlm_client, &buyer, &context.contract, price);
+
+    client.set_access_pass_status(&creator, &pass_id, &PromptSaleStatus::Paused);
+    let res = client.try_buy_access_pass(&buyer, &pass_id, &price);
+    match res {
+        Err(Ok(Error::PromptInactive)) => {}
+        other => panic!("expected PromptInactive for paused pass, got {:?}", other),
+    }
+
+    client.set_access_pass_status(&creator, &pass_id, &PromptSaleStatus::Active);
+    client.buy_access_pass(&buyer, &pass_id, &price);
+}
+
+#[test]
+fn test_retired_access_pass_cannot_be_reactivated() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let creator = Address::generate(&env);
+
+    let pass_id = client.create_access_pass(
+        &creator,
+        &String::from_str(&env, "Sunset"),
+        &1_000u64,
+        &5_000,
+        &context.xlm,
+        &0u32,
+    );
+
+    client.set_access_pass_status(&creator, &pass_id, &PromptSaleStatus::Retired);
+    let res = client.try_set_access_pass_status(&creator, &pass_id, &PromptSaleStatus::Active);
+    match res {
+        Err(Ok(Error::InvalidStatusTransition)) => {}
+        other => panic!("expected InvalidStatusTransition reviving a retired pass, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_retiring_access_pass_does_not_revoke_existing_grant() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let prompt_id = create_prompt(&env, &client, &creator, "Catalog", 1_000, &context.xlm);
+    let price = 5_000;
+
+    let pass_id = client.create_access_pass(
+        &creator,
+        &String::from_str(&env, "Grandfathered"),
+        &1_000u64,
+        &price,
+        &context.xlm,
+        &0u32,
+    );
+    fund_buyer(&xlm_client, &buyer, &context.contract, price);
+    client.buy_access_pass(&buyer, &pass_id, &price);
+
+    // Retiring the pass definition must not silently revoke access already
+    // paid for and granted (#539).
+    client.set_access_pass_status(&creator, &pass_id, &PromptSaleStatus::Retired);
+    assert!(client.has_access(&buyer, &prompt_id));
+}
+
+#[test]
+fn test_update_access_pass_price_applies_to_next_purchase() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let old_price = 5_000;
+    let new_price = 9_000;
+
+    let pass_id = client.create_access_pass(
+        &creator,
+        &String::from_str(&env, "Repriced"),
+        &1_000u64,
+        &old_price,
+        &context.xlm,
+        &0u32,
+    );
+    client.update_access_pass_price(&creator, &pass_id, &new_price);
+
+    fund_buyer(&xlm_client, &buyer, &context.contract, new_price);
+    let res = client.try_buy_access_pass(&buyer, &pass_id, &old_price);
+    match res {
+        Err(Ok(Error::InvalidPaymentAmount)) => {}
+        other => panic!("expected InvalidPaymentAmount at stale price, got {:?}", other),
+    }
+    client.buy_access_pass(&buyer, &pass_id, &new_price);
+}
+
+// ─── Issue #541: Purchase-relative dispute windows & permissionless settlement ─
+
+#[test]
+fn test_dispute_cannot_open_after_window_closes() {
+    let env: Env = Default::default();
+    env.ledger().with_mut(|ledger| ledger.timestamp = 1_000);
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let price = 5_000;
+    let prompt_id = create_prompt(&env, &client, &creator, "Windowed", price, &context.xlm);
+
+    fund_buyer(&xlm_client, &buyer, &context.contract, price);
+    client.buy_prompt(&buyer, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
+
+    // Three days plus one second after purchase, the dispute window has closed.
+    env.ledger().with_mut(|ledger| ledger.timestamp = 1_000 + 3 * 24 * 60 * 60 + 1);
+    let res = client.try_open_dispute(
+        &buyer,
+        &prompt_id,
+        &crate::types::DisputeReason::MissingMetadata,
+    );
+    match res {
+        Err(Ok(Error::DisputeWindowClosed)) => {}
+        other => panic!("expected DisputeWindowClosed, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_dispute_within_window_still_succeeds() {
+    let env: Env = Default::default();
+    env.ledger().with_mut(|ledger| ledger.timestamp = 1_000);
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let price = 5_000;
+    let prompt_id = create_prompt(&env, &client, &creator, "Windowed", price, &context.xlm);
+
+    fund_buyer(&xlm_client, &buyer, &context.contract, price);
+    client.buy_prompt(&buyer, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
+
+    env.ledger().with_mut(|ledger| ledger.timestamp = 1_000 + 3 * 24 * 60 * 60 - 1);
+    client.open_dispute(
+        &buyer,
+        &prompt_id,
+        &crate::types::DisputeReason::MissingMetadata,
+    );
+    let dispute = client.get_dispute(&prompt_id, &buyer);
+    assert_eq!(dispute.status, crate::types::DisputeStatus::Open);
+}
+
+#[test]
+fn test_permissionless_settlement_blocked_before_window_elapses() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let stranger = Address::generate(&env);
+    let price = 5_000;
+    let prompt_id = create_prompt(&env, &client, &creator, "Stale", price, &context.xlm);
+
+    fund_buyer(&xlm_client, &buyer, &context.contract, price);
+    client.buy_prompt(&buyer, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
+
+    let res = client.try_settle_purchase(&stranger, &prompt_id, &buyer);
+    match res {
+        Err(Ok(Error::DisputeWindowNotElapsed)) => {}
+        other => panic!("expected DisputeWindowNotElapsed, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_permissionless_settlement_after_window_by_any_caller() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let stranger = Address::generate(&env);
+    let price = 5_000;
+    let prompt_id = create_prompt(&env, &client, &creator, "Stale", price, &context.xlm);
+
+    fund_buyer(&xlm_client, &buyer, &context.contract, price);
+    client.buy_prompt(&buyer, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
+
+    let creator_before = xlm_client.balance(&creator);
+    env.ledger()
+        .with_mut(|ledger| ledger.timestamp = 3 * 24 * 60 * 60 + 1);
+
+    // Every escrow has a bounded path to settlement — an uninvolved third
+    // party can finalize it once the dispute window has closed (#541).
+    client.settle_purchase(&stranger, &prompt_id, &buyer);
+
+    let escrow = client.get_purchase_escrow(&prompt_id, &buyer).unwrap();
+    assert_eq!(escrow.status, crate::types::SettlementStatus::Settled);
+    assert!(xlm_client.balance(&creator) > creator_before);
+}
+
+#[test]
+fn test_settle_purchase_blocked_while_dispute_open() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let price = 5_000;
+    let prompt_id = create_prompt(&env, &client, &creator, "Contested", price, &context.xlm);
+
+    fund_buyer(&xlm_client, &buyer, &context.contract, price);
+    client.buy_prompt(&buyer, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
+    client.open_dispute(
+        &buyer,
+        &prompt_id,
+        &crate::types::DisputeReason::InvalidEncryptedPayload,
+    );
+
+    // Even the admin's fast path must go through `resolve_dispute` once a
+    // dispute is open, not bypass it via settlement (#541).
+    let res = client.try_settle_purchase(&context.admin, &prompt_id, &buyer);
+    match res {
+        Err(Ok(Error::DisputeAlreadyOpen)) => {}
+        other => panic!("expected DisputeAlreadyOpen, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_creator_can_settle_immediately_without_waiting() {
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let xlm_client = token::StellarAssetClient::new(&env, &context.xlm);
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let price = 5_000;
+    let prompt_id = create_prompt(&env, &client, &creator, "Fast Path", price, &context.xlm);
+
+    fund_buyer(&xlm_client, &buyer, &context.contract, price);
+    client.buy_prompt(&buyer, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
+
+    // The creator (privileged, like the admin) may settle right away.
+    client.settle_purchase(&creator, &prompt_id, &buyer);
+    let escrow = client.get_purchase_escrow(&prompt_id, &buyer).unwrap();
+    assert_eq!(escrow.status, crate::types::SettlementStatus::Settled);
 }

--- a/contracts/prompt-hash/src/test.rs
+++ b/contracts/prompt-hash/src/test.rs
@@ -4,7 +4,7 @@ extern crate std;
 
 use crate::mock_asset::FungibleTokenContract;
 use crate::types::{Error, ListingConfig, PromptSaleStatus, Split};
-use crate::{PromptHashContract, PromptHashContractClient};
+use crate::contract::{PromptHashContract, PromptHashContractClient};
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
     token, Address, Bytes, BytesN, Env, String, Vec,
@@ -46,7 +46,7 @@ fn setup_env() -> (Env, Address, Address, Address, Address, Address, PromptHashC
     let creator = Address::generate(&env);
     let buyer = Address::generate(&env);
 
-    let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+    let token_contract = env.register_stellar_asset_contract_v2(admin.clone()).address();
     let contract_id = env.register(
         PromptHashContract,
         (admin.clone(), fee_wallet.clone(), token_contract.clone()),
@@ -99,7 +99,7 @@ fn create_prompt_with_supply(
 ) -> u64 {
     let asset = {
         let admin = Address::generate(env);
-        env.register_stellar_asset_contract_v2(admin)
+        env.register_stellar_asset_contract_v2(admin).address()
     };
     client.create_prompt(
         creator,
@@ -183,11 +183,11 @@ fn test_create_prompt_stores_encrypted_fields() {
     assert_eq!(prompt.creator, creator);
     assert_eq!(
         prompt.preview_text,
-        String::from_str(&env, "Generate a production-ready implementation plan.")
+        String::from_str(&env, "preview")
     );
     assert_eq!(
         prompt.encrypted_payload,
-        String::from_str(&env, "ciphertext")
+        String::from_str(&env, "encrypted")
     );
     assert_eq!(prompt.encryption_iv, String::from_str(&env, "iv"));
     assert_eq!(prompt.wrapped_key, String::from_str(&env, "wrapped-key"));

--- a/contracts/prompt-hash/src/ttl_policy.rs
+++ b/contracts/prompt-hash/src/ttl_policy.rs
@@ -3,7 +3,7 @@
 // data corruption and access state violations.
 
 use crate::types::{DataKey, Error};
-use soroban_sdk::{Address, Env};
+use soroban_sdk::Env;
 
 /// TTL constants (in ledgers, ~6 seconds per ledger)
 /// Reference: 1 day ≈ 14,400 ledgers, 1 year ≈ 5.256M ledgers
@@ -23,15 +23,6 @@ pub const MAX_RENEWAL_BATCH_SIZE: u32 = 20;
 /// Ensures entitlements don't expire before supporting records
 pub fn get_ttl_for_key(key: &DataKey) -> u32 {
     match key {
-        // Instance keys — no TTL, never expire
-        DataKey::PromptCounter
-        | DataKey::FeePercentage
-        | DataKey::FeeWallet
-        | DataKey::XlmAddress
-        | DataKey::Reentrancy
-        | DataKey::ReferralPercentage
-        | DataKey::IsPaused => u32::MAX, // No renewal
-
         // Prompts — longer TTL, renewed on each access
         DataKey::Prompt(_) => ONE_YEAR,
         DataKey::CreatorPrompts(_) => ONE_YEAR,
@@ -69,6 +60,11 @@ pub fn get_ttl_for_key(key: &DataKey) -> u32 {
 
         // Vouchers — shorter, tied to prompt
         DataKey::VoucherKey(_, _) => ONE_MONTH,
+
+        // Everything else (nonce ledgers, settlement/quote/resale/governance
+        // records) defaults to the same long, conservative retention as the
+        // purchase records they support.
+        _ => ONE_YEAR + ONE_MONTH,
     }
 }
 
@@ -146,22 +142,18 @@ pub fn get_time_remaining(
     last_extended_ledger: u64,
     max_ttl: u32,
 ) -> u64 {
-    let age = current_ledger.saturating_sub(last_extended_ledger);
     let expiry_at = last_extended_ledger.saturating_add(max_ttl as u64);
     expiry_at.saturating_sub(current_ledger)
 }
 
 /// Validate that dependent keys have sufficient TTL protection
 pub fn validate_ttl_dependency(
-    env: &Env,
-    parent_key: &DataKey,
-    child_key: &DataKey,
+    _env: &Env,
+    _parent_key: &DataKey,
+    _child_key: &DataKey,
     parent_last_extended: u64,
     child_last_extended: u64,
 ) -> Result<(), Error> {
-    let parent_ttl = get_ttl_for_key(parent_key);
-    let child_ttl = get_ttl_for_key(child_key);
-
     // Child TTL must be at least as long as parent
     // Actually: child_last_extended must be >= parent_last_extended
     // so they expire at the same time or child expires later
@@ -203,19 +195,23 @@ pub fn compute_expiry_risk(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::{Address, Env};
 
     #[test]
     fn test_ttl_for_all_keys() {
         // Ensure every DataKey variant has a TTL policy
-        let sample_keys = vec![
+        let env = Env::default();
+        let addr = Address::generate(&env);
+        let sample_keys = [
             DataKey::Prompt(1),
-            DataKey::Purchase(1, Address::from_contract_id(&soroban_sdk::Env::default())),
-            DataKey::PurchaseEscrow(1, Address::from_contract_id(&soroban_sdk::Env::default())),
+            DataKey::Purchase(1, addr.clone()),
+            DataKey::PurchaseEscrow(1, addr),
         ];
 
         for key in sample_keys {
             let ttl = get_ttl_for_key(&key);
-            assert!(ttl > 0 || ttl == u32::MAX, "Key {:?} must have valid TTL", key);
+            assert!(ttl > 0, "key must have a positive TTL");
         }
     }
 
@@ -248,8 +244,10 @@ mod tests {
     #[test]
     fn test_expiry_risk_critical() {
         let max_ttl = ONE_MONTH;
-        let current_ledger = 100_000u64;
-        let last_extended = 100_000u64 - (max_ttl as u64) / 10 + 100; // Just past critical threshold
+        let current_ledger = 1_000_000u64;
+        // Nearly the full TTL has elapsed since the last renewal, so almost
+        // no time remains before expiry.
+        let last_extended = current_ledger - (max_ttl as u64) + 100;
 
         let risk = compute_expiry_risk(current_ledger, last_extended, max_ttl);
         assert!(risk.critical_keys > 0, "Should detect critical expiry risk");
@@ -258,8 +256,9 @@ mod tests {
     #[test]
     fn test_expiry_risk_at_risk() {
         let max_ttl = ONE_MONTH;
-        let current_ledger = 100_000u64;
-        let last_extended = 100_000u64 - (max_ttl as u64) / 3; // 33% through lifetime
+        let current_ledger = 1_000_000u64;
+        // 60% of the TTL has elapsed, leaving ~40% remaining (at-risk band).
+        let last_extended = current_ledger - (max_ttl as u64) * 6 / 10;
 
         let risk = compute_expiry_risk(current_ledger, last_extended, max_ttl);
         assert!(risk.at_risk_keys > 0 || risk.imminent_keys > 0, "Should detect at-risk keys");

--- a/contracts/prompt-hash/src/ttl_policy.rs
+++ b/contracts/prompt-hash/src/ttl_policy.rs
@@ -7,7 +7,6 @@ use soroban_sdk::Env;
 
 /// TTL constants (in ledgers, ~6 seconds per ledger)
 /// Reference: 1 day ≈ 14,400 ledgers, 1 year ≈ 5.256M ledgers
-
 pub const ONE_DAY: u32 = 14_400;
 pub const ONE_WEEK: u32 = 7 * ONE_DAY;
 pub const ONE_MONTH: u32 = 30 * ONE_DAY;

--- a/contracts/prompt-hash/src/ttl_policy.rs
+++ b/contracts/prompt-hash/src/ttl_policy.rs
@@ -126,22 +126,14 @@ pub struct ExpiryRisk {
 }
 
 /// Check if a key needs renewal based on current ledger and last extension
-pub fn should_renew_key(
-    current_ledger: u64,
-    last_extended_ledger: u64,
-    max_ttl: u32,
-) -> bool {
+pub fn should_renew_key(current_ledger: u64, last_extended_ledger: u64, max_ttl: u32) -> bool {
     let age = current_ledger.saturating_sub(last_extended_ledger);
     let renewal_threshold = (max_ttl as u64) * (RENEWAL_THRESHOLD_PCT as u64) / 100;
     age >= renewal_threshold
 }
 
 /// Compute time remaining before expiry (in ledgers)
-pub fn get_time_remaining(
-    current_ledger: u64,
-    last_extended_ledger: u64,
-    max_ttl: u32,
-) -> u64 {
+pub fn get_time_remaining(current_ledger: u64, last_extended_ledger: u64, max_ttl: u32) -> u64 {
     let expiry_at = last_extended_ledger.saturating_add(max_ttl as u64);
     expiry_at.saturating_sub(current_ledger)
 }
@@ -226,7 +218,11 @@ mod tests {
 
         // After 70% of TTL, should need renewal
         let renewal_point = (max_ttl as u64) * 70 / 100;
-        assert!(should_renew_key(current_ledger + renewal_point, last_extended, max_ttl));
+        assert!(should_renew_key(
+            current_ledger + renewal_point,
+            last_extended,
+            max_ttl
+        ));
     }
 
     #[test]
@@ -261,6 +257,9 @@ mod tests {
         let last_extended = current_ledger - (max_ttl as u64) * 6 / 10;
 
         let risk = compute_expiry_risk(current_ledger, last_extended, max_ttl);
-        assert!(risk.at_risk_keys > 0 || risk.imminent_keys > 0, "Should detect at-risk keys");
+        assert!(
+            risk.at_risk_keys > 0 || risk.imminent_keys > 0,
+            "Should detect at-risk keys"
+        );
     }
 }

--- a/contracts/prompt-hash/src/ttl_test.rs
+++ b/contracts/prompt-hash/src/ttl_test.rs
@@ -53,7 +53,7 @@ mod tests {
         let last_extended = 100_000u64;
 
         let remaining = get_time_remaining(current, last_extended, max_ttl);
-        let expected = (last_extended as u64 + max_ttl as u64) - current;
+        let expected = (last_extended + max_ttl as u64) - current;
 
         assert_eq!(remaining, expected);
     }
@@ -78,6 +78,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::assertions_on_constants)]
     fn test_batch_size_respected() {
         assert!(MAX_RENEWAL_BATCH_SIZE > 0, "Batch size must be positive");
         assert!(

--- a/contracts/prompt-hash/src/ttl_test.rs
+++ b/contracts/prompt-hash/src/ttl_test.rs
@@ -12,7 +12,10 @@ mod tests {
         let purchase_ttl = get_ttl_for_key(&DataKey::Purchase(1, addr.clone()));
         let dispute_ttl = get_ttl_for_key(&DataKey::PurchaseDispute(1, addr));
 
-        assert!(purchase_ttl > dispute_ttl, "Purchases must have longer TTL than disputes");
+        assert!(
+            purchase_ttl > dispute_ttl,
+            "Purchases must have longer TTL than disputes"
+        );
     }
 
     #[test]
@@ -22,7 +25,10 @@ mod tests {
         let catalog_pass_ttl = get_ttl_for_key(&DataKey::CatalogPass(addr.clone(), addr.clone()));
         let escrow_ttl = get_ttl_for_key(&DataKey::PurchaseEscrow(1, addr));
 
-        assert!(catalog_pass_ttl >= escrow_ttl, "Entitlements must outlive escrow");
+        assert!(
+            catalog_pass_ttl >= escrow_ttl,
+            "Entitlements must outlive escrow"
+        );
     }
 
     #[test]
@@ -65,7 +71,10 @@ mod tests {
         // At risk (80% through lifetime, only 20% of the TTL remains)
         let risky_extended = current - (max_ttl as u64) * 4 / 5;
         let risk = compute_expiry_risk(current, risky_extended, max_ttl);
-        assert!(risk.at_risk_keys > 0 || risk.imminent_keys > 0, "Should flag at-risk key");
+        assert!(
+            risk.at_risk_keys > 0 || risk.imminent_keys > 0,
+            "Should flag at-risk key"
+        );
     }
 
     #[test]

--- a/contracts/prompt-hash/src/ttl_test.rs
+++ b/contracts/prompt-hash/src/ttl_test.rs
@@ -2,28 +2,25 @@
 mod tests {
     use crate::ttl_policy::*;
     use crate::types::DataKey;
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::{Address, Env};
 
     #[test]
     fn test_purchase_has_longer_ttl_than_dispute() {
-        let purchase_ttl = get_ttl_for_key(&DataKey::Purchase(1, unsafe {
-            std::mem::transmute([0u8; 32])
-        }));
-        let dispute_ttl = get_ttl_for_key(&DataKey::PurchaseDispute(1, unsafe {
-            std::mem::transmute([0u8; 32])
-        }));
+        let env = Env::default();
+        let addr = Address::generate(&env);
+        let purchase_ttl = get_ttl_for_key(&DataKey::Purchase(1, addr.clone()));
+        let dispute_ttl = get_ttl_for_key(&DataKey::PurchaseDispute(1, addr));
 
         assert!(purchase_ttl > dispute_ttl, "Purchases must have longer TTL than disputes");
     }
 
     #[test]
     fn test_entitlement_outlives_escrow() {
-        let catalog_pass_ttl = get_ttl_for_key(&DataKey::CatalogPass(
-            unsafe { std::mem::transmute([0u8; 32]) },
-            unsafe { std::mem::transmute([0u8; 32]) },
-        ));
-        let escrow_ttl = get_ttl_for_key(&DataKey::PurchaseEscrow(1, unsafe {
-            std::mem::transmute([0u8; 32])
-        }));
+        let env = Env::default();
+        let addr = Address::generate(&env);
+        let catalog_pass_ttl = get_ttl_for_key(&DataKey::CatalogPass(addr.clone(), addr.clone()));
+        let escrow_ttl = get_ttl_for_key(&DataKey::PurchaseEscrow(1, addr));
 
         assert!(catalog_pass_ttl >= escrow_ttl, "Entitlements must outlive escrow");
     }
@@ -65,8 +62,8 @@ mod tests {
         assert_eq!(risk.critical_keys, 0);
         assert_eq!(risk.imminent_keys, 0);
 
-        // At risk (80% through lifetime)
-        let risky_extended = current - (max_ttl as u64) / 5;
+        // At risk (80% through lifetime, only 20% of the TTL remains)
+        let risky_extended = current - (max_ttl as u64) * 4 / 5;
         let risk = compute_expiry_risk(current, risky_extended, max_ttl);
         assert!(risk.at_risk_keys > 0 || risk.imminent_keys > 0, "Should flag at-risk key");
     }

--- a/contracts/prompt-hash/src/types.rs
+++ b/contracts/prompt-hash/src/types.rs
@@ -1,4 +1,6 @@
-use soroban_sdk::{contracterror, contracttype, Address, Bytes, BytesN, Env, String, Vec};
+use soroban_sdk::{
+    contracterror, contracttype, xdr::ToXdr, Address, Bytes, BytesN, Env, IntoVal, String, Vec,
+};
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -441,11 +443,11 @@ impl SignedDiscountAuthorization {
         buf.push_back(self.network_id.to_val());
         buf.push_back(self.contract_id.to_val());
         // Payload: prompt_id || buyer || discount_bps || nonce || expiry_ledger
-        buf.push_back((self.prompt_id as u128).into_val());
+        buf.push_back((self.prompt_id as u128).into_val(env));
         buf.push_back(self.buyer.to_val());
-        buf.push_back((self.discount_bps as u128).into_val());
+        buf.push_back((self.discount_bps as u128).into_val(env));
         buf.push_back(self.nonce.to_val());
-        buf.push_back((self.expiry_ledger as u128).into_val());
+        buf.push_back((self.expiry_ledger as u128).into_val(env));
         let raw = env.crypto().sha256(&buf.to_xdr(env));
         BytesN::from_array(env, &raw.to_array())
     }
@@ -813,7 +815,7 @@ pub trait PromptHashTrait {
         cursor: Option<String>,
         limit: u64,
     ) -> Result<(Vec<Prompt>, Option<String>), Error>;
-    fn get_prompts_by_category_paginated(
+    fn get_prompts_by_category_page(
         env: Env,
         category: String,
         cursor: Option<String>,

--- a/contracts/prompt-hash/src/types.rs
+++ b/contracts/prompt-hash/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracterror, contracttype, crypto::Crypto, Address, Bytes, BytesN, Env, String, Vec};
+use soroban_sdk::{contracterror, contracttype, Address, Bytes, BytesN, Env, String, Vec};
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -103,6 +103,10 @@ pub enum Error {
     GovernanceStateMismatch = 81,
     GovernanceNonceConsumed = 82,
     InvalidGovernanceDelay = 83,
+
+    MaxSupplyBelowCommitted = 84,
+    DisputeWindowClosed = 85,
+    DisputeWindowNotElapsed = 86,
 }
 
 #[contracttype]
@@ -223,6 +227,10 @@ pub struct PurchaseEscrow {
     pub status: SettlementStatus,
     pub created_at: u64,
     pub settled_at: u64, // 0 if not yet settled
+    /// Deadline (unix timestamp) by which a buyer must open a dispute.
+    /// After this passes with no open dispute, settlement becomes
+    /// permissionless (#541).
+    pub dispute_deadline: u64,
     pub asset: Address,
     pub referrer: Option<Address>,
     pub creator_amount: i128,
@@ -376,11 +384,13 @@ pub struct AccessPass {
     pub duration_secs: u64,
     pub price_stroops: i128,
     pub asset: Address,
-    pub active: bool,
+    pub status: PromptSaleStatus,
     pub sales_count: u32,
     pub max_supply: u32,
 }
 
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CatalogPassPurchase {
     pub creator: Address,
     pub buyer: Address,
@@ -712,6 +722,7 @@ pub trait PromptHashTrait {
 
     fn get_bundles_by_creator(env: Env, creator: Address) -> Result<Vec<Bundle>, Error>;
 
+    #[allow(clippy::too_many_arguments)]
     fn create_access_pass(
         env: Env,
         creator: Address,
@@ -719,7 +730,26 @@ pub trait PromptHashTrait {
         duration_secs: u64,
         price_stroops: i128,
         asset: Address,
+        // Maximum number of active pass grants this pass can issue (0 = unlimited).
+        max_supply: u32,
     ) -> Result<u128, Error>;
+
+    /// Pause, reactivate, or retire an access pass. Existing buyer grants are
+    /// unaffected — they follow their own stored `expires_at` regardless of
+    /// the pass's current status (#539).
+    fn set_access_pass_status(
+        env: Env,
+        creator: Address,
+        pass_id: u128,
+        status: PromptSaleStatus,
+    ) -> Result<(), Error>;
+
+    fn update_access_pass_price(
+        env: Env,
+        creator: Address,
+        pass_id: u128,
+        price_stroops: i128,
+    ) -> Result<(), Error>;
 
     fn buy_access_pass(
         env: Env,
@@ -776,6 +806,35 @@ pub trait PromptHashTrait {
     fn get_all_prompts(env: Env) -> Result<Vec<Prompt>, Error>;
     fn get_prompts_by_category(env: Env, category: String) -> Result<Vec<Prompt>, Error>;
     fn get_prompts_by_tag(env: Env, tag: String) -> Result<Vec<Prompt>, Error>;
+
+    // Paginated catalog queries (bounded, respects resource limits).
+    fn get_all_prompts_paginated(
+        env: Env,
+        cursor: Option<String>,
+        limit: u64,
+    ) -> Result<(Vec<Prompt>, Option<String>), Error>;
+    fn get_prompts_by_category_paginated(
+        env: Env,
+        category: String,
+        cursor: Option<String>,
+        limit: u64,
+    ) -> Result<(Vec<Prompt>, Option<String>), Error>;
+    fn get_prompts_by_tag_paginated(
+        env: Env,
+        tag: String,
+        cursor: Option<String>,
+        limit: u64,
+    ) -> Result<(Vec<Prompt>, Option<String>), Error>;
+    fn get_active_prompts_paginated(
+        env: Env,
+        cursor: Option<String>,
+        limit: u64,
+    ) -> Result<(Vec<Prompt>, Option<String>), Error>;
+
+    // TTL maintenance (operator utilities).
+    fn renew_critical_keys(env: Env, cursor: Option<u64>) -> Result<(u32, Option<u64>), Error>;
+    fn get_expiry_risk_metrics(env: Env) -> Result<Vec<(String, String)>, Error>;
+
     fn open_dispute(
         env: Env,
         buyer: Address,
@@ -805,6 +864,8 @@ pub trait PromptHashTrait {
     fn get_prompts_by_buyer(env: Env, buyer: Address) -> Result<Vec<Prompt>, Error>;
     fn set_fee_wallet(env: Env, new_fee_wallet: Address) -> Result<(), Error>;
     fn get_fee_wallet(env: Env) -> Option<Address>;
+    fn set_fee_percentage(env: Env, new_fee_percentage: u32) -> Result<(), Error>;
+    fn get_fee_percentage(env: Env) -> u32;
     fn set_referral_percentage(env: Env, new_referral_percentage: u32) -> Result<(), Error>;
     fn get_referral_percentage(env: Env) -> u32;
     // New platform fee governance API

--- a/contracts/prompt-hash/src/types.rs
+++ b/contracts/prompt-hash/src/types.rs
@@ -148,10 +148,10 @@ pub enum DataKey {
     Prompt(u64),
     CreatorPrompts(Address),
     BuyerPrompts(Address),
-    CategoryPrompts(String),      // Index: category → Vec<prompt_ids>
-    TagPrompts(String),            // Index: tag → Vec<prompt_ids>
-    ActivePrompts,                 // Index: all active → Vec<prompt_ids>
-    AllPrompts,                    // Index: all → Vec<prompt_ids>
+    CategoryPrompts(String), // Index: category → Vec<prompt_ids>
+    TagPrompts(String),      // Index: tag → Vec<prompt_ids>
+    ActivePrompts,           // Index: all active → Vec<prompt_ids>
+    AllPrompts,              // Index: all → Vec<prompt_ids>
     Purchase(u64, Address),
     PurchaseEscrow(u64, Address), // Settlement tracking for refunds (#420)
     VoucherKey(u64, BytesN<32>),
@@ -215,9 +215,9 @@ pub enum DisputeReason {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SettlementStatus {
-    Pending,   // Purchase received, awaiting settlement
-    Settled,   // Payment distributed successfully
-    Refunded,  // Purchase refunded atomically
+    Pending,  // Purchase received, awaiting settlement
+    Settled,  // Payment distributed successfully
+    Refunded, // Purchase refunded atomically
 }
 
 #[contracttype]
@@ -857,11 +857,7 @@ pub trait PromptHashTrait {
         prompt_id: u64,
         buyer: Address,
     ) -> Result<(), Error>;
-    fn get_purchase_escrow(
-        env: Env,
-        prompt_id: u64,
-        buyer: Address,
-    ) -> Option<PurchaseEscrow>;
+    fn get_purchase_escrow(env: Env, prompt_id: u64, buyer: Address) -> Option<PurchaseEscrow>;
     fn get_prompts_by_creator(env: Env, creator: Address) -> Result<Vec<Prompt>, Error>;
     fn get_prompts_by_buyer(env: Env, buyer: Address) -> Result<Vec<Prompt>, Error>;
     fn set_fee_wallet(env: Env, new_fee_wallet: Address) -> Result<(), Error>;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.91.0"
 targets = ["wasm32v1-none"]
 components = ["rustfmt", "clippy"]

--- a/server/src/controllers/controllers.ts
+++ b/server/src/controllers/controllers.ts
@@ -421,18 +421,12 @@ export const GetPromptReports = async (
   res: Response,
 ): Promise<Response<any>> => {
   try {
+    // Admin authentication and authorization is enforced by the
+    // `requireAdminScope("reports:read")` middleware mounted on this route
+    // (#542) — this handler only runs once that has already succeeded.
     await connectDb();
 
-    // Check admin authentication (placeholder)
-    const adminToken = req.headers.authorization?.split(" ")[1];
-    if (!adminToken) {
-      return res.status(401).json({
-        error: "Unauthorized: Admin token required",
-      });
-    }
-
-    const { searchParams } = new URL(req.url);
-    const promptId = searchParams.get("promptId");
+    const promptId = typeof req.query.promptId === "string" ? req.query.promptId : undefined;
 
     const query: any = {};
     if (promptId) {

--- a/server/src/middleware/adminAuth.ts
+++ b/server/src/middleware/adminAuth.ts
@@ -1,0 +1,115 @@
+/**
+ * Admin authentication and authorization middleware (#542).
+ *
+ * Replaces the "any bearer token present == admin" placeholder that used
+ * to guard integrity, report, and moderation endpoints. Every route that
+ * needs privileged access should mount `requireAdminScope("<scope>")`
+ * ahead of its handler — the handler itself no longer needs to know
+ * anything about authentication.
+ *
+ * A request is admitted only if its `Authorization: Bearer <token>` token:
+ *   - has a valid HMAC signature under a currently-active admin secret,
+ *   - carries `role: "admin"`,
+ *   - was issued for this environment's audience,
+ *   - has not expired,
+ *   - has not been revoked, and
+ *   - carries the scope the route requires.
+ *
+ * Every allow/deny decision is recorded through the existing audit trail
+ * so privileged access leaves tamper-evident evidence (#224/#542).
+ */
+
+import { Request, Response, NextFunction } from "express";
+import {
+  AdminTokenError,
+  AdminTokenPayload,
+  verifyAdminToken,
+} from "../services/adminToken";
+import { recordAuditEvent } from "../services/auditTrail";
+
+export interface AdminRequest extends Request {
+  admin?: AdminTokenPayload;
+  requestId?: string | null;
+}
+
+function isConfiguredSecret(value: string | undefined): value is string {
+  return Boolean(value) && value!.length >= 16;
+}
+
+function getActiveAdminSecrets(): string[] {
+  return [process.env.ADMIN_TOKEN_SECRET, process.env.ADMIN_TOKEN_SECRET_PREVIOUS].filter(
+    isConfiguredSecret,
+  );
+}
+
+function getAdminAudience(): string {
+  return process.env.ADMIN_TOKEN_AUDIENCE || "prompt-hash-admin";
+}
+
+function clientIpOf(req: Request): string {
+  return String(req.headers["x-forwarded-for"] || req.socket?.remoteAddress || "unknown");
+}
+
+/**
+ * Express middleware factory. `requiredScope` should be the narrowest
+ * permission the route actually needs (e.g. `"integrity:read"` for a
+ * read-only report, `"integrity:write"` for a mutating action) so a leaked
+ * read-only token can't be used to trigger writes.
+ */
+export function requireAdminScope(requiredScope: string) {
+  return async function adminAuthMiddleware(
+    req: AdminRequest,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> {
+    const route = `${req.method} ${req.baseUrl}${req.path}`;
+    const secrets = getActiveAdminSecrets();
+
+    if (secrets.length === 0) {
+      // Fail closed: an unconfigured secret must never fall back to "any
+      // token accepted", which is exactly the bug this middleware exists
+      // to fix.
+      console.error("ADMIN_TOKEN_SECRET is not configured; denying admin request.");
+      res.status(503).json({ error: "Admin authentication is not configured." });
+      return;
+    }
+
+    const authHeader = req.headers.authorization;
+    const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7).trim() : undefined;
+
+    if (!token) {
+      res.status(401).json({ error: "Unauthorized: admin bearer token required." });
+      return;
+    }
+
+    try {
+      const payload = verifyAdminToken(secrets, token, {
+        audience: getAdminAudience(),
+        requiredScope,
+      });
+      req.admin = payload;
+      void recordAuditEvent({
+        action: "admin_auth_success",
+        result: "success",
+        promptId: null,
+        walletAddress: null,
+        requestId: req.requestId ?? null,
+        clientIp: clientIpOf(req),
+        reason: `sub=${payload.sub} scope=${requiredScope} route=${route}`,
+      });
+      next();
+    } catch (err) {
+      const code = err instanceof AdminTokenError ? err.code : "unknown_error";
+      void recordAuditEvent({
+        action: "admin_auth_denied",
+        result: "blocked",
+        promptId: null,
+        walletAddress: null,
+        requestId: req.requestId ?? null,
+        clientIp: clientIpOf(req),
+        reason: `scope=${requiredScope} route=${route} error=${code}`,
+      });
+      res.status(401).json({ error: "Unauthorized: invalid or insufficient admin token." });
+    }
+  };
+}

--- a/server/src/models/AuditLog.ts
+++ b/server/src/models/AuditLog.ts
@@ -9,7 +9,9 @@ export type AuditAction =
   | "unlock_no_access"
   | "unlock_integrity_failure"
   | "unlock_error"
-  | "unlock_rate_limited";
+  | "unlock_rate_limited"
+  | "admin_auth_success"
+  | "admin_auth_denied";
 
 export type AuditResult = "success" | "failure" | "blocked";
 
@@ -28,6 +30,8 @@ const auditLogSchema = new mongoose.Schema(
         "unlock_integrity_failure",
         "unlock_error",
         "unlock_rate_limited",
+        "admin_auth_success",
+        "admin_auth_denied",
       ] as AuditAction[],
       index: true,
     },

--- a/server/src/routes/fulfillmentRoutes.ts
+++ b/server/src/routes/fulfillmentRoutes.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from "express";
 import FulfillmentRecord, {
   FulfillmentStatus,
 } from "../models/FulfillmentRecord";
+import { requireAdminScope } from "../middleware/adminAuth";
 
 export const fulfillmentRouter = Router();
 
@@ -131,6 +132,7 @@ fulfillmentRouter.post(
  */
 fulfillmentRouter.post(
   "/:promptId/:buyerWallet/resolve",
+  requireAdminScope("fulfillment:resolve"),
   async (req: Request, res: Response) => {
     const { promptId, buyerWallet } = req.params;
     const { refund, resolutionTxHash } = req.body as {
@@ -175,20 +177,28 @@ fulfillmentRouter.post(
  * Returns all records with status=refund_requested.
  * Intended for admin dashboards.
  */
-fulfillmentRouter.get("/pending-refunds", async (_req, res: Response) => {
-  const records = await FulfillmentRecord.find({
-    status: "refund_requested",
-  }).sort({ updatedAt: -1 });
-  res.json(records);
-});
+fulfillmentRouter.get(
+  "/pending-refunds",
+  requireAdminScope("fulfillment:read"),
+  async (_req, res: Response) => {
+    const records = await FulfillmentRecord.find({
+      status: "refund_requested",
+    }).sort({ updatedAt: -1 });
+    res.json(records);
+  },
+);
 
 /**
  * POST /api/fulfillment/auto-refund-sweep
  * Marks all purchases that are still `pending` or `failed` after the
  * timeout window as `refund_requested`.  Intended to be called by a
- * cron job or a scheduled task (#335).
+ * cron job or a scheduled task (#335). Bulk-mutates many records, so it
+ * requires the same admin/service scope as other recovery actions (#542).
  */
-fulfillmentRouter.post("/auto-refund-sweep", async (_req, res: Response) => {
+fulfillmentRouter.post(
+  "/auto-refund-sweep",
+  requireAdminScope("fulfillment:sweep"),
+  async (_req, res: Response) => {
   const timeoutMs = parseInt(
     process.env.FULFILLMENT_TIMEOUT_MS ?? "600000",
     10,
@@ -213,4 +223,5 @@ fulfillmentRouter.post("/auto-refund-sweep", async (_req, res: Response) => {
   );
 
   res.json({ swept: result.modifiedCount });
-});
+  },
+);

--- a/server/src/routes/promptRoutes.ts
+++ b/server/src/routes/promptRoutes.ts
@@ -73,8 +73,7 @@ promptRouter.get(
   requireAdminScope("integrity:read"),
   GetIntegrityReport,
 );
-promptRouter.post(
-  "/admin/integrity-check",
+promptRouter.post("/admin/integrity-check",
   requireAdminScope("integrity:write"),
   TriggerIntegrityCheck,
 );

--- a/server/src/routes/promptRoutes.ts
+++ b/server/src/routes/promptRoutes.ts
@@ -19,6 +19,7 @@ import {
   GetIntegrityReport,
   TriggerIntegrityCheck,
 } from "../controllers/purchaseControllers";
+import { requireAdminScope } from "../middleware/adminAuth";
 
 export const promptRouter = express.Router();
 
@@ -57,16 +58,26 @@ promptRouter.get("/creator/:walletAddress/drafts", GetDraftPrompts);
 promptRouter.post("/preview", RecordPreview);
 promptRouter.get("/preview/stats", GetPreviewStats);
 
-// Report endpoints — off-chain moderation data, does not affect access control
+// Report endpoints — off-chain moderation data, does not affect access control.
+// Submission is public (anyone can flag a listing); reading the queue is a
+// moderation action and requires an admin token (#542).
 promptRouter.post("/reports", SubmitPromptReport);
-promptRouter.get("/reports", GetPromptReports);
+promptRouter.get("/reports", requireAdminScope("reports:read"), GetPromptReports);
 
 // Price history — derived from indexed PromptPriceUpdated events
 promptRouter.get("/:onChainId/price-history", GetPriceHistory);
 
-// Content integrity rechecks (#460)
-promptRouter.get("/admin/integrity-report", GetIntegrityReport);
-promptRouter.post("/admin/integrity-check", TriggerIntegrityCheck);
+// Content integrity rechecks (#460) — admin-only (#542)
+promptRouter.get(
+  "/admin/integrity-report",
+  requireAdminScope("integrity:read"),
+  GetIntegrityReport,
+);
+promptRouter.post(
+  "/admin/integrity-check",
+  requireAdminScope("integrity:write"),
+  TriggerIntegrityCheck,
+);
 
 // ── User Preference (non-authoritative, wallet-signature required) ────────────
 promptRouter.post("/buyer/save", SavePrompt);

--- a/server/src/services/adminToken.ts
+++ b/server/src/services/adminToken.ts
@@ -1,0 +1,192 @@
+/**
+ * Admin session tokens (#542).
+ *
+ * Signed, expiring, scope-bound bearer tokens for privileged server
+ * operations (integrity checks, moderation reports, secret rotation,
+ * fulfillment recovery). Deliberately mirrors the HMAC token shape in
+ * `src/lib/auth/challenge.ts` — same signing primitive, same
+ * rotation-friendly multi-secret verification — but carries admin-specific
+ * claims (role, scope, issuer, audience) instead of a buyer/promptId
+ * binding. Kept as its own copy under `server/src` (rather than imported
+ * from the root `src/lib`) because this package's tsconfig `rootDir` only
+ * covers `server/src`.
+ *
+ * Tokens are minted out-of-band by whoever holds `ADMIN_TOKEN_SECRET`
+ * (an operator CLI/script), not through a public HTTP endpoint — this
+ * service has no staff-account database to authenticate a login request
+ * against.
+ */
+
+import { createHmac, randomUUID, timingSafeEqual } from "crypto";
+import { Buffer } from "buffer";
+
+const DEFAULT_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+export interface AdminTokenPayload {
+  /** Operator identifier, e.g. "ops-jane". Never a secret. */
+  sub: string;
+  role: "admin";
+  /** Granted scopes, e.g. ["integrity:read", "integrity:write"]. */
+  scope: string[];
+  /** Who minted this token (informational, included in the signed payload). */
+  iss: string;
+  /** Which deployment/environment this token is valid for. */
+  aud: string;
+  nonce: string;
+  issuedAt: number;
+  expiresAt: number;
+}
+
+export type AdminTokenErrorCode =
+  | "malformed"
+  | "invalid_signature"
+  | "wrong_role"
+  | "wrong_audience"
+  | "missing_issuer"
+  | "expired"
+  | "revoked"
+  | "insufficient_scope";
+
+export class AdminTokenError extends Error {
+  constructor(
+    public readonly code: AdminTokenErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "AdminTokenError";
+  }
+}
+
+function base64UrlEncode(value: string) {
+  return Buffer.from(value, "utf8")
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+function base64UrlDecode(value: string) {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = normalized.length % 4 === 0 ? "" : "=".repeat(4 - (normalized.length % 4));
+  return Buffer.from(`${normalized}${padding}`, "base64").toString("utf8");
+}
+
+function signPayload(secret: string, body: string) {
+  return createHmac("sha256", secret).update(body).digest("base64url");
+}
+
+export function createAdminToken(
+  secret: string,
+  params: { sub: string; scope: string[]; iss: string; aud: string; ttlMs?: number },
+  now = Date.now(),
+): { token: string; payload: AdminTokenPayload } {
+  const payload: AdminTokenPayload = {
+    sub: params.sub,
+    role: "admin",
+    scope: params.scope,
+    iss: params.iss,
+    aud: params.aud,
+    nonce: randomUUID(),
+    issuedAt: now,
+    expiresAt: now + (params.ttlMs ?? DEFAULT_TTL_MS),
+  };
+
+  const encodedPayload = base64UrlEncode(JSON.stringify(payload));
+  const signature = signPayload(secret, encodedPayload);
+
+  return { token: `${encodedPayload}.${signature}`, payload };
+}
+
+/**
+ * In-process revocation list, keyed by token nonce. A revoked token is
+ * rejected immediately regardless of its stated expiry — the mechanism a
+ * compromised or decommissioned operator token needs to be cut off before
+ * it naturally expires.
+ *
+ * Production deployments running multiple instances should back this with
+ * a shared store (Redis); for single-instance deploys and tests the
+ * in-memory set is sufficient (matches `NonceLedger` in
+ * `src/lib/auth/challenge.ts`).
+ */
+const revokedTokenIds = new Set<string>();
+
+export function revokeAdminToken(nonce: string): void {
+  revokedTokenIds.add(nonce);
+}
+
+export function isAdminTokenRevoked(nonce: string): boolean {
+  return revokedTokenIds.has(nonce);
+}
+
+/** Test-only: clear the revocation set between test cases. */
+export function __clearRevokedAdminTokensForTests(): void {
+  revokedTokenIds.clear();
+}
+
+/**
+ * Verify an admin bearer token's signature, expiry, issuer/audience
+ * binding, role, and required scope. Throws `AdminTokenError` with a
+ * stable `code` on any failure so callers can log a reason without
+ * leaking token contents.
+ */
+export function verifyAdminToken(
+  secrets: string | string[],
+  token: string,
+  opts: { audience: string; requiredScope: string },
+  now = Date.now(),
+): AdminTokenPayload {
+  const parts = token.split(".");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    throw new AdminTokenError("malformed", "Malformed admin token.");
+  }
+  const [encodedPayload, signature] = parts;
+
+  const secretList = (Array.isArray(secrets) ? secrets : [secrets]).filter(Boolean);
+  let validSignature = false;
+  for (const sec of secretList) {
+    const expectedSignature = signPayload(sec, encodedPayload);
+    const received = Buffer.from(signature, "utf8");
+    const expected = Buffer.from(expectedSignature, "utf8");
+    if (received.length === expected.length && timingSafeEqual(received, expected)) {
+      validSignature = true;
+      break;
+    }
+  }
+  if (!validSignature) {
+    throw new AdminTokenError("invalid_signature", "Invalid admin token signature.");
+  }
+
+  let payload: AdminTokenPayload;
+  try {
+    payload = JSON.parse(base64UrlDecode(encodedPayload)) as AdminTokenPayload;
+  } catch {
+    throw new AdminTokenError("malformed", "Malformed admin token payload.");
+  }
+
+  if (payload.role !== "admin") {
+    throw new AdminTokenError("wrong_role", "Token does not carry the admin role.");
+  }
+  if (!payload.iss) {
+    throw new AdminTokenError("missing_issuer", "Token is missing an issuer.");
+  }
+  // Binds a token to the environment it was minted for, so a token issued
+  // for staging cannot be replayed against production (confused-deputy /
+  // cross-environment reuse).
+  if (payload.aud !== opts.audience) {
+    throw new AdminTokenError("wrong_audience", "Token audience does not match this environment.");
+  }
+  if (payload.expiresAt < now) {
+    throw new AdminTokenError("expired", "Admin token has expired.");
+  }
+  if (isAdminTokenRevoked(payload.nonce)) {
+    throw new AdminTokenError("revoked", "Admin token has been revoked.");
+  }
+  if (!Array.isArray(payload.scope) || !payload.scope.includes(opts.requiredScope)) {
+    throw new AdminTokenError(
+      "insufficient_scope",
+      `Token lacks required scope: ${opts.requiredScope}`,
+    );
+  }
+
+  return payload;
+}

--- a/server/src/tests/adminAuth.test.ts
+++ b/server/src/tests/adminAuth.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type { Response } from "express";
+
+vi.mock("../services/auditTrail", () => ({
+  recordAuditEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+// The route-inventory tests below import the real route modules to inspect
+// their middleware chains. Those modules transitively pull in notification
+// services with dependencies this test has no need to exercise (and, for
+// nodemailer, isn't even declared in package.json) — stub them out so the
+// import succeeds without requiring real credentials or network access.
+vi.mock("../services/emailNotifications", () => ({
+  notifyPromptReported: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../services/discordNotifications", () => ({
+  announceNewPrompt: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { requireAdminScope, AdminRequest } from "../middleware/adminAuth";
+import { createAdminToken } from "../services/adminToken";
+import { recordAuditEvent } from "../services/auditTrail";
+
+const AUDIENCE = "prompt-hash-admin-test";
+
+function makeReq(headers: Record<string, string> = {}): AdminRequest {
+  return {
+    headers,
+    method: "GET",
+    baseUrl: "/api/prompts",
+    path: "/admin/integrity-report",
+    socket: { remoteAddress: "127.0.0.1" },
+  } as unknown as AdminRequest;
+}
+
+function makeRes(): Response {
+  const res: any = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  return res as Response;
+}
+
+describe("requireAdminScope middleware (#542)", () => {
+  const originalSecret = process.env.ADMIN_TOKEN_SECRET;
+  const originalPrevious = process.env.ADMIN_TOKEN_SECRET_PREVIOUS;
+  const originalAudience = process.env.ADMIN_TOKEN_AUDIENCE;
+
+  beforeEach(() => {
+    process.env.ADMIN_TOKEN_SECRET = "a-sufficiently-long-admin-secret";
+    delete process.env.ADMIN_TOKEN_SECRET_PREVIOUS;
+    process.env.ADMIN_TOKEN_AUDIENCE = AUDIENCE;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env.ADMIN_TOKEN_SECRET = originalSecret;
+    process.env.ADMIN_TOKEN_SECRET_PREVIOUS = originalPrevious;
+    process.env.ADMIN_TOKEN_AUDIENCE = originalAudience;
+  });
+
+  it("calls next() and attaches the admin payload for a valid, correctly-scoped token", async () => {
+    const { token } = createAdminToken(process.env.ADMIN_TOKEN_SECRET!, {
+      sub: "ops-jane",
+      scope: ["integrity:read"],
+      iss: "ops-cli",
+      aud: AUDIENCE,
+    });
+    const req = makeReq({ authorization: `Bearer ${token}` });
+    const res = makeRes();
+    const next = vi.fn();
+
+    await requireAdminScope("integrity:read")(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(req.admin?.sub).toBe("ops-jane");
+    expect(res.status).not.toHaveBeenCalled();
+    expect(recordAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "admin_auth_success", result: "success" }),
+    );
+  });
+
+  it("rejects a request with no Authorization header", async () => {
+    const req = makeReq();
+    const res = makeRes();
+    const next = vi.fn();
+
+    await requireAdminScope("integrity:read")(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it("rejects a bare random bearer string the same way a normal session would be rejected", async () => {
+    const req = makeReq({ authorization: "Bearer some-random-user-session-token" });
+    const res = makeRes();
+    const next = vi.fn();
+
+    await requireAdminScope("integrity:read")(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(recordAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "admin_auth_denied", result: "blocked" }),
+    );
+  });
+
+  it("rejects a valid token that lacks the scope this route requires", async () => {
+    const { token } = createAdminToken(process.env.ADMIN_TOKEN_SECRET!, {
+      sub: "ops-jane",
+      scope: ["reports:read"], // no integrity:write
+      iss: "ops-cli",
+      aud: AUDIENCE,
+    });
+    const req = makeReq({ authorization: `Bearer ${token}` });
+    const res = makeRes();
+    const next = vi.fn();
+
+    await requireAdminScope("integrity:write")(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it("fails closed (503) when ADMIN_TOKEN_SECRET is not configured, rather than admitting every request", async () => {
+    delete process.env.ADMIN_TOKEN_SECRET;
+    const req = makeReq({ authorization: "Bearer anything" });
+    const res = makeRes();
+    const next = vi.fn();
+
+    await requireAdminScope("integrity:read")(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(503);
+  });
+
+  it("rejects a token minted for a different deployment audience", async () => {
+    const { token } = createAdminToken(process.env.ADMIN_TOKEN_SECRET!, {
+      sub: "ops-jane",
+      scope: ["integrity:read"],
+      iss: "ops-cli",
+      aud: "some-other-deployment",
+    });
+    const req = makeReq({ authorization: `Bearer ${token}` });
+    const res = makeRes();
+    const next = vi.fn();
+
+    await requireAdminScope("integrity:read")(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+});
+
+describe("route inventory: every privileged endpoint carries the admin guard (#542)", () => {
+  it("mounts requireAdminScope ahead of the handler for every admin-only prompt route", async () => {
+    // Importing promptRoutes pulls in controllers.ts and its large
+    // dependency graph (ai, mongoose, etc.), which esbuild/Vite must
+    // transform on first import — allow more time than the default.
+    process.env.MONGODB_URI ||= "mongodb://127.0.0.1:27017/prompt-hash-stellar-test";
+    const { promptRouter } = await import("../routes/promptRoutes");
+    const guardedRoutes: Array<{ method: string; path: string }> = [
+      { method: "get", path: "/reports" },
+      { method: "get", path: "/admin/integrity-report" },
+      { method: "post", path: "/admin/integrity-check" },
+    ];
+
+    for (const { method, path } of guardedRoutes) {
+      const layer = (promptRouter as any).stack.find(
+        (entry: any) => entry.route?.path === path && entry.route.methods[method],
+      );
+      expect(layer, `route ${method.toUpperCase()} ${path} should be registered`).toBeTruthy();
+
+      const handlerNames = layer.route.stack.map((s: any) => s.name);
+      expect(
+        handlerNames,
+        `route ${method.toUpperCase()} ${path} is missing the admin auth guard in its middleware chain`,
+      ).toContain("adminAuthMiddleware");
+    }
+  }, 20_000);
+
+  it("mounts requireAdminScope ahead of the handler for every admin-only fulfillment route", async () => {
+    const { fulfillmentRouter } = await import("../routes/fulfillmentRoutes");
+    const guardedPaths = ["/:promptId/:buyerWallet/resolve", "/pending-refunds", "/auto-refund-sweep"];
+
+    for (const path of guardedPaths) {
+      const layer = (fulfillmentRouter as any).stack.find(
+        (entry: any) => entry.route?.path === path,
+      );
+      expect(layer, `route ${path} should be registered`).toBeTruthy();
+
+      const handlerNames = layer.route.stack.map((s: any) => s.name);
+      expect(
+        handlerNames,
+        `route ${path} is missing the admin auth guard in its middleware chain`,
+      ).toContain("adminAuthMiddleware");
+    }
+  });
+});

--- a/server/src/tests/adminToken.test.ts
+++ b/server/src/tests/adminToken.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+  AdminTokenError,
+  createAdminToken,
+  isAdminTokenRevoked,
+  revokeAdminToken,
+  verifyAdminToken,
+  __clearRevokedAdminTokensForTests,
+} from "../services/adminToken";
+
+const SECRET = "unit-test-admin-secret";
+const OTHER_SECRET = "a-completely-different-secret";
+const AUDIENCE = "prompt-hash-admin-test";
+const ISSUED_AT = 1_700_000_000_000;
+
+function mint(scope: string[], ttlMs = 60_000, secret = SECRET) {
+  return createAdminToken(
+    secret,
+    { sub: "ops-jane", scope, iss: "ops-cli", aud: AUDIENCE, ttlMs },
+    ISSUED_AT,
+  );
+}
+
+beforeEach(() => {
+  __clearRevokedAdminTokensForTests();
+});
+
+describe("admin token verification (#542)", () => {
+  it("accepts a well-formed token carrying the required scope", () => {
+    const { token } = mint(["integrity:read", "reports:read"]);
+    const payload = verifyAdminToken(
+      SECRET,
+      token,
+      { audience: AUDIENCE, requiredScope: "integrity:read" },
+      ISSUED_AT + 1_000,
+    );
+    expect(payload.sub).toBe("ops-jane");
+    expect(payload.role).toBe("admin");
+    expect(payload.scope).toContain("integrity:read");
+  });
+
+  it("rejects a token missing the required scope", () => {
+    const { token } = mint(["reports:read"]);
+    expect(() =>
+      verifyAdminToken(
+        SECRET,
+        token,
+        { audience: AUDIENCE, requiredScope: "integrity:write" },
+        ISSUED_AT + 1_000,
+      ),
+    ).toThrowError(AdminTokenError);
+
+    try {
+      verifyAdminToken(
+        SECRET,
+        token,
+        { audience: AUDIENCE, requiredScope: "integrity:write" },
+        ISSUED_AT + 1_000,
+      );
+    } catch (err) {
+      expect((err as AdminTokenError).code).toBe("insufficient_scope");
+    }
+  });
+
+  it("rejects an expired token", () => {
+    const { token } = mint(["integrity:read"], 5_000);
+    try {
+      verifyAdminToken(
+        SECRET,
+        token,
+        { audience: AUDIENCE, requiredScope: "integrity:read" },
+        ISSUED_AT + 5_001,
+      );
+      throw new Error("expected verification to throw");
+    } catch (err) {
+      expect((err as AdminTokenError).code).toBe("expired");
+    }
+  });
+
+  it("rejects a token minted for a different environment (audience)", () => {
+    const { token } = mint(["integrity:read"]);
+    try {
+      verifyAdminToken(
+        SECRET,
+        token,
+        { audience: "some-other-environment", requiredScope: "integrity:read" },
+        ISSUED_AT + 1_000,
+      );
+      throw new Error("expected verification to throw");
+    } catch (err) {
+      expect((err as AdminTokenError).code).toBe("wrong_audience");
+    }
+  });
+
+  it("rejects a token signed with a secret that isn't active", () => {
+    const { token } = mint(["integrity:read"], 60_000, OTHER_SECRET);
+    try {
+      verifyAdminToken(
+        SECRET,
+        token,
+        { audience: AUDIENCE, requiredScope: "integrity:read" },
+        ISSUED_AT + 1_000,
+      );
+      throw new Error("expected verification to throw");
+    } catch (err) {
+      expect((err as AdminTokenError).code).toBe("invalid_signature");
+    }
+  });
+
+  it("rejects a tampered payload even if the signature segment is untouched", () => {
+    const { token } = mint(["integrity:read"]);
+    const [encodedPayload, signature] = token.split(".");
+    const decoded = JSON.parse(Buffer.from(encodedPayload, "base64url").toString("utf8"));
+    decoded.scope = ["integrity:read", "integrity:write"];
+    const tamperedPayload = Buffer.from(JSON.stringify(decoded), "utf8").toString("base64url");
+    const tamperedToken = `${tamperedPayload}.${signature}`;
+
+    try {
+      verifyAdminToken(
+        SECRET,
+        tamperedToken,
+        { audience: AUDIENCE, requiredScope: "integrity:write" },
+        ISSUED_AT + 1_000,
+      );
+      throw new Error("expected verification to throw");
+    } catch (err) {
+      expect((err as AdminTokenError).code).toBe("invalid_signature");
+    }
+  });
+
+  it("accepts a token signed with the previous secret during rotation, then rejects it once retired", () => {
+    const { token } = mint(["integrity:read"], 60_000, "the-previous-secret");
+
+    // Grace period: both the new and the previous secret are active.
+    const payload = verifyAdminToken(
+      ["the-new-secret", "the-previous-secret"],
+      token,
+      { audience: AUDIENCE, requiredScope: "integrity:read" },
+      ISSUED_AT + 1_000,
+    );
+    expect(payload.sub).toBe("ops-jane");
+
+    // After the previous secret is retired, the same token is rejected.
+    try {
+      verifyAdminToken(
+        ["the-new-secret"],
+        token,
+        { audience: AUDIENCE, requiredScope: "integrity:read" },
+        ISSUED_AT + 1_000,
+      );
+      throw new Error("expected verification to throw");
+    } catch (err) {
+      expect((err as AdminTokenError).code).toBe("invalid_signature");
+    }
+  });
+
+  it("rejects a revoked token immediately, even though it has not expired", () => {
+    const { token, payload } = mint(["integrity:write"]);
+
+    verifyAdminToken(
+      SECRET,
+      token,
+      { audience: AUDIENCE, requiredScope: "integrity:write" },
+      ISSUED_AT + 1_000,
+    );
+
+    revokeAdminToken(payload.nonce);
+    expect(isAdminTokenRevoked(payload.nonce)).toBe(true);
+
+    try {
+      verifyAdminToken(
+        SECRET,
+        token,
+        { audience: AUDIENCE, requiredScope: "integrity:write" },
+        ISSUED_AT + 2_000,
+      );
+      throw new Error("expected verification to throw");
+    } catch (err) {
+      expect((err as AdminTokenError).code).toBe("revoked");
+    }
+  });
+
+  it("rejects a malformed token", () => {
+    try {
+      verifyAdminToken(
+        SECRET,
+        "not-a-real-token",
+        { audience: AUDIENCE, requiredScope: "integrity:read" },
+        ISSUED_AT,
+      );
+      throw new Error("expected verification to throw");
+    } catch (err) {
+      expect((err as AdminTokenError).code).toBe("malformed");
+    }
+  });
+});

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -1,6 +1,13 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  // Vite's default PostCSS config search climbs to the repo root and picks
+  // up the frontend's postcss.config.js (Tailwind), which isn't installed
+  // in this package's own node_modules. The server has no CSS to process,
+  // so short-circuit the search instead of pulling in frontend tooling.
+  css: {
+    postcss: {},
+  },
   test: {
     include: ["src/tests/**/*.test.ts"],
     exclude: [

--- a/tests/abi-conformance/fixtures/contract-spec.json
+++ b/tests/abi-conformance/fixtures/contract-spec.json
@@ -1,6 +1,6 @@
 {
   "_metadata": {
-    "generated_at": "2024-01-01T00:00:00Z",
+    "generated_at": "2026-07-29T23:42:17.712Z",
     "contract_version": "0.0.1",
     "spec_source": "contracts/prompt-hash/spec-baseline.json",
     "generator": "abi-conformance-test-suite"
@@ -13,14 +13,23 @@
       "pub duration_secs: u64",
       "pub price_stroops: i128",
       "pub asset: Address",
-      "pub active: bool",
-      "pub sales_count: u64"
+      "pub status: PromptSaleStatus",
+      "pub sales_count: u32",
+      "pub max_supply: u32"
+    ],
+    "AcquisitionKind": [
+      "DirectPurchase",
+      "Lease",
+      "Bundle",
+      "AccessPass",
+      "BulkCheckout",
+      "ResaleFill"
     ],
     "Bundle": [
       "pub id: u128",
       "pub creator: Address",
       "pub title: String",
-      "pub prompt_ids: Vec<u128>",
+      "pub prompt_ids: Vec<u64>",
       "pub price_stroops: i128",
       "pub asset: Address",
       "pub active: bool",
@@ -33,6 +42,48 @@
       "pub pass_id: u128",
       "pub expires_at: u64"
     ],
+    "DataKey": [
+      "Prompt(u64)",
+      "CreatorPrompts(Address)",
+      "BuyerPrompts(Address)",
+      "CategoryPrompts(String)",
+      "// Index: category → Vec<prompt_ids> TagPrompts(String)",
+      "// Index: tag → Vec<prompt_ids> ActivePrompts",
+      "// Index: all active → Vec<prompt_ids> AllPrompts",
+      "// Index: all → Vec<prompt_ids> Purchase(u64",
+      "Address)",
+      "PurchaseEscrow(u64",
+      "Address)",
+      "// Settlement tracking for refunds (#420) VoucherKey(u64",
+      "BytesN<32>)",
+      "NonceConsumed(u64",
+      "BytesN<32>)",
+      "ListingRevision(u64",
+      "u32)",
+      "PurchaseDispute(u64",
+      "Address)",
+      "Bundle(u128)",
+      "BundleCounter",
+      "CreatorBundles(Address)",
+      "AccessPass(u128)",
+      "AccessPassCounter",
+      "CreatorAccessPasses(Address)",
+      "CatalogPass(Address",
+      "Address)",
+      "QuoteNonceConsumed(Address",
+      "BytesN<32>)",
+      "Settlement(u128)",
+      "EntitlementPointer(u64",
+      "Address)",
+      "BuyerSettlements(u64",
+      "Address)",
+      "SettlementEscrow(u128)",
+      "SettlementDispute(u128)",
+      "ResaleOrder(BytesN<32>)",
+      "ResaleOrderNonce(Address",
+      "BytesN<32>)",
+      "GovernanceProposal(BytesN<32>)"
+    ],
     "DisputeReason": [
       "InvalidEncryptedPayload",
       "MissingMetadata",
@@ -43,6 +94,21 @@
       "Refunded",
       "Rejected"
     ],
+    "GovernanceAction": [
+      "Upgrade(BytesN<32>)",
+      "SetFeeWallet(Address)",
+      "SetFeePercentage(u32)",
+      "SetReferralPercentage(u32)"
+    ],
+    "GovernanceProposal": [
+      "pub action: GovernanceAction",
+      "pub proposer: Address",
+      "pub proposed_at_ledger: u32",
+      "pub executable_at_ledger: u32",
+      "pub expiry_ledger: u32",
+      "pub expected_state_hash: BytesN<32>",
+      "pub nonce: BytesN<32>"
+    ],
     "InstanceDataKey": [
       "PromptCounter",
       "FeePercentage",
@@ -51,20 +117,8 @@
       "Reentrancy",
       "ReferralPercentage",
       "IsPaused",
-      "VoucherKey(u128",
-      "BytesN<32>)",
-      "ListingRevision(u128",
-      "u32)",
-      "PurchaseDispute(u128",
-      "Address)",
-      "Bundle(u128)",
-      "BundleCounter",
-      "CreatorBundles(Address)",
-      "AccessPass(u128)",
-      "AccessPassCounter",
-      "CreatorAccessPasses(Address)",
-      "CatalogPass(Address",
-      "Address)"
+      "SettlementCounter",
+      "GovernanceDelayLedgers"
     ],
     "ListingConfig": [
       "pub price: i128",
@@ -84,6 +138,19 @@
       "pub price_stroops: i128",
       "pub revised_at: u64"
     ],
+    "PayoutPlan": [
+      "pub creator: Address",
+      "pub fee_wallet: Address",
+      "pub fee_amount: i128",
+      "pub referrer: Option<Address>",
+      "pub referral_amount: i128",
+      "pub splits: Vec<PayoutSplit>",
+      "pub creator_amount: i128"
+    ],
+    "PayoutSplit": [
+      "pub recipient: Address",
+      "pub amount: i128"
+    ],
     "PricingConfig": [
       "pub price: i128",
       "pub asset: Address"
@@ -95,19 +162,25 @@
       "pub title: String",
       "pub category: String",
       "pub preview_text: String",
-      "pub encrypted_prompt: String",
+      "pub encrypted_payload: String",
       "pub encryption_iv: String",
       "pub wrapped_key: String",
       "pub content_hash: BytesN<32>",
       "pub price_stroops: i128",
       "pub asset: Address",
-      "pub active: bool",
+      "pub status: PromptSaleStatus",
       "pub sales_count: u64",
       "pub max_supply: u64",
       "pub expires_at: u64",
       "pub splits: Vec<Split>",
       "pub revision: u32",
       "pub tags: Vec<String>"
+    ],
+    "PromptSaleStatus": [
+      "Draft",
+      "Active",
+      "Paused",
+      "Retired"
     ],
     "Purchase": [
       "pub prompt_id: u64",
@@ -127,6 +200,84 @@
       "pub resolved_at: u64",
       "pub status: DisputeStatus"
     ],
+    "PurchaseEscrow": [
+      "pub prompt_id: u64",
+      "pub buyer: Address",
+      "pub amount: i128",
+      "pub status: SettlementStatus",
+      "pub created_at: u64",
+      "pub settled_at: u64",
+      "// 0 if not yet settled pub dispute_deadline: u64",
+      "pub asset: Address",
+      "pub referrer: Option<Address>",
+      "pub creator_amount: i128",
+      "pub fee_amount: i128",
+      "pub referral_amount: i128",
+      "pub payout_plan: PayoutPlan"
+    ],
+    "QuoteCommitment": [
+      "pub network_id: BytesN<32>",
+      "pub contract_id: BytesN<32>",
+      "pub buyer: Address",
+      "pub kind: AcquisitionKind",
+      "pub acquisition_id: u128",
+      "pub asset: Address",
+      "pub terms_hash: BytesN<32>",
+      "pub max_charge: i128",
+      "pub tip_amount: i128",
+      "pub not_before_ledger: u32",
+      "pub expiry_ledger: u32",
+      "pub nonce: BytesN<32>"
+    ],
+    "ResaleOrder": [
+      "pub network_id: BytesN<32>",
+      "pub contract_id: BytesN<32>",
+      "pub seller: Address",
+      "pub prompt_id: u64",
+      "pub settlement_id: u128",
+      "pub asset: Address",
+      "pub price: i128",
+      "pub min_proceeds: i128",
+      "pub buyer: Option<Address>",
+      "pub royalty_bps: u32",
+      "pub expiry_ledger: u32",
+      "pub nonce: BytesN<32>",
+      "pub status: ResaleOrderStatus"
+    ],
+    "ResaleOrderStatus": [
+      "Open",
+      "Filled",
+      "Cancelled"
+    ],
+    "SettlementRecord": [
+      "pub settlement_id: u128",
+      "pub prompt_id: u64",
+      "pub buyer: Address",
+      "pub kind: AcquisitionKind",
+      "pub amount: i128",
+      "pub asset: Address",
+      "pub status: SettlementStatus",
+      "pub created_at: u64",
+      "pub settled_at: u64",
+      "pub supersedes: Option<u128>",
+      "pub payout_plan: PayoutPlan"
+    ],
+    "SettlementStatus": [
+      "Pending",
+      "// Purchase received",
+      "awaiting settlement Settled",
+      "// Payment distributed successfully Refunded",
+      "// Purchase refunded atomically"
+    ],
+    "SignedDiscountAuthorization": [
+      "pub prompt_id: u64",
+      "pub buyer: Address",
+      "pub discount_bps: u32",
+      "pub nonce: BytesN<32>",
+      "pub expiry_ledger: u32",
+      "pub network_id: BytesN<32>",
+      "pub contract_id: BytesN<32>"
+    ],
     "Split": [
       "pub recipient: Address",
       "pub bps: u32"
@@ -134,24 +285,45 @@
   },
   "errors": {
     "AccessPassNotFound": "40",
+    "AlreadyInitialized": "45",
     "AlreadyPurchased": "5",
     "ArithmeticOverflow": "17",
+    "AuthorizationBuyerMismatch": "51",
+    "AuthorizationDomainMismatch": "53",
+    "AuthorizationExpired": "48",
+    "AuthorizationNonceConsumed": "49",
+    "AuthorizationNotYetValid": "54",
+    "AuthorizationPromptMismatch": "52",
+    "BulkPurchaseTooLarge": "42",
     "BundleNotFound": "39",
     "ContractIsPaused": "19",
     "CreatorCannotBuy": "3",
     "DisputeAlreadyOpen": "35",
     "DisputeNotFound": "36",
     "DisputeResolved": "37",
+    "DisputeWindowClosed": "85",
+    "DisputeWindowNotElapsed": "86",
+    "DuplicatePromptId": "43",
+    "DuplicateSettlementSubmission": "67",
     "DuplicateSplitRecipient": "32",
     "FeeExceedsMaximum": "34",
     "FeeWalletNotSet": "15",
+    "GovernanceDelayNotElapsed": "79",
+    "GovernanceNonceConsumed": "82",
+    "GovernanceProposalExists": "78",
+    "GovernanceProposalExpired": "80",
+    "GovernanceProposalNotFound": "77",
+    "GovernanceStateMismatch": "81",
     "InvalidAccessDuration": "41",
     "InvalidAsset": "26",
+    "InvalidAuthorizationSignature": "50",
     "InvalidBundle": "38",
     "InvalidCategoryLength": "9",
+    "InvalidCursor": "46",
     "InvalidDiscountPercentage": "24",
     "InvalidEncryptedPromptLength": "11",
     "InvalidFeePercentage": "7",
+    "InvalidGovernanceDelay": "83",
     "InvalidImageUrlLength": "13",
     "InvalidIvLength": "14",
     "InvalidLicenseTransfer": "30",
@@ -159,20 +331,44 @@
     "InvalidPreviewLength": "10",
     "InvalidPrice": "6",
     "InvalidReferralPercentage": "23",
+    "InvalidResaleOrderSignature": "76",
     "InvalidSplits": "27",
+    "InvalidStatusTransition": "44",
     "InvalidTitleLength": "8",
+    "InvalidTtlPolicy": "47",
     "InvalidVoucher": "22",
     "InvalidWrappedKeyLength": "12",
     "LicenseNotFound": "29",
     "ListingExpired": "28",
+    "MaxSupplyBelowCommitted": "84",
     "MaxSupplyReached": "25",
     "PromptInactive": "4",
     "PromptNotFound": "2",
+    "QuoteAcquisitionMismatch": "59",
+    "QuoteAssetMismatch": "60",
+    "QuoteChargeExceeded": "62",
+    "QuoteDomainMismatch": "58",
+    "QuoteExpired": "55",
+    "QuoteNonceConsumed": "57",
+    "QuoteNotYetValid": "56",
+    "QuoteTermsChanged": "61",
     "ReentrancyGuard": "18",
     "ReferrerCannotBeBuyerOrCreator": "20",
+    "ResaleOrderBuyerMismatch": "72",
+    "ResaleOrderCancelled": "70",
+    "ResaleOrderDomainMismatch": "73",
+    "ResaleOrderExpired": "69",
+    "ResaleOrderNonceConsumed": "71",
+    "ResaleOrderNotFound": "68",
+    "ResaleOrderOwnershipChanged": "74",
+    "ResaleProceedsBelowMinimum": "75",
     "RevisionFieldsUnchanged": "31",
+    "SettlementAlreadyFinalized": "65",
+    "SettlementEntitlementMismatch": "66",
+    "SettlementNotFound": "64",
     "TooManySplits": "33",
     "Unauthorized": "1",
+    "UnauthorizedTip": "63",
     "XlmAddressNotSet": "16"
   },
   "events": {
@@ -182,11 +378,19 @@
       "pub duration_secs: u64",
       "pub price_stroops: i128"
     ],
+    "AccessPassPriceUpdated": [
+      "pub pass_id: u128",
+      "pub price_stroops: i128"
+    ],
     "AccessPassPurchased": [
       "pub pass_id: u128",
       "pub buyer: Address",
       "pub creator: Address",
       "pub expires_at: u64"
+    ],
+    "AccessPassStatusUpdated": [
+      "pub pass_id: u128",
+      "pub status: PromptSaleStatus"
     ],
     "BundleCreated": [
       "pub bundle_id: u128",
@@ -202,6 +406,11 @@
     ],
     "ContractPausedStateChanged": [
       "pub is_paused: bool"
+    ],
+    "DiscountApplied": [
+      "pub prompt_id: u64",
+      "pub buyer: Address",
+      "pub discount_bps: u32"
     ],
     "DisputeOpened": [
       "pub prompt_id: u64",
@@ -242,13 +451,17 @@
     "PromptAdminModerated": [
       "pub prompt_id: u64",
       "pub admin: Address",
-      "pub active: bool"
+      "pub status: PromptSaleStatus"
     ],
     "PromptCreated": [
       "pub prompt_id: u64",
       "pub creator: Address",
       "pub price_stroops: i128",
       "pub asset: Address"
+    ],
+    "PromptMaxSupplyUpdated": [
+      "pub prompt_id: u64",
+      "pub max_supply: u64"
     ],
     "PromptPriceUpdated": [
       "pub prompt_id: u64",
@@ -263,12 +476,23 @@
     ],
     "PromptSaleStatusUpdated": [
       "pub prompt_id: u64",
-      "pub active: bool"
+      "pub status: PromptSaleStatus"
     ],
     "PromptTipped": [
       "pub prompt_id: u64",
       "pub buyer: Address",
       "pub amount_tipped: i128"
+    ],
+    "SignedDiscountAdded": [
+      "pub prompt_id: u64",
+      "pub creator: Address",
+      "pub discount_bps: u32",
+      "pub nonce: BytesN<32>"
+    ],
+    "SignedDiscountRevoked": [
+      "pub prompt_id: u64",
+      "pub creator: Address",
+      "pub nonce: BytesN<32>"
     ],
     "SplitsUpdated": [
       "pub prompt_id: u64"
@@ -285,24 +509,29 @@
   },
   "functions": {
     "__constructor": "fn __constructor( env: Env, admin: Address, fee_wallet: Address, xlm_sac: Address, ) -> Result<(), Error>",
+    "add_signed_discount_auth": "fn add_signed_discount_auth( env: Env, creator: Address, authorization: SignedDiscountAuthorization, signature: BytesN<64>, ) -> Result<(), Error>",
     "add_voucher": "fn add_voucher( env: Env, creator: Address, prompt_id: u64, hashed_code: BytesN<32>, discount_bps: u32, ) -> Result<(), Error>",
-    "admin_set_prompt_sale_status": "fn admin_set_prompt_sale_status( env: Env, admin: Address, prompt_id: u128, active: bool, ) -> Result<(), Error>",
+    "admin_set_prompt_sale_status": "fn admin_set_prompt_sale_status( env: Env, admin: Address, prompt_id: u64, status: PromptSaleStatus, ) -> Result<(), Error>",
     "buy_access_pass": "fn buy_access_pass( env: Env, buyer: Address, pass_id: u128, payment_amount_stroops: i128, ) -> Result<(), Error>",
     "buy_bundle": "fn buy_bundle( env: Env, buyer: Address, bundle_id: u128, payment_amount_stroops: i128, ) -> Result<(), Error>",
     "buy_prompt": "fn buy_prompt( env: Env, buyer: Address, prompt_id: u64, referrer: Option<Address>, payment_amount_stroops: i128, voucher: Option<Bytes>, ) -> Result<(), Error>",
+    "buy_prompt_with_auth": "fn buy_prompt_with_auth( env: Env, buyer: Address, prompt_id: u64, referrer: Option<Address>, payment_amount_stroops: i128, authorization: SignedDiscountAuthorization, creator_sig: BytesN<64>, ) -> Result<(), Error>",
     "buy_prompts_bulk": "fn buy_prompts_bulk( env: Env, buyer: Address, prompt_ids: Vec<u64>, payment_amounts: Vec<i128>, referrer: Option<Address>, ) -> Result<(), Error>",
-    "create_access_pass": "fn create_access_pass( env: Env, creator: Address, title: String, duration_secs: u64, price_stroops: i128, asset: Address, ) -> Result<u128, Error>",
-    "create_bundle": "fn create_bundle( env: Env, creator: Address, title: String, prompt_ids: Vec<u128>, price_stroops: i128, asset: Address, expires_at: u64, ) -> Result<u128, Error>",
+    "create_access_pass": "fn create_access_pass( env: Env, creator: Address, title: String, duration_secs: u64, price_stroops: i128, asset: Address, max_supply: u32, ) -> Result<u128, Error>",
+    "create_bundle": "fn create_bundle( env: Env, creator: Address, title: String, prompt_ids: Vec<u64>, price_stroops: i128, asset: Address, expires_at: u64, ) -> Result<u128, Error>",
     "create_prompt": "fn create_prompt( env: Env, creator: Address, image_url: String, title: String, category: String, preview_text: String, encrypted_prompt: String, encryption_iv: String, wrapped_key: String, content_hash: BytesN<32>, listing: ListingConfig, ) -> Result<u64, Error>",
     "extend_all_ttl": "fn extend_all_ttl(env: Env) -> Result<(), Error>",
     "extend_listing": "fn extend_listing( env: Env, creator: Address, prompt_id: u64, new_expires_at: u64, ) -> Result<(), Error>",
     "extend_ttl": "fn extend_ttl(env: Env, key: DataKey) -> Result<(), Error>",
     "get_access_pass": "fn get_access_pass(env: Env, pass_id: u128) -> Result<AccessPass, Error>",
     "get_access_passes_by_creator": "fn get_access_passes_by_creator(env: Env, creator: Address) -> Result<Vec<AccessPass>, Error>",
+    "get_active_prompts_paginated": "fn get_active_prompts_paginated( env: Env, cursor: Option<String>, limit: u64, ) -> Result<(Vec<Prompt>, Option<String>), Error>",
     "get_all_prompts": "fn get_all_prompts(env: Env) -> Result<Vec<Prompt>, Error>",
+    "get_all_prompts_paginated": "fn get_all_prompts_paginated( env: Env, cursor: Option<String>, limit: u64, ) -> Result<(Vec<Prompt>, Option<String>), Error>",
     "get_bundle": "fn get_bundle(env: Env, bundle_id: u128) -> Result<Bundle, Error>",
     "get_bundles_by_creator": "fn get_bundles_by_creator(env: Env, creator: Address) -> Result<Vec<Bundle>, Error>",
     "get_dispute": "fn get_dispute(env: Env, prompt_id: u64, buyer: Address) -> Result<PurchaseDispute, Error>",
+    "get_expiry_risk_metrics": "fn get_expiry_risk_metrics(env: Env) -> Result<Vec<(String, String)>, Error>",
     "get_fee_percentage": "fn get_fee_percentage(env: Env) -> u32",
     "get_fee_wallet": "fn get_fee_wallet(env: Env) -> Option<Address>",
     "get_listing_revision": "fn get_listing_revision( env: Env, prompt_id: u64, revision: u32, ) -> Result<ListingRevisionRecord, Error>",
@@ -310,9 +539,12 @@
     "get_prompt": "fn get_prompt(env: Env, prompt_id: u64) -> Result<Prompt, Error>",
     "get_prompts_by_buyer": "fn get_prompts_by_buyer(env: Env, buyer: Address) -> Result<Vec<Prompt>, Error>",
     "get_prompts_by_category": "fn get_prompts_by_category(env: Env, category: String) -> Result<Vec<Prompt>, Error>",
+    "get_prompts_by_category_page": "fn get_prompts_by_category_page( env: Env, category: String, cursor: Option<String>, limit: u64, ) -> Result<(Vec<Prompt>, Option<String>), Error>",
     "get_prompts_by_creator": "fn get_prompts_by_creator(env: Env, creator: Address) -> Result<Vec<Prompt>, Error>",
     "get_prompts_by_ids": "fn get_prompts_by_ids(env: Env, prompt_ids: Vec<u64>) -> Result<Vec<Prompt>, Error>",
     "get_prompts_by_tag": "fn get_prompts_by_tag(env: Env, tag: String) -> Result<Vec<Prompt>, Error>",
+    "get_prompts_by_tag_paginated": "fn get_prompts_by_tag_paginated( env: Env, tag: String, cursor: Option<String>, limit: u64, ) -> Result<(Vec<Prompt>, Option<String>), Error>",
+    "get_purchase_escrow": "fn get_purchase_escrow(env: Env, prompt_id: u64, buyer: Address) -> Option<PurchaseEscrow>",
     "get_referral_percentage": "fn get_referral_percentage(env: Env) -> u32",
     "get_xlm_sac": "fn get_xlm_sac(env: Env) -> Option<Address>",
     "has_access": "fn has_access(env: Env, user: Address, prompt_id: u64) -> Result<bool, Error>",
@@ -320,15 +552,20 @@
     "lease_prompt": "fn lease_prompt( env: Env, buyer: Address, prompt_id: u64, lease_duration_secs: u64, ) -> Result<(), Error>",
     "open_dispute": "fn open_dispute( env: Env, buyer: Address, prompt_id: u64, reason: DisputeReason, ) -> Result<(), Error>",
     "remove_voucher": "fn remove_voucher( env: Env, creator: Address, prompt_id: u64, hashed_code: BytesN<32>, ) -> Result<(), Error>",
+    "renew_critical_keys": "fn renew_critical_keys(env: Env, cursor: Option<u64>) -> Result<(u32, Option<u64>), Error>",
     "resolve_dispute": "fn resolve_dispute( env: Env, admin: Address, prompt_id: u64, buyer: Address, refund: bool, ) -> Result<(), Error>",
     "revise_listing": "fn revise_listing( env: Env, creator: Address, prompt_id: u64, title: String, category: String, preview_text: String, image_url: String, price_stroops: i128, ) -> Result<u32, Error>",
+    "revoke_discount_auth": "fn revoke_discount_auth( env: Env, creator: Address, prompt_id: u64, nonce: BytesN<32>, ) -> Result<(), Error>",
+    "set_access_pass_status": "fn set_access_pass_status( env: Env, creator: Address, pass_id: u128, status: PromptSaleStatus, ) -> Result<(), Error>",
     "set_fee_percentage": "fn set_fee_percentage(env: Env, new_fee_percentage: u32) -> Result<(), Error>",
     "set_fee_wallet": "fn set_fee_wallet(env: Env, new_fee_wallet: Address) -> Result<(), Error>",
     "set_pause_status": "fn set_pause_status(env: Env, paused: bool) -> Result<(), Error>",
     "set_prompt_max_supply": "fn set_prompt_max_supply( env: Env, creator: Address, prompt_id: u64, max_supply: u64, ) -> Result<(), Error>",
-    "set_prompt_sale_status": "fn set_prompt_sale_status( env: Env, creator: Address, prompt_id: u64, active: bool, ) -> Result<(), Error>",
+    "set_prompt_sale_status": "fn set_prompt_sale_status( env: Env, creator: Address, prompt_id: u64, status: PromptSaleStatus, ) -> Result<(), Error>",
     "set_referral_percentage": "fn set_referral_percentage(env: Env, new_referral_percentage: u32) -> Result<(), Error>",
+    "settle_purchase": "fn settle_purchase( env: Env, caller: Address, prompt_id: u64, buyer: Address, ) -> Result<(), Error>",
     "transfer_license": "fn transfer_license( env: Env, seller: Address, prompt_id: u64, new_buyer: Address, resale_price: i128, ) -> Result<(), Error>",
+    "update_access_pass_price": "fn update_access_pass_price( env: Env, creator: Address, pass_id: u128, price_stroops: i128, ) -> Result<(), Error>",
     "update_platform_fee": "fn update_platform_fee(env: Env, admin: Address, new_fee: u32) -> Result<(), Error>",
     "update_prompt_price": "fn update_prompt_price( env: Env, creator: Address, prompt_id: u64, price_stroops: i128, ) -> Result<(), Error>",
     "update_splits": "fn update_splits( env: Env, creator: Address, prompt_id: u64, new_splits: Vec<Split>, ) -> Result<(), Error>",


### PR DESCRIPTION
## Summary

Implements four Stellar Wave issues assigned to me. The smart contract (`contracts/prompt-hash/src/contract.rs`, `test.rs`, `lib.rs`, and the workspace `Cargo.toml`'s `stellar-contracts` pin) was left in a broken, half-merged state on `main` — it did not compile — so this PR first restores a clean, fully-passing baseline (123/123 contract tests) before layering the feature work on top. That restoration is scoped tightly to what's needed to compile and test; no unrelated behavior was changed.

### #538 — Enforce supply limits across direct sales, leases, bundles, passes, and resale
- Centralizes supply check-and-reserve into `reserve_supply`/`reserve_pass_supply`, used consistently by `execute_buy`, `lease_prompt`, and `buy_bundle` (leases previously bypassed `max_supply` entirely).
- `set_prompt_max_supply` now rejects lowering a cap below already-committed sales (`MaxSupplyBelowCommitted`).
- A dispute refund releases the reserved unit back to the pool so another buyer can acquire it.
- `transfer_license` (resale) continues to neither consume nor free a supply unit — it's a transfer of an already-reserved unit.
- Access passes gain their own `max_supply`, enforced on purchase.

### #539 — Lifecycle controls and renewal policy for catalog access passes
- `AccessPass.active: bool` → `status: PromptSaleStatus` (Active/Paused/Retired), with creator-only `set_access_pass_status` transitions (Retired is terminal, mirroring the existing prompt status state machine).
- New `update_access_pass_price`.
- Renewing before expiry now extends from the *existing* expiry rather than resetting from `now` — no lost time, no double-charged overlap. Renewing after expiry starts a fresh period from `now`.
- Retiring/pausing a pass no longer affects access already granted to existing buyers.

### #541 — Purchase-relative dispute windows before permissionless escrow finalization
- `PurchaseEscrow` now records a `dispute_deadline`. `open_dispute` enforces it for pending escrows.
- `settle_purchase` is permissionless once the window closes with no open dispute — every escrow now has a bounded path to `Released`, even if the admin/creator never act. The admin/creator fast path still works immediately, but is now blocked while a dispute is open (previously it could race `resolve_dispute`).

### #542 — Replace placeholder admin checks on integrity, reports, and moderation APIs
- New signed, scoped, expiring admin bearer token (`server/src/services/adminToken.ts`): HMAC-SHA256, validates signature/issuer/audience/expiry/role/scope, supports secret rotation (grace-period dual-secret verification) and revocation.
- New `requireAdminScope(scope)` Express middleware (`server/src/middleware/adminAuth.ts`), replacing the "any bearer token present" placeholder that used to guard `GET /reports`. Now also guards the previously **unauthenticated** `GET/POST /admin/integrity-*` endpoints, fulfillment recovery (`/resolve`, `/pending-refunds`, `/auto-refund-sweep`), and the secret-rotation endpoint (which previously did a static shared-secret string compare).
- Every allow/deny decision is written to the existing audit trail (`admin_auth_success` / `admin_auth_denied`).
- A route-inventory test fails if a privileged endpoint's middleware chain loses the guard.

## Test plan
- [x] `cargo test --lib` in `contracts/prompt-hash`: **123 passed, 0 failed** (105 pre-existing + 18 new, covering supply enforcement across all acquisition paths, pass renewal/lifecycle, and dispute-window/permissionless-settlement behavior).
- [x] `cargo check --lib` and `cargo build --target wasm32v1-none` were used to confirm the contract compiles; a full `stellar contract build` wasm artifact could not be produced in this environment due to a local toolchain/stellar-cli version mismatch unrelated to this change (soroban-sdk 27 requires rustc 1.91+, which the locally available stellar-cli rejects) — worth a maintainer double-check in CI.
- [x] `vitest run` in `server/`: new `adminToken.test.ts` (9 tests) and `adminAuth.test.ts` (8 tests, including the route-inventory check) pass. Pre-existing, unrelated failures in `versioning.test.ts` and `indexer.test.ts` are unchanged by this PR.
- [ ] Maintainers should mint a real `ADMIN_TOKEN_SECRET` for each deployment environment (see `server/src/services/adminToken.ts`) before this ships — there is no public admin-login endpoint by design; tokens are minted out-of-band by whoever holds the secret.

Closes #538
Closes #539
Closes #541
Closes #542

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added capped access passes, pass status/price controls, signed-discount prompt purchases, and buyer prompt lookup.
  * Introduced max-supply enforcement across purchases/leases/bundles and configurable dispute windows with permissionless settlement after disputes expire.
  * Added scoped, expiring admin authentication for reporting, integrity checks, moderation, fulfillment recovery, and secret rotation.
  * Added paginated prompt query support and improved cursor serialization.
* **Bug Fixes**
  * Improved escrow/dispute refund accounting and strengthened TTL/pagination indexing consistency.
  * Enhanced audit logging for admin auth allow/deny outcomes.
* **Tests**
  * Expanded coverage for max-supply, dispute/settlement rules, admin tokens, route protection, and cursor/TTL behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->