### PR TITLE
feat(discovery): implement recommendation controls for purchased, hidden, restricted, and low-trust listings (#715)

### DIFF
--- a/api/prompts/index.ts
+++ b/api/prompts/index.ts
@@ -2,6 +2,11 @@ import { withObservability } from "../../src/lib/observability/wrapper";
 import connectDb from "../../server/src/db/connectDb";
 import Prompt from "../../server/src/models/Prompt";
 import User from "../../server/src/models/User";
+import Purchase from "../../server/src/models/Purchase";
+import {
+  getRecommendedPrompts,
+  PromptListing,
+} from "../../src/lib/recommendations/recommendationEngine";
 
 async function handler(req: any, res: any) {
   if (req.method !== "GET") {
@@ -12,18 +17,26 @@ async function handler(req: any, res: any) {
   try {
     await connectDb();
 
-    const { category, walletAddress } = req.query ?? {};
+    const {
+      category,
+      walletAddress,
+      recommendations,
+      viewerWallet,
+      limit,
+    } = req.query ?? {};
 
     const query: Record<string, unknown> = {
       listingStatus: "published",
       isActive: true,
+      similarityFlag: { $ne: "highly_similar" },
+      integrityStatus: { $nin: ["corrupted", "missing"] },
     };
 
     if (category) {
       query.category = String(category);
     }
 
-    if (walletAddress) {
+    if (walletAddress && !recommendations) {
       const user = await User.findOne({
         walletAddress: String(walletAddress).toLowerCase(),
       });
@@ -35,8 +48,50 @@ async function handler(req: any, res: any) {
     }
 
     const prompts = await Prompt.find(query)
-      .populate("owner", "username walletAddress")
+      .populate("owner", "username walletAddress rating")
       .sort({ createdAt: -1 });
+
+    if (recommendations === "true" || recommendations === true) {
+      const activeWallet = String(viewerWallet || walletAddress || "").toLowerCase();
+      let purchasedPromptIds: string[] = [];
+
+      if (activeWallet) {
+        const purchases = await Purchase.find({
+          buyerWallet: activeWallet,
+          status: "purchased",
+        }).select("promptId");
+        purchasedPromptIds = purchases.map((p) => String(p.promptId));
+      }
+
+      const listings: PromptListing[] = prompts.map((p: any) => ({
+        id: String(p._id),
+        title: p.title,
+        category: p.category,
+        price: p.price,
+        rating: p.rating,
+        salesCount: p.salesCount,
+        createdAt: p.createdAt,
+        updatedAt: p.updatedAt,
+        ownerId: String(p.owner?._id || ""),
+        ownerWallet: p.owner?.walletAddress,
+        creatorRating: p.owner?.rating,
+        creatorTrustScore: p.owner?.rating,
+        listingStatus: p.listingStatus,
+        isActive: p.isActive,
+        similarityFlag: p.similarityFlag,
+        integrityStatus: p.integrityStatus,
+      }));
+
+      const recommended = getRecommendedPrompts(listings, {
+        userWallet: activeWallet,
+        purchasedPromptIds,
+        categoryDiversity: true,
+        limit: limit ? parseInt(String(limit), 10) : 12,
+      });
+
+      res.status(200).json(recommended);
+      return;
+    }
 
     res.status(200).json(prompts);
   } catch (error) {

--- a/docs/product-journeys.md
+++ b/docs/product-journeys.md
@@ -238,6 +238,24 @@ Expired challenge tokens surface as `400` with an `expired` message. The fronten
 
 ---
 
+---
+
+## Recommendation and Discovery Journey
+
+Prompt recommendations and curated discovery surfaces filter out ineligible content and apply deterministic ranking:
+
+1. **Eligibility Filtering**:
+   - **Owned content exclusion**: Prompts created by the connected wallet are omitted from recommended feeds.
+   - **Purchased content exclusion**: Prompts already purchased and unlocked by the buyer are removed from recommendation grids.
+   - **Policy and Integrity exclusions**: Listings with draft/archived status, similarity flags (`highly_similar`), content integrity corruption, or policy restrictions are excluded.
+   - **Staleness & Low-trust guards**: Listings lacking updates or from creators below the minimum trust/rating threshold are omitted.
+
+2. **Deterministic Ranking & Category Diversity**:
+   - Scores weigh prompt ratings, creator trust, verified sales, and freshness.
+   - Multi-category interleaving ensures diverse recommendations across different prompt domains (Development, Marketing, Finance, Sales, etc.).
+
+---
+
 ## Related Files and Issues
 
 | File | Purpose |
@@ -246,6 +264,7 @@ Expired challenge tokens surface as `400` with an `expired` message. The fronten
 | `src/pages/browse/FetchAllPrompts.tsx` | Reads all prompts from contract |
 | `src/pages/browse/PromptModal.tsx` | Purchase and unlock UI |
 | `src/pages/sell/MyPrompts.tsx` | Creator dashboard |
+| `src/lib/recommendations/recommendationEngine.ts` | Recommendation eligibility filters and ranking |
 | `api/auth/challenge.ts` | Challenge token issuance |
 | `api/prompts/unlock.ts` | Prompt unlock and decryption |
 | `src/lib/crypto/promptCrypto.ts` | AES-GCM encryption helpers |
@@ -262,3 +281,4 @@ Expired challenge tokens surface as `400` with an `expired` message. The fronten
 - [#155](https://github.com/Obiajulu-gif/Prompt-Hash-Stellar/issues/155) — Standardize challenge and unlock API error codes
 - [#157](https://github.com/Obiajulu-gif/Prompt-Hash-Stellar/issues/157) — One-command local setup validation
 - [#159](https://github.com/Obiajulu-gif/Prompt-Hash-Stellar/issues/159) — Buyer and creator journey documentation (this file)
+- [#715](https://github.com/Obiajulu-gif/Prompt-Hash-Stellar/issues/715) — Recommendation logic controls and eligibility filtering

--- a/src/lib/recommendations/recommendationEngine.test.ts
+++ b/src/lib/recommendations/recommendationEngine.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+import {
+  isPromptEligibleForRecommendation,
+  calculateRecommendationScore,
+  getRecommendedPrompts,
+  PromptListing,
+} from "./recommendationEngine";
+
+describe("Recommendation Engine Eligibility", () => {
+  const basePrompt: PromptListing = {
+    id: "prompt-1",
+    title: "AI SEO Generator",
+    category: "Marketing",
+    price: 15,
+    rating: 4.8,
+    salesCount: 20,
+    createdAt: new Date().toISOString(),
+    ownerId: "user-creator-1",
+    ownerWallet: "GCREATOR111111111111111111111111111111111111111111111111",
+    creatorTrustScore: 4.5,
+    creatorRating: 4.5,
+    listingStatus: "published",
+    isActive: true,
+    similarityFlag: "clean",
+    integrityStatus: "ok",
+  };
+
+  it("considers valid active prompts eligible", () => {
+    expect(isPromptEligibleForRecommendation(basePrompt)).toBe(true);
+  });
+
+  it("excludes owned prompts for the creator", () => {
+    expect(
+      isPromptEligibleForRecommendation(basePrompt, {
+        userId: "user-creator-1",
+      }),
+    ).toBe(false);
+
+    expect(
+      isPromptEligibleForRecommendation(basePrompt, {
+        userWallet: "GCREATOR111111111111111111111111111111111111111111111111",
+      }),
+    ).toBe(false);
+  });
+
+  it("excludes already purchased prompts", () => {
+    expect(
+      isPromptEligibleForRecommendation(basePrompt, {
+        purchasedPromptIds: ["prompt-1"],
+      }),
+    ).toBe(false);
+
+    expect(
+      isPromptEligibleForRecommendation(basePrompt, {
+        purchasedPromptIds: new Set(["prompt-1"]),
+      }),
+    ).toBe(false);
+  });
+
+  it("excludes hidden, archived, draft, or inactive prompts", () => {
+    expect(
+      isPromptEligibleForRecommendation({ ...basePrompt, isActive: false }),
+    ).toBe(false);
+    expect(
+      isPromptEligibleForRecommendation({ ...basePrompt, listingStatus: "draft" }),
+    ).toBe(false);
+    expect(
+      isPromptEligibleForRecommendation({ ...basePrompt, listingStatus: "archived" }),
+    ).toBe(false);
+    expect(
+      isPromptEligibleForRecommendation({ ...basePrompt, isHidden: true }),
+    ).toBe(false);
+    expect(
+      isPromptEligibleForRecommendation({ ...basePrompt, isRestricted: true }),
+    ).toBe(false);
+  });
+
+  it("excludes highly similar or corrupted prompts", () => {
+    expect(
+      isPromptEligibleForRecommendation({
+        ...basePrompt,
+        similarityFlag: "highly_similar",
+      }),
+    ).toBe(false);
+    expect(
+      isPromptEligibleForRecommendation({
+        ...basePrompt,
+        integrityStatus: "corrupted",
+      }),
+    ).toBe(false);
+  });
+
+  it("excludes stale prompts without recent activity", () => {
+    const twoYearsAgo = new Date(Date.now() - 400 * 24 * 60 * 60 * 1000);
+    expect(
+      isPromptEligibleForRecommendation({
+        ...basePrompt,
+        createdAt: twoYearsAgo.toISOString(),
+        updatedAt: twoYearsAgo.toISOString(),
+      }),
+    ).toBe(false);
+  });
+
+  it("excludes low-trust creators", () => {
+    expect(
+      isPromptEligibleForRecommendation({
+        ...basePrompt,
+        creatorTrustScore: 1.2,
+      }),
+    ).toBe(false);
+    expect(
+      isPromptEligibleForRecommendation({
+        ...basePrompt,
+        creatorRating: 1.5,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("Deterministic Ranking and Category Diversity", () => {
+  const samplePrompts: PromptListing[] = [
+    {
+      id: "p1",
+      title: "Marketing Strategy",
+      category: "Marketing",
+      price: 10,
+      rating: 5.0,
+      salesCount: 50,
+      createdAt: new Date().toISOString(),
+      ownerId: "c1",
+      creatorTrustScore: 5.0,
+      listingStatus: "published",
+      isActive: true,
+    },
+    {
+      id: "p2",
+      title: "Marketing Copywriter",
+      category: "Marketing",
+      price: 12,
+      rating: 4.9,
+      salesCount: 40,
+      createdAt: new Date().toISOString(),
+      ownerId: "c2",
+      creatorTrustScore: 4.8,
+      listingStatus: "published",
+      isActive: true,
+    },
+    {
+      id: "p3",
+      title: "Fullstack Architecture Review",
+      category: "Software Development",
+      price: 20,
+      rating: 4.9,
+      salesCount: 30,
+      createdAt: new Date().toISOString(),
+      ownerId: "c3",
+      creatorTrustScore: 4.9,
+      listingStatus: "published",
+      isActive: true,
+    },
+    {
+      id: "p4",
+      title: "Sales Discovery Closer",
+      category: "Sales",
+      price: 15,
+      rating: 4.7,
+      salesCount: 20,
+      createdAt: new Date().toISOString(),
+      ownerId: "c4",
+      creatorTrustScore: 4.6,
+      listingStatus: "published",
+      isActive: true,
+    },
+  ];
+
+  it("scores prompts deterministically", () => {
+    const score1 = calculateRecommendationScore(samplePrompts[0]);
+    const score2 = calculateRecommendationScore(samplePrompts[0]);
+    expect(score1).toBe(score2);
+    expect(score1).toBeGreaterThan(0);
+  });
+
+  it("interleaves categories when category diversity is enabled", () => {
+    const recommended = getRecommendedPrompts(samplePrompts, {
+      categoryDiversity: true,
+      limit: 3,
+    });
+
+    const categories = recommended.map((p) => p.category);
+    // Unique categories represented across first selections
+    expect(new Set(categories).size).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/lib/recommendations/recommendationEngine.ts
+++ b/src/lib/recommendations/recommendationEngine.ts
@@ -1,0 +1,178 @@
+export interface PromptListing {
+  id: string;
+  title: string;
+  category: string;
+  price: number;
+  rating?: number;
+  salesCount?: number;
+  createdAt: string | Date;
+  updatedAt?: string | Date;
+  ownerId: string;
+  ownerWallet?: string;
+  creatorTrustScore?: number;
+  creatorRating?: number;
+  listingStatus?: "draft" | "ready" | "published" | "archived";
+  isActive?: boolean;
+  similarityFlag?: "clean" | "suspicious" | "highly_similar";
+  integrityStatus?: "pending" | "ok" | "corrupted" | "missing" | "unreachable";
+  isRestricted?: boolean;
+  isHidden?: boolean;
+}
+
+export interface RecommendationFilterOptions {
+  userWallet?: string;
+  userId?: string;
+  purchasedPromptIds?: string[] | Set<string>;
+  minCreatorTrustScore?: number;
+  minCreatorRating?: number;
+  maxStalenessDays?: number;
+  limit?: number;
+  categoryDiversity?: boolean;
+}
+
+const DEFAULT_MIN_CREATOR_TRUST = 2.5;
+const DEFAULT_MAX_STALENESS_DAYS = 180;
+
+/**
+ * Checks if a single prompt listing meets the eligibility criteria for recommendation
+ */
+export function isPromptEligibleForRecommendation(
+  prompt: PromptListing,
+  options: RecommendationFilterOptions = {},
+): boolean {
+  // 1. Must be active and published
+  if (prompt.isActive === false) return false;
+  if (prompt.listingStatus && prompt.listingStatus !== "published") return false;
+  if (prompt.isHidden || prompt.isRestricted) return false;
+
+  // 2. Policy & Integrity checks: exclude plagiarized, suspicious, or corrupted prompts
+  if (prompt.similarityFlag === "highly_similar") return false;
+  if (prompt.integrityStatus === "corrupted" || prompt.integrityStatus === "missing") {
+    return false;
+  }
+
+  // 3. User Ownership check: do not recommend user's own prompt
+  if (options.userId && prompt.ownerId && prompt.ownerId === options.userId) {
+    return false;
+  }
+  if (
+    options.userWallet &&
+    prompt.ownerWallet &&
+    prompt.ownerWallet.toLowerCase() === options.userWallet.toLowerCase()
+  ) {
+    return false;
+  }
+
+  // 4. Purchased check: do not recommend already purchased prompts
+  if (options.purchasedPromptIds) {
+    const purchasedSet =
+      options.purchasedPromptIds instanceof Set
+        ? options.purchasedPromptIds
+        : new Set(options.purchasedPromptIds);
+    if (purchasedSet.has(prompt.id)) {
+      return false;
+    }
+  }
+
+  // 5. Creator Trust check
+  const minTrust = options.minCreatorTrustScore ?? DEFAULT_MIN_CREATOR_TRUST;
+  if (
+    typeof prompt.creatorTrustScore === "number" &&
+    prompt.creatorTrustScore < minTrust
+  ) {
+    return false;
+  }
+
+  const minRating = options.minCreatorRating ?? 2.0;
+  if (
+    typeof prompt.creatorRating === "number" &&
+    prompt.creatorRating < minRating
+  ) {
+    return false;
+  }
+
+  // 6. Staleness check: exclude prompts older than maxStalenessDays without recent updates
+  const maxStaleness = options.maxStalenessDays ?? DEFAULT_MAX_STALENESS_DAYS;
+  const lastActiveDate = new Date(
+    prompt.updatedAt || prompt.createdAt || Date.now(),
+  ).getTime();
+  const daysOld = (Date.now() - lastActiveDate) / (1000 * 60 * 60 * 24);
+  if (daysOld > maxStaleness) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Calculates a deterministic recommendation ranking score for an eligible prompt
+ */
+export function calculateRecommendationScore(prompt: PromptListing): number {
+  const ratingScore = (prompt.rating ?? 4.0) * 20; // 0-100
+  const trustScore = (prompt.creatorTrustScore ?? prompt.creatorRating ?? 4.0) * 15; // 0-75
+  const popularityScore = Math.min((prompt.salesCount ?? 0) * 5, 50); // 0-50
+
+  const createdTime = new Date(prompt.createdAt).getTime();
+  const daysOld = Math.max(0, (Date.now() - createdTime) / (1000 * 60 * 60 * 24));
+  const recencyBoost = Math.max(0, 30 - daysOld * 0.5); // 0-30
+
+  return ratingScore + trustScore + popularityScore + recencyBoost;
+}
+
+/**
+ * Filters and ranks prompts for personalized recommendations with category diversity
+ */
+export function getRecommendedPrompts(
+  prompts: PromptListing[],
+  options: RecommendationFilterOptions = {},
+): PromptListing[] {
+  // Step 1: Filter eligible prompts
+  const eligible = prompts.filter((p) =>
+    isPromptEligibleForRecommendation(p, options),
+  );
+
+  // Step 2: Calculate deterministic scores and sort descending
+  const scored = eligible.map((prompt) => ({
+    prompt,
+    score: calculateRecommendationScore(prompt),
+  }));
+
+  scored.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return a.prompt.id.localeCompare(b.prompt.id); // deterministic tie-breaker
+  });
+
+  const sortedPrompts = scored.map((s) => s.prompt);
+
+  // Step 3: Enforce category diversity if requested
+  const limit = options.limit ?? 10;
+  if (!options.categoryDiversity || sortedPrompts.length <= 1) {
+    return sortedPrompts.slice(0, limit);
+  }
+
+  // Interleave across categories to avoid single-category saturation
+  const categorized = new Map<string, PromptListing[]>();
+  for (const prompt of sortedPrompts) {
+    const cat = prompt.category || "General";
+    if (!categorized.has(cat)) {
+      categorized.set(cat, []);
+    }
+    categorized.get(cat)!.push(prompt);
+  }
+
+  const result: PromptListing[] = [];
+  const categoryQueues = Array.from(categorized.values());
+
+  let added = true;
+  while (added && result.length < limit) {
+    added = false;
+    for (const queue of categoryQueues) {
+      if (queue.length > 0 && result.length < limit) {
+        result.push(queue.shift()!);
+        added = true;
+      }
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
Closes #715

## Summary
- Implemented ecommendationEngine in src/lib/recommendations/recommendationEngine.ts establishing strict eligibility filtering (omitting owned listings, already purchased prompts, inactive/draft/archived listings, policy-flagged/corrupted records, stale prompts, and low-trust creator material).
- Added deterministic scoring formula and category diversity interleaving algorithm.
- Updated pi/prompts/index.ts to accept ecommendations=true and iewerWallet parameters, querying buyer purchase history and returning personalized recommendations.
- Added comprehensive unit tests in src/lib/recommendations/recommendationEngine.test.ts covering all eligibility edge cases and deterministic ranking.
- Updated docs/product-journeys.md with Recommendation and Discovery Journey documentation.