### PR TITLE
chore(ci): fix rustfmt drift and playwright corepack setup

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
+    - name: Enable Corepack
+      run: corepack enable
     - uses: actions/setup-node@v7
       with:
         node-version: lts/*

--- a/contracts/prompt-hash/src/contract.rs
+++ b/contracts/prompt-hash/src/contract.rs
@@ -5,7 +5,9 @@ use super::types::{
     ListingConfig, ListingRevisionRecord, Prompt, PromptHashTrait, PromptSaleStatus,
     PurchaseDispute, PurchaseEscrow, SettlementStatus, SignedDiscountAuthorization, Split,
 };
-use soroban_sdk::{contract, contractimpl, crypto::Crypto, token, Address, Bytes, BytesN, Env, String, Vec};
+use soroban_sdk::{
+    contract, contractimpl, crypto::Crypto, token, Address, Bytes, BytesN, Env, String, Vec,
+};
 use stellar_access::ownable::{self as ownable, Ownable};
 use stellar_macros::{default_impl, only_owner};
 
@@ -136,7 +138,10 @@ impl PromptHashTrait for PromptHashContract {
         let mut prompt = Storage::require_prompt(&env, prompt_id)?;
         ensure(prompt.creator == creator, Error::Unauthorized)?;
 
-        ensure(prompt.status != PromptSaleStatus::Retired, Error::InvalidStatusTransition)?;
+        ensure(
+            prompt.status != PromptSaleStatus::Retired,
+            Error::InvalidStatusTransition,
+        )?;
         ensure(prompt.status != status, Error::InvalidStatusTransition)?;
 
         prompt.status = status.clone();
@@ -157,7 +162,10 @@ impl PromptHashTrait for PromptHashContract {
         ensure(owner == admin, Error::Unauthorized)?;
 
         let mut prompt = Storage::require_prompt(&env, prompt_id)?;
-        ensure(prompt.status != PromptSaleStatus::Retired, Error::InvalidStatusTransition)?;
+        ensure(
+            prompt.status != PromptSaleStatus::Retired,
+            Error::InvalidStatusTransition,
+        )?;
         ensure(prompt.status != status, Error::InvalidStatusTransition)?;
 
         prompt.status = status.clone();
@@ -274,11 +282,9 @@ impl PromptHashTrait for PromptHashContract {
         // 6. Verify creator signature
         let auth_hash = authorization.hash(&env);
         let creator_pub_key = prompt.creator.clone();
-        let valid_sig = env.crypto().ed25519_verify(
-            &creator_pub_key,
-            &auth_hash,
-            &creator_sig,
-        );
+        let valid_sig = env
+            .crypto()
+            .ed25519_verify(&creator_pub_key, &auth_hash, &creator_sig);
         ensure(valid_sig, Error::InvalidAuthorizationSignature)?;
 
         // 7. Consume the nonce atomically
@@ -325,7 +331,10 @@ impl PromptHashTrait for PromptHashContract {
         let mut prompt = Storage::require_prompt(&env, prompt_id)?;
         let now = env.ledger().timestamp();
 
-        ensure(prompt.status == PromptSaleStatus::Active, Error::PromptInactive)?;
+        ensure(
+            prompt.status == PromptSaleStatus::Active,
+            Error::PromptInactive,
+        )?;
         ensure(prompt.creator != buyer, Error::CreatorCannotBuy)?;
         ensure(lease_duration_secs > 0, Error::InvalidPrice)?;
         ensure(
@@ -483,7 +492,10 @@ impl PromptHashTrait for PromptHashContract {
         for index in 0..prompt_ids.len() {
             let prompt = Storage::require_prompt(&env, prompt_ids.get(index).unwrap())?;
             ensure(prompt.creator == creator, Error::Unauthorized)?;
-            ensure(prompt.status == PromptSaleStatus::Active, Error::PromptInactive)?;
+            ensure(
+                prompt.status == PromptSaleStatus::Active,
+                Error::PromptInactive,
+            )?;
             ensure(prompt.asset == asset, Error::InvalidAsset)?;
             if prompt.expires_at != 0 {
                 ensure(prompt.expires_at >= now, Error::ListingExpired)?;
@@ -541,7 +553,10 @@ impl PromptHashTrait for PromptHashContract {
         for index in 0..bundle.prompt_ids.len() {
             let mut prompt = Storage::require_prompt(&env, bundle.prompt_ids.get(index).unwrap())?;
             ensure(prompt.creator == bundle.creator, Error::Unauthorized)?;
-            ensure(prompt.status == PromptSaleStatus::Active, Error::PromptInactive)?;
+            ensure(
+                prompt.status == PromptSaleStatus::Active,
+                Error::PromptInactive,
+            )?;
             ensure(prompt.asset == bundle.asset, Error::InvalidAsset)?;
             if prompt.expires_at != 0 {
                 ensure(prompt.expires_at >= now, Error::ListingExpired)?;
@@ -1045,7 +1060,7 @@ impl PromptHashTrait for PromptHashContract {
 
         let key = crate::types::DataKey::AllPrompts;
         let prompts = Storage::get_prompts_paginated(&env, &key, cursor_id, limit);
-        
+
         let next_cursor = if !prompts.is_empty() {
             let last_id = prompts.last().ok_or(Error::PromptNotFound)?.id;
             Some(encode_cursor(last_id, IndexType::All).to_string())
@@ -1075,7 +1090,7 @@ impl PromptHashTrait for PromptHashContract {
 
         let key = crate::types::DataKey::CategoryPrompts(category);
         let prompts = Storage::get_prompts_paginated(&env, &key, cursor_id, limit);
-        
+
         let next_cursor = if !prompts.is_empty() {
             let last_id = prompts.last().ok_or(Error::PromptNotFound)?.id;
             Some(encode_cursor(last_id, IndexType::Category).to_string())
@@ -1105,7 +1120,7 @@ impl PromptHashTrait for PromptHashContract {
 
         let key = crate::types::DataKey::TagPrompts(tag);
         let prompts = Storage::get_prompts_paginated(&env, &key, cursor_id, limit);
-        
+
         let next_cursor = if !prompts.is_empty() {
             let last_id = prompts.last().ok_or(Error::PromptNotFound)?.id;
             Some(encode_cursor(last_id, IndexType::Tag).to_string())
@@ -1132,7 +1147,7 @@ impl PromptHashTrait for PromptHashContract {
 
         let key = crate::types::DataKey::ActivePrompts;
         let prompts = Storage::get_prompts_paginated(&env, &key, cursor_id, limit);
-        
+
         let next_cursor = if !prompts.is_empty() {
             let last_id = prompts.last().ok_or(Error::PromptNotFound)?.id;
             Some(encode_cursor(last_id, IndexType::Active).to_string())
@@ -1252,7 +1267,10 @@ impl PromptHashTrait for PromptHashContract {
         )?;
 
         let mut escrow = Storage::require_purchase_escrow(&env, &prompt_id, &buyer)?;
-        ensure(escrow.status == SettlementStatus::Pending, Error::DisputeResolved)?;
+        ensure(
+            escrow.status == SettlementStatus::Pending,
+            Error::DisputeResolved,
+        )?;
 
         let now = env.ledger().timestamp();
         let this_contract = env.current_contract_address();
@@ -1304,11 +1322,7 @@ impl PromptHashTrait for PromptHashContract {
         Storage::require_dispute(&env, prompt_id, &buyer)
     }
 
-    fn get_purchase_escrow(
-        env: Env,
-        prompt_id: u64,
-        buyer: Address,
-    ) -> Option<PurchaseEscrow> {
+    fn get_purchase_escrow(env: Env, prompt_id: u64, buyer: Address) -> Option<PurchaseEscrow> {
         Storage::get_purchase_escrow(&env, prompt_id, &buyer)
     }
 
@@ -1438,7 +1452,9 @@ impl PromptHashTrait for PromptHashContract {
 
         // Verify the signature is valid from the creator
         let auth_hash = authorization.hash(&env);
-        let valid_sig = env.crypto().ed25519_verify(&creator, &auth_hash, &signature);
+        let valid_sig = env
+            .crypto()
+            .ed25519_verify(&creator, &auth_hash, &signature);
         ensure(valid_sig, Error::InvalidAuthorizationSignature)?;
 
         // Store the authorization for later verification during buy_prompt_with_auth
@@ -1549,7 +1565,10 @@ fn execute_buy(
     let mut prompt = Storage::require_prompt(env, prompt_id)?;
     let now = env.ledger().timestamp();
 
-    ensure(prompt.status == PromptSaleStatus::Active, Error::PromptInactive)?;
+    ensure(
+        prompt.status == PromptSaleStatus::Active,
+        Error::PromptInactive,
+    )?;
     ensure(prompt.creator != *buyer, Error::CreatorCannotBuy)?;
     ensure(
         !Storage::has_active_purchase(env, prompt_id, buyer, now),
@@ -1597,7 +1616,14 @@ fn execute_buy(
         )?;
     }
 
-    execute_buy_with_required_price(env, buyer, prompt_id, referrer, payment_amount_stroops, required_price)
+    execute_buy_with_required_price(
+        env,
+        buyer,
+        prompt_id,
+        referrer,
+        payment_amount_stroops,
+        required_price,
+    )
 }
 
 /// Buy execution after all price and voucher validation is done.
@@ -1885,4 +1911,3 @@ fn validate_no_duplicate_prompt_ids(prompt_ids: &Vec<u64>) -> Result<(), Error> 
 fn validate_len(value: &String, max_len: u32, error: Error) -> Result<(), Error> {
     ensure(!value.is_empty() && value.len() <= max_len, error)
 }
-

--- a/contracts/prompt-hash/src/events.rs
+++ b/contracts/prompt-hash/src/events.rs
@@ -232,7 +232,12 @@ impl Events {
         );
     }
 
-    pub fn emit_prompt_admin_moderated(env: &Env, prompt_id: u64, admin: Address, status: PromptSaleStatus) {
+    pub fn emit_prompt_admin_moderated(
+        env: &Env,
+        prompt_id: u64,
+        admin: Address,
+        status: PromptSaleStatus,
+    ) {
         env.events().publish(
             (soroban_sdk::symbol_short!("MODERATED"), prompt_id),
             PromptAdminModerated {
@@ -341,12 +346,7 @@ impl Events {
         .publish(env);
     }
 
-    pub fn emit_discount_applied(
-        env: &Env,
-        prompt_id: u64,
-        buyer: Address,
-        discount_bps: u32,
-    ) {
+    pub fn emit_discount_applied(env: &Env, prompt_id: u64, buyer: Address, discount_bps: u32) {
         DiscountApplied {
             prompt_id,
             buyer,

--- a/contracts/prompt-hash/src/lib.rs
+++ b/contracts/prompt-hash/src/lib.rs
@@ -14,4 +14,3 @@ mod types;
 
 pub use contract::PromptHashContract;
 pub use types::{DataKey, Error, Prompt};
-

--- a/contracts/prompt-hash/src/pagination.rs
+++ b/contracts/prompt-hash/src/pagination.rs
@@ -1,7 +1,7 @@
 // Cursor pagination for bounded catalog queries.
 // Prevents full-catalog scans and respects Soroban resource limits.
 
-use soroban_sdk::{Env, Vec, String as SorobanString};
+use soroban_sdk::{Env, String as SorobanString, Vec};
 
 pub const MAX_PAGE_SIZE: u64 = 50;
 
@@ -60,7 +60,10 @@ pub fn decode_cursor(env: &Env, cursor: &SorobanString) -> Result<Cursor, crate:
     let type_num = parts[1].parse::<u8>().map_err(|_| Error::InvalidCursor)?;
     let index_type = IndexType::from_u8(type_num).ok_or(Error::InvalidCursor)?;
 
-    Ok(Cursor { last_id, index_type })
+    Ok(Cursor {
+        last_id,
+        index_type,
+    })
 }
 
 /// Paginated result with cursor for next page
@@ -68,4 +71,3 @@ pub struct PageResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<SorobanString>, // None if end of results
 }
-

--- a/contracts/prompt-hash/src/storage.rs
+++ b/contracts/prompt-hash/src/storage.rs
@@ -109,15 +109,11 @@ impl InstanceStorage {
     /// rather than silently using wrong defaults.
     pub fn require_config_initialized(env: &Env) -> Result<(), Error> {
         ensure(
-            env.storage()
-                .instance()
-                .has(&InstanceDataKey::FeeWallet),
+            env.storage().instance().has(&InstanceDataKey::FeeWallet),
             Error::FeeWalletNotSet,
         )?;
         ensure(
-            env.storage()
-                .instance()
-                .has(&InstanceDataKey::XlmAddress),
+            env.storage().instance().has(&InstanceDataKey::XlmAddress),
             Error::XlmAddressNotSet,
         )
     }
@@ -130,7 +126,7 @@ pub struct Storage;
 impl Storage {
     pub fn extend_key_ttl(env: &Env, key: &DataKey) {
         use crate::ttl_policy::get_ttl_for_key;
-        
+
         if !env.storage().persistent().has(key) {
             return;
         }
@@ -140,11 +136,9 @@ impl Storage {
             return; // Instance keys don't get TTL management
         }
 
-        env.storage().persistent().extend_ttl(
-            key,
-            PERSISTENT_LIFETIME_THRESHOLD,
-            max_ttl,
-        );
+        env.storage()
+            .persistent()
+            .extend_ttl(key, PERSISTENT_LIFETIME_THRESHOLD, max_ttl);
     }
 
     pub fn save_prompt(env: &Env, prompt: &Prompt) -> Result<(), Error> {
@@ -154,12 +148,12 @@ impl Storage {
 
         let next_prompt_id = prompt.id.checked_add(1).ok_or(Error::ArithmeticOverflow)?;
         InstanceStorage::save_prompt_counter(env, next_prompt_id);
-        
+
         // Update all indexes for pagination
         Self::update_category_index(env, prompt);
         Self::update_tag_index(env, prompt);
         Self::update_status_indexes(env, prompt);
-        
+
         Ok(())
     }
 
@@ -372,7 +366,11 @@ impl Storage {
         Self::extend_key_ttl(env, &key);
     }
 
-    pub fn get_purchase_escrow(env: &Env, prompt_id: u64, buyer: &Address) -> Option<PurchaseEscrow> {
+    pub fn get_purchase_escrow(
+        env: &Env,
+        prompt_id: u64,
+        buyer: &Address,
+    ) -> Option<PurchaseEscrow> {
         let key = DataKey::PurchaseEscrow(prompt_id, buyer.clone());
         let escrow = env.storage().persistent().get(&key);
         if env.storage().persistent().has(&key) {
@@ -679,11 +677,7 @@ impl Storage {
         use crate::pagination::MAX_PAGE_SIZE;
 
         let limit = std::cmp::min(limit, MAX_PAGE_SIZE);
-        let ids: Vec<u64> = env
-            .storage()
-            .persistent()
-            .get(key)
-            .unwrap_or(Vec::new(env));
+        let ids: Vec<u64> = env.storage().persistent().get(key).unwrap_or(Vec::new(env));
 
         let mut results = Vec::new(env);
         let mut start_idx = 0usize;
@@ -780,10 +774,7 @@ impl Storage {
 
     /// Renew all critical keys (purchases, escrow) in a bounded batch
     /// Returns (renewed_count, next_cursor_if_more_work)
-    pub fn renew_critical_keys(
-        env: &Env,
-        cursor: Option<u64>,
-    ) -> (u32, Option<u64>) {
+    pub fn renew_critical_keys(env: &Env, cursor: Option<u64>) -> (u32, Option<u64>) {
         use crate::ttl_policy::MAX_RENEWAL_BATCH_SIZE;
 
         let mut renewed_count = 0u32;
@@ -815,9 +806,21 @@ impl Storage {
 
         // Check sample critical keys
         let sample_keys = vec![
-            (DataKey::Purchase(1, Address::from_contract_id(env)), "Purchase"),
-            (DataKey::PurchaseEscrow(1, Address::from_contract_id(env)), "Escrow"),
-            (DataKey::CatalogPass(Address::from_contract_id(env), Address::from_contract_id(env)), "CatalogPass"),
+            (
+                DataKey::Purchase(1, Address::from_contract_id(env)),
+                "Purchase",
+            ),
+            (
+                DataKey::PurchaseEscrow(1, Address::from_contract_id(env)),
+                "Escrow",
+            ),
+            (
+                DataKey::CatalogPass(
+                    Address::from_contract_id(env),
+                    Address::from_contract_id(env),
+                ),
+                "CatalogPass",
+            ),
         ];
 
         for (key, label) in sample_keys {

--- a/contracts/prompt-hash/src/test.rs
+++ b/contracts/prompt-hash/src/test.rs
@@ -36,7 +36,15 @@ fn setup(env: &Env) -> PromptHashContext {
     }
 }
 
-fn setup_env() -> (Env, Address, Address, Address, Address, Address, PromptHashContractClient<'static>) {
+fn setup_env() -> (
+    Env,
+    Address,
+    Address,
+    Address,
+    Address,
+    Address,
+    PromptHashContractClient<'static>,
+) {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -51,7 +59,15 @@ fn setup_env() -> (Env, Address, Address, Address, Address, Address, PromptHashC
     let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
     client.initialize(&fee_wallet, &token_contract);
 
-    (env, admin, fee_wallet, creator, buyer, token_contract, client)
+    (
+        env,
+        admin,
+        fee_wallet,
+        creator,
+        buyer,
+        token_contract,
+        client,
+    )
 }
 
 fn create_native_token(env: &Env, admin: &Address) -> token::Client<'static> {
@@ -913,14 +929,8 @@ fn test_buy_prompt_with_zero_fee() {
     client.settle_purchase(&context.admin, &prompt_id, &buyer);
 
     // With 0% fee, creator gets the full price
-    assert_eq!(
-        xlm_client.balance(&creator),
-        creator_start + price
-    );
-    assert_eq!(
-        xlm_client.balance(&context.fee_wallet),
-        fee_start
-    );
+    assert_eq!(xlm_client.balance(&creator), creator_start + price);
+    assert_eq!(xlm_client.balance(&context.fee_wallet), fee_start);
 }
 
 #[test]
@@ -953,11 +963,29 @@ fn test_multiple_buyers_until_supply_exhausted() {
     fund_buyer(&xlm_client, &buyer3, &context.contract, price);
 
     // Two buyers can purchase
-    client.buy_prompt(&buyer1, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
-    client.buy_prompt(&buyer2, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
+    client.buy_prompt(
+        &buyer1,
+        &prompt_id,
+        &None::<Address>,
+        &price,
+        &None::<Bytes>,
+    );
+    client.buy_prompt(
+        &buyer2,
+        &prompt_id,
+        &None::<Address>,
+        &price,
+        &None::<Bytes>,
+    );
 
     // Third buyer cannot
-    let result = client.try_buy_prompt(&buyer3, &prompt_id, &None::<Address>, &price, &None::<Bytes>);
+    let result = client.try_buy_prompt(
+        &buyer3,
+        &prompt_id,
+        &None::<Address>,
+        &price,
+        &None::<Bytes>,
+    );
     assert_eq!(result, Err(Ok(Error::MaxSupplyReached)));
 }
 
@@ -980,7 +1008,8 @@ fn test_supply_check_happens_before_payment() {
     );
 
     // Try to update status as stranger
-    let status_res = client.try_set_prompt_sale_status(&stranger, &prompt_id, &PromptSaleStatus::Paused);
+    let status_res =
+        client.try_set_prompt_sale_status(&stranger, &prompt_id, &PromptSaleStatus::Paused);
     match status_res {
         Err(Ok(Error::Unauthorized)) => {}
         other => panic!("expected unauthorized for status update, got {:?}", other),
@@ -3937,13 +3966,26 @@ fn test_payout_invariant_fee_plus_creator_equals_payment() {
     let buyer = Address::generate(&env);
     let payment: i128 = 100_000;
 
-    let prompt_id = create_prompt(&env, &client, &creator, "Invariant Test", payment, &context.xlm);
+    let prompt_id = create_prompt(
+        &env,
+        &client,
+        &creator,
+        "Invariant Test",
+        payment,
+        &context.xlm,
+    );
     fund_buyer(&xlm_client, &buyer, &context.contract, payment);
 
     let creator_balance_before = xlm_client.balance(&creator);
     let fee_wallet_balance_before = xlm_client.balance(&context.fee_wallet);
 
-    client.buy_prompt(&buyer, &prompt_id, &None::<Address>, &payment, &None::<Bytes>);
+    client.buy_prompt(
+        &buyer,
+        &prompt_id,
+        &None::<Address>,
+        &payment,
+        &None::<Bytes>,
+    );
 
     client.settle_purchase(&context.admin, &prompt_id, &buyer);
 
@@ -3973,7 +4015,14 @@ fn test_payout_invariant_with_referral() {
     let referrer = Address::generate(&env);
     let payment: i128 = 100_000;
 
-    let prompt_id = create_prompt(&env, &client, &creator, "Referral Test", payment, &context.xlm);
+    let prompt_id = create_prompt(
+        &env,
+        &client,
+        &creator,
+        "Referral Test",
+        payment,
+        &context.xlm,
+    );
     fund_buyer(&xlm_client, &buyer, &context.contract, payment);
 
     let creator_balance_before = xlm_client.balance(&creator);
@@ -4045,7 +4094,13 @@ fn test_payout_invariant_with_splits() {
     let split_1_balance_before = xlm_client.balance(&split_recipient_1);
     let split_2_balance_before = xlm_client.balance(&split_recipient_2);
 
-    client.buy_prompt(&buyer, &prompt_id, &None::<Address>, &payment, &None::<Bytes>);
+    client.buy_prompt(
+        &buyer,
+        &prompt_id,
+        &None::<Address>,
+        &payment,
+        &None::<Bytes>,
+    );
 
     client.settle_purchase(&context.admin, &prompt_id, &buyer);
 
@@ -4091,7 +4146,13 @@ fn test_payout_invariant_with_tip() {
     let creator_balance_before = xlm_client.balance(&creator);
     let fee_wallet_balance_before = xlm_client.balance(&context.fee_wallet);
 
-    client.buy_prompt(&buyer, &prompt_id, &None::<Address>, &payment, &None::<Bytes>);
+    client.buy_prompt(
+        &buyer,
+        &prompt_id,
+        &None::<Address>,
+        &payment,
+        &None::<Bytes>,
+    );
 
     client.settle_purchase(&context.admin, &prompt_id, &buyer);
 

--- a/contracts/prompt-hash/src/ttl_policy.rs
+++ b/contracts/prompt-hash/src/ttl_policy.rs
@@ -130,22 +130,14 @@ pub struct ExpiryRisk {
 }
 
 /// Check if a key needs renewal based on current ledger and last extension
-pub fn should_renew_key(
-    current_ledger: u64,
-    last_extended_ledger: u64,
-    max_ttl: u32,
-) -> bool {
+pub fn should_renew_key(current_ledger: u64, last_extended_ledger: u64, max_ttl: u32) -> bool {
     let age = current_ledger.saturating_sub(last_extended_ledger);
     let renewal_threshold = (max_ttl as u64) * (RENEWAL_THRESHOLD_PCT as u64) / 100;
     age >= renewal_threshold
 }
 
 /// Compute time remaining before expiry (in ledgers)
-pub fn get_time_remaining(
-    current_ledger: u64,
-    last_extended_ledger: u64,
-    max_ttl: u32,
-) -> u64 {
+pub fn get_time_remaining(current_ledger: u64, last_extended_ledger: u64, max_ttl: u32) -> u64 {
     let age = current_ledger.saturating_sub(last_extended_ledger);
     let expiry_at = last_extended_ledger.saturating_add(max_ttl as u64);
     expiry_at.saturating_sub(current_ledger)
@@ -215,7 +207,11 @@ mod tests {
 
         for key in sample_keys {
             let ttl = get_ttl_for_key(&key);
-            assert!(ttl > 0 || ttl == u32::MAX, "Key {:?} must have valid TTL", key);
+            assert!(
+                ttl > 0 || ttl == u32::MAX,
+                "Key {:?} must have valid TTL",
+                key
+            );
         }
     }
 
@@ -230,7 +226,11 @@ mod tests {
 
         // After 70% of TTL, should need renewal
         let renewal_point = (max_ttl as u64) * 70 / 100;
-        assert!(should_renew_key(current_ledger + renewal_point, last_extended, max_ttl));
+        assert!(should_renew_key(
+            current_ledger + renewal_point,
+            last_extended,
+            max_ttl
+        ));
     }
 
     #[test]
@@ -262,6 +262,9 @@ mod tests {
         let last_extended = 100_000u64 - (max_ttl as u64) / 3; // 33% through lifetime
 
         let risk = compute_expiry_risk(current_ledger, last_extended, max_ttl);
-        assert!(risk.at_risk_keys > 0 || risk.imminent_keys > 0, "Should detect at-risk keys");
+        assert!(
+            risk.at_risk_keys > 0 || risk.imminent_keys > 0,
+            "Should detect at-risk keys"
+        );
     }
 }

--- a/contracts/prompt-hash/src/ttl_test.rs
+++ b/contracts/prompt-hash/src/ttl_test.rs
@@ -12,7 +12,10 @@ mod tests {
             std::mem::transmute([0u8; 32])
         }));
 
-        assert!(purchase_ttl > dispute_ttl, "Purchases must have longer TTL than disputes");
+        assert!(
+            purchase_ttl > dispute_ttl,
+            "Purchases must have longer TTL than disputes"
+        );
     }
 
     #[test]
@@ -25,7 +28,10 @@ mod tests {
             std::mem::transmute([0u8; 32])
         }));
 
-        assert!(catalog_pass_ttl >= escrow_ttl, "Entitlements must outlive escrow");
+        assert!(
+            catalog_pass_ttl >= escrow_ttl,
+            "Entitlements must outlive escrow"
+        );
     }
 
     #[test]
@@ -68,7 +74,10 @@ mod tests {
         // At risk (80% through lifetime)
         let risky_extended = current - (max_ttl as u64) / 5;
         let risk = compute_expiry_risk(current, risky_extended, max_ttl);
-        assert!(risk.at_risk_keys > 0 || risk.imminent_keys > 0, "Should flag at-risk key");
+        assert!(
+            risk.at_risk_keys > 0 || risk.imminent_keys > 0,
+            "Should flag at-risk key"
+        );
     }
 
     #[test]

--- a/contracts/prompt-hash/src/types.rs
+++ b/contracts/prompt-hash/src/types.rs
@@ -1,4 +1,6 @@
-use soroban_sdk::{contracterror, contracttype, crypto::Crypto, Address, Bytes, BytesN, Env, String, Vec};
+use soroban_sdk::{
+    contracterror, contracttype, crypto::Crypto, Address, Bytes, BytesN, Env, String, Vec,
+};
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -142,10 +144,10 @@ pub enum DataKey {
     Prompt(u64),
     CreatorPrompts(Address),
     BuyerPrompts(Address),
-    CategoryPrompts(String),      // Index: category → Vec<prompt_ids>
-    TagPrompts(String),            // Index: tag → Vec<prompt_ids>
-    ActivePrompts,                 // Index: all active → Vec<prompt_ids>
-    AllPrompts,                    // Index: all → Vec<prompt_ids>
+    CategoryPrompts(String), // Index: category → Vec<prompt_ids>
+    TagPrompts(String),      // Index: tag → Vec<prompt_ids>
+    ActivePrompts,           // Index: all active → Vec<prompt_ids>
+    AllPrompts,              // Index: all → Vec<prompt_ids>
     Purchase(u64, Address),
     PurchaseEscrow(u64, Address), // Settlement tracking for refunds (#420)
     VoucherKey(u64, BytesN<32>),
@@ -209,9 +211,9 @@ pub enum DisputeReason {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SettlementStatus {
-    Pending,   // Purchase received, awaiting settlement
-    Settled,   // Payment distributed successfully
-    Refunded,  // Purchase refunded atomically
+    Pending,  // Purchase received, awaiting settlement
+    Settled,  // Payment distributed successfully
+    Refunded, // Purchase refunded atomically
 }
 
 #[contracttype]
@@ -796,11 +798,7 @@ pub trait PromptHashTrait {
         prompt_id: u64,
         buyer: Address,
     ) -> Result<(), Error>;
-    fn get_purchase_escrow(
-        env: Env,
-        prompt_id: u64,
-        buyer: Address,
-    ) -> Option<PurchaseEscrow>;
+    fn get_purchase_escrow(env: Env, prompt_id: u64, buyer: Address) -> Option<PurchaseEscrow>;
     fn get_prompts_by_creator(env: Env, creator: Address) -> Result<Vec<Prompt>, Error>;
     fn get_prompts_by_buyer(env: Env, buyer: Address) -> Result<Vec<Prompt>, Error>;
     fn set_fee_wallet(env: Env, new_fee_wallet: Address) -> Result<(), Error>;


### PR DESCRIPTION
This is a CI-infrastructure fix, not tied to a numbered feature issue. It
unblocks PR #575 (`feat(listings): fix #500 bulk activate, pause, and
retire for creator listings`), and any other open PR, since the failures it
fixes are inherited from `main` rather than caused by any individual PR's
diff.

While preparing #575 (#500's PR), four of its required
checks failed: `CI / Contracts (Rust)`, `CI / CI Gate`, `Frontend CI`, and
`Playwright Tests`. Investigation showed none of these failures were caused
by the #500 diff — they reproduce identically on `main` itself:

- **`cargo fmt --all -- --check` fails on `main`.** Nine files under
  `contracts/prompt-hash/src/` (`contract.rs`, `events.rs`, `lib.rs`,
  `pagination.rs`, `storage.rs`, `test.rs`, `ttl_policy.rs`, `ttl_test.rs`,
  `types.rs`) have drifted out of rustfmt's expected style — mostly long
  `use` statements and `ensure(...)` calls that should be wrapped across
  multiple lines. This PR runs `rustfmt --edition 2021` across exactly
  those files and nothing else; every change is whitespace/line-wrapping
  only, verified against the CI-reported diff and re-checked with
  `rustfmt --check` afterward.
- **`Playwright Tests` fails because `corepack enable` is missing from
  `.github/workflows/playwright.yml`.** The job runs `npm install
  --legacy-peer-deps` but Playwright's own `webServer.command` in
  `playwright.config.ts` is `yarn dev`. Without Corepack enabled first, that
  `yarn` resolves to the runner's system Yarn Classic (1.22.22) instead of
  the Yarn 4.9.2 pinned in `package.json`'s `packageManager` field, and the
  webServer refuses to start. `ci.yml` and `frontend.yml` already run
  `corepack enable` as their first step; this PR adds the same one-line
  step to `playwright.yml` so it matches.

**Not fixed in this PR:** the `yarn install --immutable` failure in
`CI / API (Express / server)` and `CI / CI Gate` ("the lockfile would have
been modified by this install"). Reproducing and safely regenerating
`yarn.lock` requires Corepack downloading the real Yarn 4.9.2 release from
`repo.yarnpkg.com`, which isn't reachable from this environment, so I
couldn't verify a fix without risking a bad lockfile edit. This needs to be
resolved by running `yarn install` with full network access and committing
whatever lockfile diff results — flagged separately, not guessed at here.

Once merged to `main`, #500 (and any other open PR) can rebase onto this
commit and should see the Rust formatting and Playwright jobs go green.

## Changed

- `contracts/prompt-hash/src/contract.rs` — rustfmt wrapping only (long
  `use` statement, `ensure(...)` calls, `ed25519_verify` chain, function
  signatures). No logic changes. Part of this CI fix.
- `contracts/prompt-hash/src/events.rs` — rustfmt wrapping of two function
  signatures. Part of this CI fix.
- `contracts/prompt-hash/src/lib.rs` — rustfmt: removed a stray trailing
  blank line. Part of this CI fix.
- `contracts/prompt-hash/src/pagination.rs` — rustfmt: import ordering and
  blank-line cleanup. Part of this CI fix.
- `contracts/prompt-hash/src/storage.rs` — rustfmt wrapping of chained
  storage calls and function signatures, blank-line cleanup. Part of this CI fix.
- `contracts/prompt-hash/src/test.rs` — rustfmt wrapping of long test
  helper signatures and assertion calls. Part of this CI fix.
- `contracts/prompt-hash/src/ttl_policy.rs` — rustfmt wrapping of function
  signatures and `assert!` calls. Part of this CI fix.
- `contracts/prompt-hash/src/ttl_test.rs` — rustfmt wrapping of `assert!`
  calls. Part of this CI fix.
- `contracts/prompt-hash/src/types.rs` — rustfmt wrapping of a long `use`
  statement, trait method signatures, and comment alignment. Part of this CI fix.
- `.github/workflows/playwright.yml` — added the `corepack enable` step
  (already present in `ci.yml`/`frontend.yml`) before `actions/setup-node`.
  Part of this CI fix.

## Testing

- `rustfmt --edition 2021 --check contracts/prompt-hash/src/*.rs` — passes
  with exit code 0 on every file in the crate after this change.
- Spot-compared the produced diff against the exact rustfmt output CI
  reported for #500's failed `Contracts (Rust)` check — the wrapped `use`
  statement and `ensure(...)` calls in `contract.rs` match line-for-line.
- Confirmed via `git fetch upstream main` that these files are unmodified
  on `main` relative to this branch's parent commit, i.e. these failures
  pre-date and are independent of any feature branch.
- Did not run `yarn install` / Playwright locally — `repo.yarnpkg.com` is
  not reachable from this environment, so the Playwright fix is verified by
  workflow-file diff parity with the already-passing `ci.yml`/`frontend.yml`
  jobs rather than an end-to-end run. Recommend a maintainer confirm green
  on push.

## Scope Notes

- Formatting-only change to Rust source (no behavior change) plus a
  one-line CI workflow addition. No contract logic, no frontend logic, no
  backend/API changes.
- Does **not** touch `yarn.lock` or `package.json` — the `yarn install
  --immutable` lockfile failure is still open and needs to be fixed with
  full network access to the Yarn registry; noted above rather than
  guessed at.
- This branch is cut from `main` directly (not from the #500 branch) so it
  can be reviewed and merged independently; #500 should rebase onto it
  once merged.

## Push Command

```
git push -u origin chore/ci-rustfmt-and-playwright-corepack
```