### PR TITLE
feat(schema): enforce semantic version migration for prompt metadata (#677)

### DIFF
--- a/packages/schema/src/promptMetadata.test.ts
+++ b/packages/schema/src/promptMetadata.test.ts
@@ -57,3 +57,51 @@ describe("promptMetadataSchema", () => {
     expect(PROMPT_CATEGORIES.length).toBeGreaterThan(0);
   });
 });
+
+describe("migratePromptMetadata", () => {
+  it("migrates legacy v0 unversioned metadata to current schema version", async () => {
+    const { migratePromptMetadata } = await import("./promptMetadata.js");
+    const legacy = {
+      title: "Legacy Prompt without Schema Version",
+      category: "Marketing",
+      image: "https://example.com/legacy.png",
+      price: "10.5",
+    };
+
+    const res = migratePromptMetadata(legacy);
+    expect(res.data).not.toBeNull();
+    expect(res.data?.schemaVersion).toBe(PROMPT_METADATA_SCHEMA_VERSION);
+    expect(res.data?.description).toBe("");
+    expect(res.data?.tags).toEqual([]);
+    expect(res.data?.licence).toBe("standard");
+  });
+
+  it("fails with a clear error on unsupported future schema versions", async () => {
+    const { migratePromptMetadata } = await import("./promptMetadata.js");
+    const futurePrompt = {
+      schemaVersion: 99,
+      title: "Future Prompt",
+      category: "Other",
+      image: "https://example.com/future.png",
+      price: 5,
+    };
+
+    const res = migratePromptMetadata(futurePrompt);
+    expect(res.data).toBeNull();
+    expect(res.error).toContain("Unsupported future schema version: 99");
+  });
+
+  it("fails when input is invalid or missing required title/image", async () => {
+    const { migratePromptMetadata } = await import("./promptMetadata.js");
+    const invalid = {
+      title: "ab", // below min length
+      category: "Other",
+      image: "https://example.com/i.png",
+      price: 1,
+    };
+
+    const res = migratePromptMetadata(invalid);
+    expect(res.data).toBeNull();
+    expect(res.error).toBeDefined();
+  });
+});

--- a/packages/schema/src/promptMetadata.ts
+++ b/packages/schema/src/promptMetadata.ts
@@ -47,6 +47,7 @@ export const PROMPT_METADATA_LIMITS = {
 } as const;
 
 export const promptMetadataSchema = z.object({
+  schemaVersion: z.number().int().min(1).default(PROMPT_METADATA_SCHEMA_VERSION),
   title: z
     .string()
     .trim()
@@ -103,4 +104,49 @@ export function validatePromptMetadata(input: unknown): {
     }
   }
   return { data: null, errors };
+}
+
+/**
+ * Migrates legacy prompt metadata records (v0 / unversioned) to the current
+ * canonical schema version, while rejecting future unsupported schema versions (#677).
+ */
+export function migratePromptMetadata(raw: any): {
+  data: PromptMetadata | null;
+  error?: string;
+} {
+  if (!raw || typeof raw !== "object") {
+    return { data: null, error: "Invalid metadata: input must be an object" };
+  }
+
+  const version = raw.schemaVersion ?? 0;
+
+  if (version > PROMPT_METADATA_SCHEMA_VERSION) {
+    return {
+      data: null,
+      error: `Unsupported future schema version: ${version}. Current supported version is ${PROMPT_METADATA_SCHEMA_VERSION}.`,
+    };
+  }
+
+  // Legacy v0 -> v1 migration
+  const normalized = {
+    ...raw,
+    schemaVersion: PROMPT_METADATA_SCHEMA_VERSION,
+    description: raw.description ?? "",
+    tags: Array.isArray(raw.tags) ? raw.tags : [],
+    licence: raw.licence ?? "standard",
+    status: raw.status ?? raw.listingStatus ?? "draft",
+    category: (PROMPT_CATEGORIES as readonly string[]).includes(raw.category)
+      ? raw.category
+      : "Other",
+  };
+
+  const validation = validatePromptMetadata(normalized);
+  if (!validation.data) {
+    return {
+      data: null,
+      error: `Metadata migration validation failed: ${Object.values(validation.errors).join(", ")}`,
+    };
+  }
+
+  return { data: validation.data };
 }


### PR DESCRIPTION
Closes #677

## Summary
- Added schemaVersion to promptMetadataSchema (defaulting to PROMPT_METADATA_SCHEMA_VERSION).
- Implemented migratePromptMetadata(raw) in packages/schema/src/promptMetadata.ts with legacy v0 to v1 migration, default backfilling, and clear failure errors on unsupported future schema versions.
- Added comprehensive unit tests in packages/schema/src/promptMetadata.test.ts verifying legacy metadata migration, future version rejection, and invalid input handling.