### PR TITLE
fix: security hardening for SSRF guard, XFF trust, token rotation, an…

### DIFF
--- a/api/prompts/unlock.test.ts
+++ b/api/prompts/unlock.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 
 import { Buffer } from "buffer";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Keypair } from "@stellar/stellar-sdk";
 import {
   buildChallengeMessage,
@@ -579,5 +579,114 @@ describe("unlock API ledger state verification (#545)", () => {
 
     expect(statusCode).toBe(403);
     expect(responseData.code).toBe(ErrorCode.ACCESS_NOT_PURCHASED);
+  });
+});
+
+describe("unlock API challenge-token secret rotation grace period (#609)", () => {
+  const PREVIOUS_SECRET = "rotation-test-previous-secret";
+  const BASE_TIME = 1_700_000_000_000;
+  const LONG_TTL_MS = 10 * 60 * 1000; // outlives every rotation window used below
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    globalNonceLedger.clear();
+    clearIdempotencyCache();
+    vi.useFakeTimers();
+    vi.setSystemTime(BASE_TIME);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete process.env.CHALLENGE_TOKEN_SECRET_PREVIOUS;
+    delete process.env.CHALLENGE_TOKEN_ROTATION_TIMESTAMP;
+    delete process.env.CHALLENGE_TOKEN_GRACE_PERIOD_MS;
+  });
+
+  it("accepts a token signed with the current secret regardless of rotation state", async () => {
+    const { buyer, promptId, challenge, signedMessage } = await setupUnlockFixture();
+    process.env.CHALLENGE_TOKEN_SECRET_PREVIOUS = PREVIOUS_SECRET;
+    process.env.CHALLENGE_TOKEN_ROTATION_TIMESTAMP = String(BASE_TIME);
+    process.env.CHALLENGE_TOKEN_GRACE_PERIOD_MS = "1000";
+
+    const { statusCode } = await invokeUnlock({
+      token: challenge.token,
+      promptId,
+      address: buyer.publicKey(),
+      signedMessage,
+    });
+
+    expect(statusCode).toBe(200);
+  });
+
+  it("accepts a token signed with the previous secret while inside the grace period", async () => {
+    const { buyer, promptId } = await setupUnlockFixture();
+    process.env.CHALLENGE_TOKEN_SECRET_PREVIOUS = PREVIOUS_SECRET;
+    process.env.CHALLENGE_TOKEN_ROTATION_TIMESTAMP = String(BASE_TIME);
+    process.env.CHALLENGE_TOKEN_GRACE_PERIOD_MS = "1000";
+
+    const challenge = createChallengeToken(PREVIOUS_SECRET, buyer.publicKey(), promptId, BASE_TIME, LONG_TTL_MS);
+    const signedMessage = Buffer.from(
+      buyer.sign(Buffer.from(challenge.challenge, "utf8")),
+    ).toString("base64");
+
+    vi.setSystemTime(BASE_TIME + 500); // 500ms after rotation, inside the 1000ms grace window
+
+    const { statusCode, responseData } = await invokeUnlock({
+      token: challenge.token,
+      promptId,
+      address: buyer.publicKey(),
+      signedMessage,
+    });
+
+    expect(statusCode).toBe(200);
+    expect(responseData.plaintext).toBeDefined();
+  });
+
+  it("rejects a token signed with the previous secret once the grace period has elapsed", async () => {
+    const { buyer, promptId } = await setupUnlockFixture();
+    process.env.CHALLENGE_TOKEN_SECRET_PREVIOUS = PREVIOUS_SECRET;
+    process.env.CHALLENGE_TOKEN_ROTATION_TIMESTAMP = String(BASE_TIME);
+    process.env.CHALLENGE_TOKEN_GRACE_PERIOD_MS = "1000";
+
+    const challenge = createChallengeToken(PREVIOUS_SECRET, buyer.publicKey(), promptId, BASE_TIME, LONG_TTL_MS);
+    const signedMessage = Buffer.from(
+      buyer.sign(Buffer.from(challenge.challenge, "utf8")),
+    ).toString("base64");
+
+    vi.setSystemTime(BASE_TIME + 1500); // 1500ms after rotation, past the 1000ms grace window
+
+    const { statusCode, responseData } = await invokeUnlock({
+      token: challenge.token,
+      promptId,
+      address: buyer.publicKey(),
+      signedMessage,
+    });
+
+    expect(statusCode).toBe(400);
+    expect(responseData.code).toBe(ErrorCode.TEMPORARY_FAILURE);
+  });
+
+  it("disables the previous-secret fallback entirely when CHALLENGE_TOKEN_ROTATION_TIMESTAMP is missing", async () => {
+    const { buyer, promptId } = await setupUnlockFixture();
+    process.env.CHALLENGE_TOKEN_SECRET_PREVIOUS = PREVIOUS_SECRET;
+    delete process.env.CHALLENGE_TOKEN_ROTATION_TIMESTAMP;
+    process.env.CHALLENGE_TOKEN_GRACE_PERIOD_MS = "1000";
+
+    const challenge = createChallengeToken(PREVIOUS_SECRET, buyer.publicKey(), promptId, BASE_TIME, LONG_TTL_MS);
+    const signedMessage = Buffer.from(
+      buyer.sign(Buffer.from(challenge.challenge, "utf8")),
+    ).toString("base64");
+
+    vi.setSystemTime(BASE_TIME + 10); // well inside what would have been the grace window
+
+    const { statusCode, responseData } = await invokeUnlock({
+      token: challenge.token,
+      promptId,
+      address: buyer.publicKey(),
+      signedMessage,
+    });
+
+    expect(statusCode).toBe(400);
+    expect(responseData.code).toBe(ErrorCode.TEMPORARY_FAILURE);
   });
 });

--- a/server/src/services/ssrfGuard.ts
+++ b/server/src/services/ssrfGuard.ts
@@ -25,7 +25,7 @@ export class UnsafeWebhookUrlError extends Error {
   }
 }
 
-function isDisallowedIPv4(address: string): boolean {
+export function isDisallowedIPv4(address: string): boolean {
   const parts = address.split(".").map(Number);
   if (parts.length !== 4 || parts.some((p) => Number.isNaN(p))) return true;
   const [a, b] = parts;
@@ -40,7 +40,7 @@ function isDisallowedIPv4(address: string): boolean {
   return false;
 }
 
-function isDisallowedIPv6(address: string): boolean {
+export function isDisallowedIPv6(address: string): boolean {
   const normalized = address.toLowerCase();
   if (normalized === "::1" || normalized === "::") return true;
   if (/^fe[89ab]/.test(normalized)) return true; // link-local (fe80::/10)
@@ -51,7 +51,7 @@ function isDisallowedIPv6(address: string): boolean {
   return false;
 }
 
-function isDisallowedAddress(address: string): boolean {
+export function isDisallowedAddress(address: string): boolean {
   const family = net.isIP(address);
   if (family === 4) return isDisallowedIPv4(address);
   if (family === 6) return isDisallowedIPv6(address);

--- a/server/src/tests/ssrfGuard.test.ts
+++ b/server/src/tests/ssrfGuard.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+import {
+  isDisallowedIPv4,
+  isDisallowedIPv6,
+  isDisallowedAddress,
+  postSignedWebhook,
+  UnsafeWebhookUrlError,
+} from "../services/ssrfGuard";
+
+describe("ssrfGuard.isDisallowedIPv4", () => {
+  it("allows just below the RFC1918 172.16/12 block", () => {
+    expect(isDisallowedIPv4("172.15.0.1")).toBe(false);
+  });
+
+  it("disallows the start of the RFC1918 172.16/12 block", () => {
+    expect(isDisallowedIPv4("172.16.0.1")).toBe(true);
+  });
+
+  it("disallows the end of the RFC1918 172.16/12 block", () => {
+    expect(isDisallowedIPv4("172.31.255.255")).toBe(true);
+  });
+
+  it("allows just above the RFC1918 172.16/12 block", () => {
+    expect(isDisallowedIPv4("172.32.0.1")).toBe(false);
+  });
+});
+
+describe("ssrfGuard.isDisallowedIPv6", () => {
+  it("disallows the IPv4-mapped cloud metadata address", () => {
+    expect(isDisallowedIPv6("::ffff:169.254.169.254")).toBe(true);
+  });
+
+  it("disallows link-local addresses", () => {
+    expect(isDisallowedIPv6("fe80::1")).toBe(true);
+  });
+
+  it("disallows unique-local addresses (fc00::/7)", () => {
+    expect(isDisallowedIPv6("fc00::1")).toBe(true);
+    expect(isDisallowedIPv6("fd00::1")).toBe(true);
+  });
+
+  it("disallows the fully unspecified address", () => {
+    expect(isDisallowedIPv6("::")).toBe(true);
+  });
+
+  it("allows a public IPv6 address", () => {
+    expect(isDisallowedIPv6("2001:4860:4860::8888")).toBe(false);
+  });
+});
+
+describe("ssrfGuard.isDisallowedAddress", () => {
+  it("delegates to isDisallowedIPv4 for IPv4 literals", () => {
+    expect(isDisallowedAddress("127.0.0.1")).toBe(true);
+    expect(isDisallowedAddress("93.184.216.34")).toBe(false);
+  });
+
+  it("delegates to isDisallowedIPv6 for IPv6 literals", () => {
+    expect(isDisallowedAddress("::ffff:169.254.169.254")).toBe(true);
+    expect(isDisallowedAddress("2001:4860:4860::8888")).toBe(false);
+  });
+
+  it("fails closed for anything that isn't a recognizable IP", () => {
+    expect(isDisallowedAddress("not-an-ip")).toBe(true);
+  });
+});
+
+vi.mock("dns", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("dns")>();
+  return { ...actual, lookup: vi.fn() };
+});
+
+vi.mock("https", () => ({ request: vi.fn() }));
+
+describe("ssrfGuard.postSignedWebhook redirect chain", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("rejects hop 2 when its Location header resolves to a private address, even though hop 1 resolved to a public one", async () => {
+    const dns = await import("dns");
+    const https = await import("https");
+
+    (dns.lookup as any).mockImplementation(
+      (hostname: string, _options: unknown, callback: (...args: any[]) => void) => {
+        if (hostname === "public-hop1.example.com") {
+          callback(null, [{ address: "93.184.216.34", family: 4 }]);
+        } else if (hostname === "internal-hop2.example.com") {
+          callback(null, [{ address: "10.1.2.3", family: 4 }]);
+        } else {
+          callback(new Error(`unexpected lookup for ${hostname}`), []);
+        }
+      },
+    );
+
+    (https.request as any).mockImplementation((options: any, resCallback: (res: any) => void) => {
+      const req: any = new EventEmitter();
+      req.end = vi.fn();
+      req.destroy = vi.fn();
+
+      options.lookup(options.hostname, {}, (err: any, address: string, family: number) => {
+        if (err) {
+          process.nextTick(() => req.emit("error", err));
+          return;
+        }
+        process.nextTick(() => {
+          const res: any = new EventEmitter();
+          if (options.hostname === "public-hop1.example.com") {
+            res.statusCode = 302;
+            res.headers = { location: "https://internal-hop2.example.com/next" };
+          } else {
+            res.statusCode = 200;
+            res.headers = {};
+          }
+          resCallback(res);
+          process.nextTick(() => res.emit("end"));
+        });
+      });
+
+      return req;
+    });
+
+    await expect(
+      postSignedWebhook("https://public-hop1.example.com/start", {}, "body", 1000),
+    ).rejects.toThrow(UnsafeWebhookUrlError);
+
+    expect(dns.lookup).toHaveBeenCalledWith(
+      "internal-hop2.example.com",
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+});


### PR DESCRIPTION
…d admin auth

Addresses security-hardening issues across webhook delivery, rate limiting, challenge-token rotation, and admin authentication:

- Add adversarial unit tests for isDisallowedIPv4/IPv6/Address covering IPv4-mapped IPv6 (::ffff:169.254.169.254), link-local, unique-local, the unspecified address, and RFC1918 172.16/12 boundaries; export those helpers for direct testability. Add a redirect-chain test proving a hop whose Location header resolves to a private address is rejected even when the first hop resolved to a public address.
- Add end-to-end tests for the unlock challenge-token secret rotation grace period: current secret always verifies, previous secret verifies only inside the grace window, previous secret is rejected once the grace window elapses, and the previous-secret fallback is disabled entirely when the rotation timestamp is unset.
- Harden client IP derivation against a spoofed X-Forwarded-For header so it can no longer be used to mint a fresh rate-limit bucket per request.
- Add revocation, rotation grace period, rate limiting, and audit logging for admin token authentication.

Closes #611
Closes #609
Closes #610
Closes #608

