### PR TITLE
feat: remove unauthenticated init, fix indexer profiles, lease polling, SBOM workflow

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,128 @@
+name: SBOM & Provenance
+
+on:
+  push:
+    branches: ["main"]
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write       # required for OIDC provenance attestation
+  attestations: write   # required for actions/attest-build-provenance
+
+jobs:
+  sbom-cargo:
+    name: Cargo SBOM (CycloneDX)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32v1-none
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Install cargo-cyclonedx
+        run: cargo install cargo-cyclonedx --locked
+
+      - name: Generate Cargo SBOM
+        run: cargo cyclonedx --format json --all --output-cdx sbom-cargo.cdx.json
+
+      - name: Build WASM artifact
+        run: cargo build --release --target wasm32v1-none
+
+      - name: Attest WASM provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            target/wasm32v1-none/release/*.wasm
+            sbom-cargo.cdx.json
+
+      - name: Upload Cargo SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-cargo
+          path: sbom-cargo.cdx.json
+          retention-days: 90
+
+  sbom-npm:
+    name: Node.js SBOM (CycloneDX)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Install @cyclonedx/cyclonedx-npm
+        run: yarn global add @cyclonedx/cyclonedx-npm
+
+      - name: Generate root SBOM
+        run: cyclonedx-npm --output-format JSON --output-file sbom-root.cdx.json
+
+      - name: Generate server SBOM
+        run: cyclonedx-npm --package-lock-only --output-format JSON --output-file sbom-server.cdx.json
+        working-directory: server
+
+      - name: Attest Node.js provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            sbom-root.cdx.json
+            sbom-server.cdx.json
+
+      - name: Upload Node.js SBOMs
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-npm
+          path: |
+            sbom-root.cdx.json
+            sbom-server.cdx.json
+          retention-days: 90
+
+  verify-attestations:
+    name: Verify attestations
+    runs-on: ubuntu-latest
+    needs: [sbom-cargo, sbom-npm]
+    if: github.event_name == 'release'
+    steps:
+      - name: Install gh CLI attestation verifier
+        run: |
+          type -p gh >/dev/null || (sudo apt-get install -y gh)
+
+      - name: Download all SBOMs
+        uses: actions/download-artifact@v4
+        with:
+          path: sboms
+
+      - name: Verify provenance attestations
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for f in sboms/**/*.cdx.json sboms/**/*.wasm; do
+            [ -f "$f" ] || continue
+            echo "Verifying $f"
+            gh attestation verify "$f" \
+              --repo ${{ github.repository }} \
+              --signer-workflow sbom.yml
+          done

--- a/contracts/prompt-hash/src/contract.rs
+++ b/contracts/prompt-hash/src/contract.rs
@@ -1,9 +1,3 @@
-use crate::types::{DataKey, Error, Prompt};
-use soroban_sdk::{
-    contract, contractimpl, token, Address, Env, String, Vec,
-};
-
-const PLATFORM_FEE_BPS: i128 = 500; // 5%
 use super::events::Events;
 use super::storage::{InstanceStorage, Storage};
 use super::types::{
@@ -41,16 +35,6 @@ const MAX_BULK_PURCHASE_SIZE: u32 = 20;
 #[contract]
 pub struct PromptHashContract;
 
-#[contractimpl]
-impl PromptHashContract {
-    pub fn initialize(env: Env, fee_wallet: Address, token_contract: Address) {
-        if env.storage().instance().has(&DataKey::FeeWallet) {
-            panic!("already initialized");
-        }
-        env.storage().instance().set(&DataKey::FeeWallet, &fee_wallet);
-        env.storage()
-            .instance()
-            .set(&DataKey::TokenContract, &token_contract);
 impl PromptHashTrait for PromptHashContract {
     fn __constructor(
         env: Env,
@@ -84,6 +68,7 @@ impl PromptHashTrait for PromptHashContract {
         listing: ListingConfig,
     ) -> Result<u64, Error> {
         creator.require_auth();
+        InstanceStorage::require_config_initialized(&env)?;
         ensure(!InstanceStorage::is_paused(&env), Error::ContractIsPaused)?;
         validate_prompt_fields(
             &image_url,
@@ -1449,14 +1434,5 @@ fn validate_no_duplicate_prompt_ids(prompt_ids: &Vec<u64>) -> Result<(), Error> 
 
 fn validate_len(value: &String, max_len: u32, error: Error) -> Result<(), Error> {
     ensure(!value.is_empty() && value.len() <= max_len, error)
-}
-
-
-    pub fn set_fee_wallet(env: Env, admin: Address, fee_wallet: Address) {
-        admin.require_auth();
-        env.storage()
-            .instance()
-            .set(&DataKey::FeeWallet, &fee_wallet);
-    }
 }
 

--- a/contracts/prompt-hash/src/storage.rs
+++ b/contracts/prompt-hash/src/storage.rs
@@ -102,6 +102,25 @@ impl InstanceStorage {
         let key = InstanceDataKey::IsPaused;
         env.storage().instance().get(&key).unwrap_or(false)
     }
+
+    /// Asserts that the canonical configuration written by `__constructor` is
+    /// present. Any economic entry-point must call this before reading config
+    /// so that a partially-constructed or legacy-migrated instance fails loudly
+    /// rather than silently using wrong defaults.
+    pub fn require_config_initialized(env: &Env) -> Result<(), Error> {
+        ensure(
+            env.storage()
+                .instance()
+                .has(&InstanceDataKey::FeeWallet),
+            Error::FeeWalletNotSet,
+        )?;
+        ensure(
+            env.storage()
+                .instance()
+                .has(&InstanceDataKey::XlmAddress),
+            Error::XlmAddressNotSet,
+        )
+    }
 }
 
 /// Persistent storage for prompt, purchase, and user-index records.

--- a/contracts/prompt-hash/src/types.rs
+++ b/contracts/prompt-hash/src/types.rs
@@ -49,6 +49,7 @@ pub enum Error {
     BulkPurchaseTooLarge = 42,
     DuplicatePromptId = 43,
     InvalidStatusTransition = 44,
+    AlreadyInitialized = 45,
 }
 
 #[contracttype]

--- a/server/src/models/IndexerState.ts
+++ b/server/src/models/IndexerState.ts
@@ -5,6 +5,10 @@ const indexerStateSchema = new mongoose.Schema(
     key: { type: String, required: true, unique: true },
     lastIndexedLedger: { type: Number, default: 0 },
     lastFinalizedLedger: { type: Number, default: 0 }, // Track finality separately for fork recovery
+    // Distributed lease fields (#547)
+    leaseHolder: { type: String, default: null },   // replica/process identity holding the lease
+    leaseExpiresAt: { type: Date, default: null },  // wall-clock expiry; null = no active lease
+    fencingToken: { type: Number, default: 0 },     // monotonically increasing; old holders are rejected
   },
   { timestamps: true },
 );

--- a/server/src/services/indexer.ts
+++ b/server/src/services/indexer.ts
@@ -1,3 +1,4 @@
+import os from "os";
 import { rpc as StellarRpc, scValToNative } from "@stellar/stellar-sdk";
 import Prompt from "../models/Prompt";
 import User from "../models/User";
@@ -11,20 +12,23 @@ import { cacheDel, cacheDelPattern, CACHE_KEYS } from "./cacheService";
 import { decodeEvent } from "../../../packages/sdk/src/events/decode.js";
 
 const POLL_INTERVAL_MS = 5_000;
+const LEASE_TTL_MS = 30_000; // lease expires after 30 s of inactivity
+const REPLICA_ID = `${process.pid}@${os.hostname()}`;
+
+let tickInFlight = false; // single-flight guard for the current process
 
 /**
- * Resolves a wallet address to a User document, creating a lightweight record
- * if one does not exist yet (e.g. prompts created or acquired off-platform).
+ * Resolves a wallet address to a User document, creating a minimal wallet
+ * subject if none exists yet. The subject carries only the on-chain address;
+ * no synthetic username or reputation rating is injected. Identity fields
+ * (username, displayName, rating) must be set explicitly through verified
+ * profile claims to prevent unearned reputation from landing in the index.
  */
 async function ensureUser(walletAddress: string) {
   const normalized = walletAddress.toLowerCase();
   let user = await User.findOne({ walletAddress: normalized });
   if (!user) {
-    user = await User.create({
-      walletAddress: normalized,
-      username: `user_${walletAddress.slice(0, 6)}`,
-      rating: 4,
-    });
+    user = await User.create({ walletAddress: normalized });
   }
   return user;
 }
@@ -82,10 +86,45 @@ export async function startIndexer(): Promise<void> {
     { upsert: true, new: true },
   );
 
-  console.log("[indexer] Soroban event indexer started.");
+  console.log("[indexer] Soroban event indexer started.", { replicaId: REPLICA_ID });
 
   setInterval(async () => {
+    // Single-flight: skip this tick if the previous one is still running.
+    if (tickInFlight) {
+      console.warn("[indexer] Tick skipped — previous tick still in flight.");
+      return;
+    }
+
+    tickInFlight = true;
     try {
+      // Acquire or renew the distributed lease via a compare-and-swap write.
+      // Only one replica holds the lease at a time; others skip their tick.
+      const now = new Date();
+      const leaseExpiry = new Date(now.getTime() + LEASE_TTL_MS);
+
+      const leased = await IndexerState.findOneAndUpdate(
+        {
+          key: "prompt_hash_contract",
+          $or: [
+            { leaseHolder: REPLICA_ID },                  // we already hold it
+            { leaseExpiresAt: { $lt: now } },             // it has expired
+            { leaseHolder: null },                        // nobody holds it
+          ],
+        },
+        {
+          $set: { leaseHolder: REPLICA_ID, leaseExpiresAt: leaseExpiry },
+          $inc: { fencingToken: 1 },
+        },
+        { new: true },
+      );
+
+      if (!leased) {
+        // Another replica holds a valid lease — yield this tick.
+        return;
+      }
+
+      const myToken = leased.fencingToken;
+
       const latestLedger = await server.getLatestLedger();
       const startLedger = (state.lastIndexedLedger || 0) + 1;
 
@@ -109,6 +148,14 @@ export async function startIndexer(): Promise<void> {
         lastFinalizedLedger = Math.max(lastFinalizedLedger, event.ledger || 0);
       }
 
+      // Fence: only commit the checkpoint if we still hold the same lease epoch.
+      // A stale replica that woke up after expiry is rejected here.
+      const current = await IndexerState.findOne({ key: "prompt_hash_contract" });
+      if (!current || current.fencingToken !== myToken) {
+        console.warn("[indexer] Fencing token mismatch — checkpoint discarded.");
+        return;
+      }
+
       // Update cursors: track both indexed and finalized ledgers separately
       // for fork recovery and ensuring only finalized events are processed
       state.lastIndexedLedger = latestLedger.sequence;
@@ -118,6 +165,8 @@ export async function startIndexer(): Promise<void> {
       await state.save();
     } catch (err) {
       console.error("Indexer Error:", err);
+    } finally {
+      tickInFlight = false;
     }
   }, POLL_INTERVAL_MS);
 }


### PR DESCRIPTION
Closes #537
Closes #546
Closes #547
Closes #550

## Changes

**#537 — Remove unauthenticated initialize path**
- Deleted the legacy `impl PromptHashContract { initialize() }` block and its orphaned `set_fee_wallet` stub that used non-existent `DataKey::FeeWallet`/`DataKey::TokenContract` variants — this dead code made the file fail to compile and exposed a post-deployment re-initialization surface.
- Removed the conflicting legacy import preamble (lines 1–6) that duplicated the canonical imports.
- Added `AlreadyInitialized = 45` to the `Error` enum.
- Added `InstanceStorage::require_config_initialized()` in `storage.rs` that asserts both `FeeWallet` and `XlmAddress` are present before any economic operation; called at the top of `create_prompt`.

**#546 — Stop creating unverified default-rated profiles**
- `ensureUser` in `indexer.ts` now creates a wallet subject with only `walletAddress` — no synthetic `user_<prefix>` username and no injected `rating: 4`. Identity fields must be set through explicit verified profile claims.

**#547 — Distributed leases and single-flight polling**
- `IndexerState` model extended with `leaseHolder`, `leaseExpiresAt`, and `fencingToken` fields.
- `startIndexer` uses a MongoDB compare-and-swap write to acquire/renew a `LEASE_TTL_MS = 30 s` distributed lease before each tick; replicas without a valid lease skip the tick without processing.
- A process-local `tickInFlight` boolean prevents overlapping ticks within a single replica when RPC is slow.
- Fencing token check before checkpoint commit rejects stale replicas that wake after lease expiry.

**#550 — Signed SBOMs and reproducible release attestations**
- New `.github/workflows/sbom.yml` with three jobs:
  - `sbom-cargo`: generates a CycloneDX JSON SBOM via `cargo-cyclonedx`, builds the WASM artifact, and attests both with `actions/attest-build-provenance`.
  - `sbom-npm`: generates CycloneDX JSON SBOMs for the root and `server` workspaces via `@cyclonedx/cyclonedx-npm` and attests them.
  - `verify-attestations` (release-only): downloads all SBOM artifacts and verifies each attestation via `gh attestation verify`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added secure contract setup through a constructor-based initialization flow.
  - Added owner-controlled fee wallet updates with event notifications.
  - Added configuration checks before creating prompts.

- **Bug Fixes**
  - Improved indexing reliability across multiple running instances.
  - Prevented overlapping indexing operations and discarded stale updates.
  - New wallet users now receive minimal profiles without generated usernames or ratings.

- **Security**
  - Added automated software bills of materials and provenance attestations for builds and releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->