### PR TITLE
fix: harden unlock security and migrations

### DIFF
--- a/api/auth/challenge.ts
+++ b/api/auth/challenge.ts
@@ -20,6 +20,7 @@ type ExtendedRequest = VercelRequest & {
 export interface ChallengeRequest {
   address: string;
   promptId: string;
+  action?: string;
 }
 
 export interface ChallengeResponse {
@@ -53,7 +54,7 @@ async function handler(
   const clientIp = String(
     req.headers["x-forwarded-for"] || req.socket?.remoteAddress || "unknown",
   );
-  const { address, promptId }: Partial<ChallengeRequest> = req.body ?? {};
+  const { address, promptId, action = "unlock" }: Partial<ChallengeRequest> = req.body ?? {};
 
   const isAuthenticated = Boolean(address);
 
@@ -107,7 +108,13 @@ async function handler(
   // unreasonably long-lived tokens.
   const MAX_TTL_MS = 10 * 60 * 1000;
   const ttlMs = Math.min(5 * 60 * 1000, MAX_TTL_MS);
-  const challenge = createChallengeToken(secret, String(address), String(promptId), Date.now(), ttlMs);
+  const challenge = createChallengeToken(secret, String(address), String(promptId), Date.now(), ttlMs, {
+    origin: String(req.headers.origin ?? ""),
+    networkPassphrase:
+      process.env.PUBLIC_STELLAR_NETWORK_PASSPHRASE ?? "Test SDF Network ; September 2015",
+    contractId: process.env.PUBLIC_PROMPT_HASH_CONTRACT_ID ?? "",
+    action: String(action),
+  });
 
   const response: ChallengeResponse = {
     token: challenge.token,

--- a/api/prompts/unlock.test.ts
+++ b/api/prompts/unlock.test.ts
@@ -61,6 +61,16 @@ vi.mock("../../server/src/services/auditTrail", () => ({
 
 import handler from "./unlock";
 
+const TEST_NETWORK_PASSPHRASE = "Test SDF Network ; September 2015";
+const TEST_CONTRACT_ID =
+  "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
+const TEST_CHALLENGE_CONTEXT = {
+  origin: "",
+  networkPassphrase: TEST_NETWORK_PASSPHRASE,
+  contractId: TEST_CONTRACT_ID,
+  action: "unlock",
+};
+
 async function setupUnlockFixture(plaintext = PLAINTEXT) {
   const buyer = Keypair.random();
   const contentHash = CONTENT_HASH;
@@ -68,8 +78,8 @@ async function setupUnlockFixture(plaintext = PLAINTEXT) {
   process.env.CHALLENGE_TOKEN_SECRET = "integration-test-challenge-secret";
   process.env.UNLOCK_PUBLIC_KEY = "d".repeat(32);
   process.env.UNLOCK_PRIVATE_KEY = "e".repeat(32);
-  process.env.PUBLIC_PROMPT_HASH_CONTRACT_ID =
-    "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
+  process.env.PUBLIC_PROMPT_HASH_CONTRACT_ID = TEST_CONTRACT_ID;
+  process.env.PUBLIC_STELLAR_NETWORK_PASSPHRASE = TEST_NETWORK_PASSPHRASE;
   process.env.PUBLIC_STELLAR_SIMULATION_ACCOUNT = buyer.publicKey();
   process.env.PUBLIC_STELLAR_RPC_URL = "https://soroban-testnet.stellar.org";
 
@@ -78,6 +88,9 @@ async function setupUnlockFixture(plaintext = PLAINTEXT) {
     process.env.CHALLENGE_TOKEN_SECRET,
     buyer.publicKey(),
     promptId,
+    Date.now(),
+    5 * 60 * 1000,
+    TEST_CHALLENGE_CONTEXT,
   );
   const signedMessage = Buffer.from(
     buyer.sign(Buffer.from(challenge.challenge, "utf8")),
@@ -88,7 +101,7 @@ async function setupUnlockFixture(plaintext = PLAINTEXT) {
     ledgerSequence: 123456,
     ledgerHash: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
     networkId: "testnet",
-    contractId: "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+    contractId: TEST_CONTRACT_ID,
     checkedAt: Date.now(),
   });
   hasAccessMock.mockResolvedValue(true);
@@ -231,10 +244,11 @@ describe("unlock challenge message contract", () => {
       nonce: "nonce-123",
       issuedAt: 1_700_000_000_000,
       expiresAt: 1_700_000_000_000,
+      ...TEST_CHALLENGE_CONTEXT,
     };
 
     expect(buildChallengeMessage(payload)).toBe(
-      "prompt-hash unlock:GBUYERACCOUNT1234567890ABCDEFGH1234567890ABCDEFGH123456789:7:nonce-123:1700000000000:1700000000000",
+      "prompt-hash:unlock::Test SDF Network ; September 2015:CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC:GBUYERACCOUNT1234567890ABCDEFGH1234567890ABCDEFGH123456789:7:nonce-123:1700000000000:1700000000000",
     );
   });
 });
@@ -281,6 +295,7 @@ describe("unlock API replay, expiry, and missing-field rejection", () => {
       promptId,
       Date.now() - 60_000, // 1 minute ago
       1000,                 // 1 second TTL
+      TEST_CHALLENGE_CONTEXT,
     );
 
     const { statusCode, responseData } = await invokeUnlock({
@@ -462,6 +477,7 @@ describe("unlock API idempotency", () => {
       promptId,
       Date.now() - 60_000,
       1000,
+      TEST_CHALLENGE_CONTEXT,
     );
 
     // First request — fails with expired challenge
@@ -624,7 +640,14 @@ describe("unlock API challenge-token secret rotation grace period (#609)", () =>
     process.env.CHALLENGE_TOKEN_ROTATION_TIMESTAMP = String(BASE_TIME);
     process.env.CHALLENGE_TOKEN_GRACE_PERIOD_MS = "1000";
 
-    const challenge = createChallengeToken(PREVIOUS_SECRET, buyer.publicKey(), promptId, BASE_TIME, LONG_TTL_MS);
+    const challenge = createChallengeToken(
+      PREVIOUS_SECRET,
+      buyer.publicKey(),
+      promptId,
+      BASE_TIME,
+      LONG_TTL_MS,
+      TEST_CHALLENGE_CONTEXT,
+    );
     const signedMessage = Buffer.from(
       buyer.sign(Buffer.from(challenge.challenge, "utf8")),
     ).toString("base64");
@@ -648,7 +671,14 @@ describe("unlock API challenge-token secret rotation grace period (#609)", () =>
     process.env.CHALLENGE_TOKEN_ROTATION_TIMESTAMP = String(BASE_TIME);
     process.env.CHALLENGE_TOKEN_GRACE_PERIOD_MS = "1000";
 
-    const challenge = createChallengeToken(PREVIOUS_SECRET, buyer.publicKey(), promptId, BASE_TIME, LONG_TTL_MS);
+    const challenge = createChallengeToken(
+      PREVIOUS_SECRET,
+      buyer.publicKey(),
+      promptId,
+      BASE_TIME,
+      LONG_TTL_MS,
+      TEST_CHALLENGE_CONTEXT,
+    );
     const signedMessage = Buffer.from(
       buyer.sign(Buffer.from(challenge.challenge, "utf8")),
     ).toString("base64");
@@ -672,7 +702,14 @@ describe("unlock API challenge-token secret rotation grace period (#609)", () =>
     delete process.env.CHALLENGE_TOKEN_ROTATION_TIMESTAMP;
     process.env.CHALLENGE_TOKEN_GRACE_PERIOD_MS = "1000";
 
-    const challenge = createChallengeToken(PREVIOUS_SECRET, buyer.publicKey(), promptId, BASE_TIME, LONG_TTL_MS);
+    const challenge = createChallengeToken(
+      PREVIOUS_SECRET,
+      buyer.publicKey(),
+      promptId,
+      BASE_TIME,
+      LONG_TTL_MS,
+      TEST_CHALLENGE_CONTEXT,
+    );
     const signedMessage = Buffer.from(
       buyer.sign(Buffer.from(challenge.challenge, "utf8")),
     ).toString("base64");

--- a/api/prompts/unlock.ts
+++ b/api/prompts/unlock.ts
@@ -237,12 +237,20 @@ async function handler(
   try {
     // Support multiple active secrets during rotation grace period
     const activeSecrets = getActiveSecrets(challengeSecret);
+    const config = getServerConfig();
     
     const payload = verifyChallengeToken(
       activeSecrets,
       String(token),
       String(address),
       String(promptId),
+      Date.now(),
+      {
+        origin: String(req.headers.origin ?? ""),
+        networkPassphrase: config.networkPassphrase,
+        contractId: config.promptHashContractId,
+        action: "unlock",
+      },
     );
     const challengeMessage = buildChallengeMessage(payload);
     const validSignature = verifyChallengeSignature(
@@ -309,7 +317,6 @@ async function handler(
       return;
     }
 
-    const config = getServerConfig();
     const id = BigInt(promptId);
 
     // Verify entitlement against finalized ledger state (#545).

--- a/index.html
+++ b/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https: wss:; require-trusted-types-for 'script'; trusted-types react default"
+    />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <title>Prompt Hash Stellar</title>
     <meta name="description" content="Buy and sell AI prompts securely on the Stellar blockchain. Wallet-verified access, on-chain ownership." />

--- a/server/src/db/migrateCli.ts
+++ b/server/src/db/migrateCli.ts
@@ -7,16 +7,17 @@ async function main() {
   const command = args[0] || "up";
   const targetIndex = args.indexOf("--target");
   const targetVersion = targetIndex !== -1 ? parseInt(args[targetIndex + 1], 10) : undefined;
+  const dryRun = args.includes("--dry-run");
 
   if (command !== "up" && command !== "down") {
-    console.error("Usage: ts-node migrateCli.ts [up|down] [--target <version>]");
+    console.error("Usage: ts-node migrateCli.ts [up|down] [--target <version>] [--dry-run]");
     process.exit(1);
   }
 
-  console.log(`[migration-cli] Running database migrations in direction: ${command.toUpperCase()}${targetVersion !== undefined ? ` (target: ${targetVersion})` : ""}`);
+  console.log(`[migration-cli] Running database migrations in direction: ${command.toUpperCase()}${targetVersion !== undefined ? ` (target: ${targetVersion})` : ""}${dryRun ? " [dry-run]" : ""}`);
 
   try {
-    await runMigrations(undefined, command, targetVersion);
+    await runMigrations(undefined, command, targetVersion, { dryRun });
     console.log("[migration-cli] Completed migrations successfully.");
     await mongoose.disconnect();
     process.exit(0);

--- a/server/src/db/migrationRunner.ts
+++ b/server/src/db/migrationRunner.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import { randomUUID } from "crypto";
 import mongoose from "mongoose";
 import connectDb from "./connectDb";
 
@@ -11,7 +12,12 @@ export interface MigrationFile {
   down: (db: mongoose.mongo.Db) => Promise<void>;
 }
 
+export interface MigrationRunOptions {
+  dryRun?: boolean;
+}
+
 const defaultMigrationsDir = path.join(__dirname, "migrations");
+const DEFAULT_LEASE_MS = 5 * 60 * 1000;
 
 /**
  * Dynamic discovery and loading of migrations from the migrations directory.
@@ -56,7 +62,8 @@ export async function getMigrationFiles(migrationsDir: string = defaultMigration
 export async function runMigrations(
   migrationsDir: string = defaultMigrationsDir,
   direction: "up" | "down" = "up",
-  targetVersion?: number
+  targetVersion?: number,
+  options: MigrationRunOptions = {},
 ): Promise<void> {
   const conn = await connectDb();
   const db = conn.db;
@@ -65,67 +72,194 @@ export async function runMigrations(
   }
 
   const migrationCollection = db.collection("migrations");
-  await migrationCollection.createIndex({ version: 1 }, { unique: true });
-
   const migrationFiles = await getMigrationFiles(migrationsDir);
-  const appliedMigrations = await migrationCollection.find().toArray();
-  const appliedVersions = new Set(appliedMigrations.map((m) => m.version));
+  const appliedMigrations = (await migrationCollection.find().toArray()) as Array<{ version: number }>;
+  const appliedVersions = new Set<number>(appliedMigrations.map((migration) => migration.version));
 
   console.log(`[migration] Found ${migrationFiles.length} migration files.`);
   console.log(`[migration] Applied versions in DB: ${Array.from(appliedVersions).sort((a, b) => a - b).join(", ") || "none"}`);
 
-  if (direction === "up") {
-    // Forward migrations: only those not yet applied
-    const pending = migrationFiles.filter((m) => !appliedVersions.has(m.version));
-    if (pending.length === 0) {
-      console.log("[migration] Database is up-to-date. No pending migrations.");
-      return;
+  if (options.dryRun) {
+    const plan = selectMigrationPlan(migrationFiles, appliedVersions, direction, targetVersion);
+    console.log(`[migration] DRY RUN: ${plan.length} ${direction === "up" ? "pending" : "rollback"} migration(s).`);
+    for (const migration of plan) {
+      console.log(`[migration] DRY RUN: ${direction.toUpperCase()} ${migration.version} - ${migration.name}`);
     }
-
-    for (const migration of pending) {
-      if (targetVersion !== undefined && migration.version > targetVersion) {
-        break;
-      }
-
-      console.log(`[migration] UP: Applying version ${migration.version} - ${migration.name}...`);
-      try {
-        await migration.up(db);
-        await migrationCollection.insertOne({
-          version: migration.version,
-          name: migration.name,
-          appliedAt: new Date(),
-        });
-        console.log(`[migration] UP: Successfully applied version ${migration.version}`);
-      } catch (err) {
-        console.error(`[migration] UP: Error applying version ${migration.version}:`, err);
-        throw err; // Stop deployment on failure
-      }
-    }
-  } else {
-    // Rollback migrations: those already applied, executed in descending order
-    const toRollback = migrationFiles
-      .filter((m) => appliedVersions.has(m.version))
-      .reverse();
-
-    if (toRollback.length === 0) {
-      console.log("[migration] No applied migrations to roll back.");
-      return;
-    }
-
-    for (const migration of toRollback) {
-      if (targetVersion !== undefined && migration.version <= targetVersion) {
-        break;
-      }
-
-      console.log(`[migration] DOWN: Rolling back version ${migration.version} - ${migration.name}...`);
-      try {
-        await migration.down(db);
-        await migrationCollection.deleteOne({ version: migration.version });
-        console.log(`[migration] DOWN: Successfully rolled back version ${migration.version}`);
-      } catch (err) {
-        console.error(`[migration] DOWN: Error rolling back version ${migration.version}:`, err);
-        throw err;
-      }
-    }
+    return;
   }
+
+  const checkpointCollection = db.collection("migration_checkpoints");
+  await migrationCollection.createIndex({ version: 1 }, { unique: true });
+  await checkpointCollection.createIndex({ version: 1, direction: 1 }, { unique: true });
+  const lease = await acquireMigrationLease(db, direction);
+
+  try {
+    if (direction === "up") {
+      // Forward migrations: only those not yet applied
+      const pending = selectMigrationPlan(migrationFiles, appliedVersions, direction, targetVersion);
+      if (pending.length === 0) {
+        console.log("[migration] Database is up-to-date. No pending migrations.");
+        return;
+      }
+
+      for (const migration of pending) {
+        console.log(`[migration] UP: Applying version ${migration.version} - ${migration.name}...`);
+        try {
+          await recordCheckpoint(checkpointCollection, migration, direction, "running", lease.token);
+          await migration.up(db);
+          await migrationCollection.insertOne({
+            version: migration.version,
+            name: migration.name,
+            appliedAt: new Date(),
+            schemaVersion: migration.version,
+            leaseToken: lease.token,
+          });
+          await recordCheckpoint(checkpointCollection, migration, direction, "applied", lease.token);
+          console.log(`[migration] UP: Successfully applied version ${migration.version}`);
+        } catch (err) {
+          await recordCheckpoint(checkpointCollection, migration, direction, "failed", lease.token, err);
+          console.error(`[migration] UP: Error applying version ${migration.version}:`, err);
+          throw err; // Stop deployment on failure
+        }
+      }
+    } else {
+      // Rollback migrations: those already applied, executed in descending order
+      const toRollback = selectMigrationPlan(migrationFiles, appliedVersions, direction, targetVersion);
+      if (toRollback.length === 0) {
+        console.log("[migration] No applied migrations to roll back.");
+        return;
+      }
+
+      for (const migration of toRollback) {
+        console.log(`[migration] DOWN: Rolling back version ${migration.version} - ${migration.name}...`);
+        try {
+          await recordCheckpoint(checkpointCollection, migration, direction, "running", lease.token);
+          await migration.down(db);
+          await migrationCollection.deleteOne({ version: migration.version });
+          await recordCheckpoint(checkpointCollection, migration, direction, "rolled_back", lease.token);
+          console.log(`[migration] DOWN: Successfully rolled back version ${migration.version}`);
+        } catch (err) {
+          await recordCheckpoint(checkpointCollection, migration, direction, "failed", lease.token, err);
+          console.error(`[migration] DOWN: Error rolling back version ${migration.version}:`, err);
+          throw err;
+        }
+      }
+    }
+  } finally {
+    await releaseMigrationLease(db, lease.token);
+  }
+}
+
+function selectMigrationPlan(
+  migrationFiles: MigrationFile[],
+  appliedVersions: Set<number>,
+  direction: "up" | "down",
+  targetVersion?: number,
+): MigrationFile[] {
+  if (direction === "up") {
+    return migrationFiles.filter(
+      (migration) =>
+        !appliedVersions.has(migration.version) &&
+        (targetVersion === undefined || migration.version <= targetVersion),
+    );
+  }
+
+  return migrationFiles
+    .filter(
+      (migration) =>
+        appliedVersions.has(migration.version) &&
+        (targetVersion === undefined || migration.version > targetVersion),
+    )
+    .reverse();
+}
+
+async function acquireMigrationLease(
+  db: mongoose.mongo.Db,
+  direction: "up" | "down",
+  leaseMs = DEFAULT_LEASE_MS,
+): Promise<{ token: string }> {
+  const token = randomUUID();
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + leaseMs);
+  const leases = db.collection("migration_leases");
+  await leases.createIndex({ name: 1 }, { unique: true });
+  let result: unknown;
+  try {
+    result = await leases.findOneAndUpdate(
+      {
+        name: "global",
+        $or: [{ expiresAt: { $lte: now } }, { token: { $exists: false } }],
+      },
+      {
+        $set: {
+          name: "global",
+          token,
+          direction,
+          acquiredAt: now,
+          expiresAt,
+        },
+      },
+      { upsert: true, returnDocument: "after" },
+    );
+  } catch (err) {
+    if (typeof err === "object" && err !== null && "code" in err && err.code === 11000) {
+      throw new Error("[migration] Another migration worker holds the lease");
+    }
+    throw err;
+  }
+
+  const acquiredToken = getAcquiredLeaseToken(result);
+  if (acquiredToken !== token) {
+    throw new Error("[migration] Another migration worker holds the lease");
+  }
+  return { token };
+}
+
+function getAcquiredLeaseToken(
+  result: unknown,
+): string | undefined {
+  if (!result || typeof result !== "object") {
+    return undefined;
+  }
+  if ("value" in result) {
+    const value = result.value;
+    if (value && typeof value === "object" && "token" in value) {
+      return typeof value.token === "string" ? value.token : undefined;
+    }
+    return undefined;
+  }
+  if ("token" in result) {
+    return typeof result.token === "string" ? result.token : undefined;
+  }
+  return undefined;
+}
+
+async function releaseMigrationLease(db: mongoose.mongo.Db, token: string): Promise<void> {
+  await db.collection("migration_leases").deleteOne({ name: "global", token });
+}
+
+async function recordCheckpoint(
+  collection: mongoose.mongo.Collection,
+  migration: MigrationFile,
+  direction: "up" | "down",
+  status: "running" | "applied" | "rolled_back" | "failed",
+  leaseToken: string,
+  error?: unknown,
+): Promise<void> {
+  await collection.updateOne(
+    { version: migration.version, direction },
+    {
+      $set: {
+        version: migration.version,
+        name: migration.name,
+        direction,
+        status,
+        leaseToken,
+        updatedAt: new Date(),
+        error: error instanceof Error ? error.message : error ? String(error) : null,
+      },
+      $setOnInsert: { createdAt: new Date() },
+    },
+    { upsert: true },
+  );
 }

--- a/server/src/tests/migrations.test.ts
+++ b/server/src/tests/migrations.test.ts
@@ -26,7 +26,11 @@ describe("Database Migration Framework", () => {
       }),
       insertOne: vi.fn().mockResolvedValue({}),
       deleteOne: vi.fn().mockResolvedValue({}),
+      updateOne: vi.fn().mockResolvedValue({ modifiedCount: 1, upsertedCount: 1 }),
       updateMany: vi.fn().mockResolvedValue({ modifiedCount: 1 }),
+      findOneAndUpdate: vi.fn((_query, update) =>
+        Promise.resolve({ value: { token: update.$set.token } }),
+      ),
     };
 
     mockDb = {
@@ -94,6 +98,11 @@ describe("Database Migration Framework", () => {
 
     // Expect migrations index creation
     expect(mockCollection.createIndex).toHaveBeenCalledWith({ version: 1 }, { unique: true });
+    expect(mockCollection.findOneAndUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "global" }),
+      expect.objectContaining({ $set: expect.objectContaining({ direction: "up" }) }),
+      expect.objectContaining({ upsert: true }),
+    );
 
     // Expect migration application records to be inserted
     expect(mockCollection.insertOne).toHaveBeenCalledTimes(2);
@@ -108,6 +117,20 @@ describe("Database Migration Framework", () => {
 
     // Verify migration functions were run against mock DB
     expect(mockCollection.updateMany).toHaveBeenCalledTimes(2);
+    expect(mockCollection.updateOne).toHaveBeenCalledWith(
+      { version: 1, direction: "up" },
+      expect.objectContaining({
+        $set: expect.objectContaining({ status: "running" }),
+      }),
+      { upsert: true },
+    );
+    expect(mockCollection.updateOne).toHaveBeenCalledWith(
+      { version: 2, direction: "up" },
+      expect.objectContaining({
+        $set: expect.objectContaining({ status: "applied" }),
+      }),
+      { upsert: true },
+    );
   });
 
   it("should only apply pending migrations on an existing database", async () => {
@@ -136,10 +159,16 @@ describe("Database Migration Framework", () => {
 
     await runMigrations(tempMigrationsDir, "down");
 
-    // Should call deleteOne for both migrations
-    expect(mockCollection.deleteOne).toHaveBeenCalledTimes(2);
+    // Should call deleteOne for both migrations before releasing the lease
     expect(mockCollection.deleteOne).toHaveBeenNthCalledWith(1, { version: 2 });
     expect(mockCollection.deleteOne).toHaveBeenNthCalledWith(2, { version: 1 });
+    expect(mockCollection.updateOne).toHaveBeenCalledWith(
+      { version: 2, direction: "down" },
+      expect.objectContaining({
+        $set: expect.objectContaining({ status: "rolled_back" }),
+      }),
+      { upsert: true },
+    );
   });
 
   it("should stop execution and throw error if a migration fails", async () => {
@@ -160,5 +189,34 @@ describe("Database Migration Framework", () => {
 
     // Version 3 should NOT have been recorded as applied
     expect(mockCollection.insertOne).toHaveBeenCalledTimes(2); // only version 1 and 2
+    expect(mockCollection.updateOne).toHaveBeenCalledWith(
+      { version: 3, direction: "up" },
+      expect.objectContaining({
+        $set: expect.objectContaining({
+          status: "failed",
+          error: "Simulated migration failure",
+        }),
+      }),
+      { upsert: true },
+    );
+  });
+
+  it("should reject a concurrent worker when the lease is held", async () => {
+    mockCollection.findOneAndUpdate = vi.fn().mockResolvedValue({
+      value: { token: "other-worker" },
+    });
+
+    await expect(runMigrations(tempMigrationsDir, "up")).rejects.toThrow(
+      "Another migration worker holds the lease",
+    );
+  });
+
+  it("should report a dry-run plan without applying migrations or acquiring a lease", async () => {
+    await runMigrations(tempMigrationsDir, "up", undefined, { dryRun: true });
+
+    expect(mockCollection.findOneAndUpdate).toHaveBeenCalledTimes(0);
+    expect(mockCollection.insertOne).toHaveBeenCalledTimes(0);
+    expect(mockCollection.updateMany).toHaveBeenCalledTimes(0);
+    expect(mockCollection.updateOne).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/lib/auth/challenge.test.ts
+++ b/src/lib/auth/challenge.test.ts
@@ -50,6 +50,36 @@ describe("unlock challenge verification", () => {
     expect(msg).toContain(String(challenge.expiresAt));
   });
 
+  it.each([
+    ["origin", { origin: "https://evil.example" }, "origin mismatch"],
+    ["network", { networkPassphrase: "Public Global Stellar Network ; September 2015" }, "network mismatch"],
+    ["contract", { contractId: "CNEWCONTRACT" }, "contract mismatch"],
+    ["action", { action: "webhook" }, "action mismatch"],
+  ])("rejects cross-%s challenge replay", (_label, override, expected) => {
+    const address = Keypair.random().publicKey();
+    const context = {
+      origin: "https://app.example",
+      networkPassphrase: "Test SDF Network ; September 2015",
+      contractId: "CPROMPTHASH",
+      action: "unlock",
+    };
+    const challenge = createChallengeToken(
+      SECRET,
+      address,
+      "99",
+      ISSUED_AT,
+      60_000,
+      context,
+    );
+
+    expect(() =>
+      verifyChallengeToken(SECRET, challenge.token, address, "99", WITHIN_TTL, {
+        ...context,
+        ...override,
+      }),
+    ).toThrow(expected);
+  });
+
   it("rejects expired challenge tokens", () => {
     const address = Keypair.random().publicKey();
     const challenge = createChallengeToken(SECRET, address, "7", ISSUED_AT, 1000);

--- a/src/lib/auth/challenge.ts
+++ b/src/lib/auth/challenge.ts
@@ -8,9 +8,20 @@ const DEFAULT_TTL_MS = 5 * 60 * 1000;
 export interface ChallengePayload {
   address: string;
   promptId: string;
+  origin: string;
+  networkPassphrase: string;
+  contractId: string;
+  action: string;
   nonce: string;
   issuedAt: number;
   expiresAt: number;
+}
+
+export interface ChallengeContext {
+  origin?: string;
+  networkPassphrase?: string;
+  contractId?: string;
+  action?: string;
 }
 
 function base64UrlEncode(value: string) {
@@ -32,7 +43,18 @@ function signPayload(secret: string, body: string) {
 }
 
 export function buildChallengeMessage(payload: ChallengePayload) {
-  return `prompt-hash unlock:${payload.address}:${payload.promptId}:${payload.nonce}:${payload.issuedAt}:${payload.expiresAt}`;
+  return [
+    "prompt-hash",
+    payload.action,
+    payload.origin,
+    payload.networkPassphrase,
+    payload.contractId,
+    payload.address,
+    payload.promptId,
+    payload.nonce,
+    payload.issuedAt,
+    payload.expiresAt,
+  ].join(":");
 }
 
 export function createChallengeToken(
@@ -41,10 +63,15 @@ export function createChallengeToken(
   promptId: string,
   now = Date.now(),
   ttlMs = DEFAULT_TTL_MS,
+  context: ChallengeContext = {},
 ) {
   const payload: ChallengePayload = {
     address,
     promptId,
+    origin: context.origin ?? "*",
+    networkPassphrase: context.networkPassphrase ?? "",
+    contractId: context.contractId ?? "",
+    action: context.action ?? "unlock",
     nonce: randomUUID(),
     issuedAt: now,
     expiresAt: now + ttlMs,
@@ -68,6 +95,7 @@ export function verifyChallengeToken(
   address: string,
   promptId: string,
   now = Date.now(),
+  expectedContext: ChallengeContext = {},
 ) {
   const [encodedPayload, signature] = token.split(".");
   if (!encodedPayload || !signature) {
@@ -96,6 +124,30 @@ export function verifyChallengeToken(
   const payload = JSON.parse(base64UrlDecode(encodedPayload)) as ChallengePayload;
   if (payload.address !== address || payload.promptId !== promptId) {
     throw new Error("Challenge token does not match the requested prompt unlock.");
+  }
+  if (
+    expectedContext.origin !== undefined &&
+    payload.origin !== expectedContext.origin
+  ) {
+    throw new Error("Challenge token origin mismatch.");
+  }
+  if (
+    expectedContext.networkPassphrase !== undefined &&
+    payload.networkPassphrase !== expectedContext.networkPassphrase
+  ) {
+    throw new Error("Challenge token network mismatch.");
+  }
+  if (
+    expectedContext.contractId !== undefined &&
+    payload.contractId !== expectedContext.contractId
+  ) {
+    throw new Error("Challenge token contract mismatch.");
+  }
+  if (
+    expectedContext.action !== undefined &&
+    payload.action !== expectedContext.action
+  ) {
+    throw new Error("Challenge token action mismatch.");
   }
 
   if (payload.expiresAt < now) {

--- a/src/lib/ipfs/gateway.ts
+++ b/src/lib/ipfs/gateway.ts
@@ -133,8 +133,10 @@ export class IPFSGatewayPool {
     try {
       const response = await fetch(url, {
         signal: controller.signal,
+        redirect: "error",
         headers: {
           "User-Agent": "PromptHash-IPFS-Client/1.0",
+          "Accept-Encoding": "identity",
         },
       });
 
@@ -144,6 +146,10 @@ export class IPFSGatewayPool {
 
       // Validate content type
       const contentType = response.headers.get("content-type") || "";
+      const contentEncoding = response.headers.get("content-encoding") || "";
+      if (contentEncoding && contentEncoding.toLowerCase() !== "identity") {
+        throw new Error(`Compressed gateway responses are not accepted: ${contentEncoding}`);
+      }
       if (
         contentType.includes("text/html") ||
         contentType.includes("application/json")

--- a/src/lib/ipfs/ipfs.test.ts
+++ b/src/lib/ipfs/ipfs.test.ts
@@ -62,7 +62,27 @@ describe("fetchCiphertextFromIpfs", () => {
     expect(result).toBe("CIPHERTEXT");
     expect(fetchMock).toHaveBeenCalledWith(
       "https://gw.test/ipfs/bafyabc",
-      expect.anything(),
+      expect.objectContaining({
+        redirect: "error",
+        headers: expect.objectContaining({
+          "Accept-Encoding": "identity",
+        }),
+      }),
+    );
+  });
+
+  it("rejects compressed gateway responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        headers: new Headers({ "content-encoding": "gzip" }),
+        text: async () => "CIPHERTEXT",
+      }),
+    );
+
+    await expect(fetchCiphertextFromIpfs("ipfs://bafyabc")).rejects.toThrow(
+      /Compressed gateway responses/,
     );
   });
 


### PR DESCRIPTION
## Summary
- bind wallet challenge tokens and signed challenge messages to origin, Stellar network passphrase, contract deployment, and action purpose
- reject redirected or compressed IPFS gateway responses before bounded ciphertext reads
- add CSP and Trusted Types hardening for decrypted prompt rendering entrypoint
- make migrations lease-based with resumable checkpoints, rollback failure records, and dry-run planning

## Verification
- `npx vitest run src/tests/migrations.test.ts` (server) passed: 7 tests
- `git diff --check` passed (CRLF warnings only)
- Root-level `npx vitest ...` could not run because the root `vitest` binary is unavailable after dependency installation failed on Windows postinstall (`yarn setup || true`)
- Server `npm run lint` could not run because local `tsc` is unavailable; ad hoc `npx --package typescript@6.0.3 tsc --noEmit` still reports pre-existing project dependency/config errors outside this change set, and no remaining errors for the touched migration files

Closes #655
Closes #657
Closes #658
Closes #660