### PR TITLE
Seller analytics, migration dry-run, OpenAPI schema, abuse-report triage

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Upgrade preflight self-check (#435)
         run: python3 scripts/preflight_upgrade.py check --self-check
 
+      - name: Migration dry-run self-check (#712)
+        run: python3 scripts/dry-run-migration.py self-test
+
       - name: Set up Node.js for ABI conformance tests
         uses: actions/setup-node@v7
         with:

--- a/api/prompts/reports.ts
+++ b/api/prompts/reports.ts
@@ -1,4 +1,6 @@
-import type { ReportReason } from "../../src/lib/reports/reportClient";
+import type { ReportReason, ReportEvidence } from "../../src/lib/reports/reportClient";
+
+export type ReportStatus = "pending" | "investigating" | "resolved" | "dismissed";
 
 interface StoredPromptReport {
   _id: string;
@@ -6,10 +8,61 @@ interface StoredPromptReport {
   reporterAddress: string;
   reason: ReportReason;
   description?: string;
-  status: "pending" | "investigating" | "resolved" | "dismissed";
+  evidence: ReportEvidence[];
+  status: ReportStatus;
   adminNotes?: string;
   createdAt: string;
   updatedAt: string;
+}
+
+const VALID_REASONS: ReportReason[] = [
+  "quality-issue",
+  "misleading-content",
+  "plagiarism",
+  "harmful-content",
+  "copyright",
+  "other",
+];
+
+const STATUS_ORDER: Record<ReportStatus, number> = {
+  pending: 0,
+  investigating: 1,
+  resolved: 2,
+  dismissed: 2,
+};
+
+const VALID_EVIDENCE_KINDS = ["image", "pdf", "link", "text"];
+
+function isReportStatus(value: unknown): value is ReportStatus {
+  return (
+    typeof value === "string" &&
+    (value === "pending" ||
+      value === "investigating" ||
+      value === "resolved" ||
+      value === "dismissed")
+  );
+}
+
+function normalizeEvidence(raw: unknown): ReportEvidence[] {
+  if (!Array.isArray(raw)) return [];
+  const evidence: ReportEvidence[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object") continue;
+    const url = (item as { url?: unknown }).url;
+    const kind = (item as { kind?: unknown }).kind;
+    if (typeof url !== "string" || !url.trim()) continue;
+    evidence.push({
+      url: url.trim(),
+      kind:
+        typeof kind === "string" && VALID_EVIDENCE_KINDS.includes(kind)
+          ? (kind as ReportEvidence["kind"])
+          : "link",
+      addedBy: String(
+        (item as { addedBy?: unknown }).addedBy ?? "reporter",
+      ),
+    });
+  }
+  return evidence.slice(0, 10);
 }
 
 const reports = new Map<string, StoredPromptReport[]>();
@@ -28,11 +81,19 @@ function allReports(): StoredPromptReport[] {
 
 export default async function handler(req: any, res: any) {
   if (req.method === "POST") {
-    const { promptId, reporterAddress, reason, description } = req.body ?? {};
+    const { promptId, reporterAddress, reason, description, evidence } =
+      req.body ?? {};
 
     if (!promptId || !reporterAddress || !reason) {
       res.status(400).json({
         error: "Missing required fields: promptId, reporterAddress, reason",
+      });
+      return;
+    }
+
+    if (typeof reason !== "string" || !VALID_REASONS.includes(reason as ReportReason)) {
+      res.status(400).json({
+        error: `Invalid reason. Must be one of: ${VALID_REASONS.join(", ")}`,
       });
       return;
     }
@@ -44,6 +105,7 @@ export default async function handler(req: any, res: any) {
       reporterAddress: String(reporterAddress),
       reason,
       description: description ? String(description).trim() : undefined,
+      evidence: normalizeEvidence(evidence),
       status: "pending",
       createdAt: now,
       updatedAt: now,
@@ -57,6 +119,7 @@ export default async function handler(req: any, res: any) {
       success: true,
       message: "Report submitted successfully",
       reportId: report._id,
+      evidenceCount: report.evidence.length,
     });
     return;
   }
@@ -68,7 +131,16 @@ export default async function handler(req: any, res: any) {
     }
 
     const promptId = req.query?.promptId ? String(req.query.promptId) : "";
-    res.status(200).json(promptId ? reports.get(promptId) ?? [] : allReports());
+    const status = req.query?.status ? String(req.query.status).trim() : "";
+    const filter = isReportStatus(status) ? status : "";
+
+    if (promptId) {
+      const rows = reports.get(promptId) ?? [];
+      res.status(200).json(filter ? rows.filter((r) => r.status === filter) : rows);
+      return;
+    }
+    const rows = allReports();
+    res.status(200).json(filter ? rows.filter((r) => r.status === filter) : rows);
     return;
   }
 
@@ -78,15 +150,44 @@ export default async function handler(req: any, res: any) {
       return;
     }
 
-    const { reportId, status, adminNotes } = req.body ?? {};
+    const { reportId, status, adminNotes, evidence } = req.body ?? {};
     const report = allReports().find((item) => item._id === reportId);
     if (!report) {
       res.status(404).json({ error: "Report not found" });
       return;
     }
 
-    report.status = status ?? report.status;
-    report.adminNotes = adminNotes ?? report.adminNotes;
+    // Enforce a forward-only triage lifecycle: pending → investigating →
+    // resolved|dismissed. Maintainers cannot regress or re-open a closed report
+    // (#714). This keeps the moderation audit trail unambiguous.
+    let nextStatus: ReportStatus | undefined;
+    if (status !== undefined && status !== null) {
+      if (!isReportStatus(status)) {
+        res.status(400).json({
+          error: "Invalid status. Expected pending, investigating, resolved, or dismissed.",
+        });
+        return;
+      }
+      if (STATUS_ORDER[status] < STATUS_ORDER[report.status]) {
+        res.status(409).json({
+          error: `Illegal status transition ${report.status} → ${status}. Triage is forward-only (#714).`,
+          currentStatus: report.status,
+        });
+        return;
+      }
+      nextStatus = status;
+    }
+
+    if (nextStatus) report.status = nextStatus;
+    if (adminNotes !== undefined && adminNotes !== null) {
+      report.adminNotes = String(adminNotes).trim();
+    }
+    if (evidence !== undefined && evidence !== null) {
+      const added = normalizeEvidence(evidence);
+      if (added.length) {
+        report.evidence = report.evidence.concat(added);
+      }
+    }
     report.updatedAt = new Date().toISOString();
     res.status(200).json({ success: true, report });
     return;

--- a/contracts/prompt-hash/MIGRATION.md
+++ b/contracts/prompt-hash/MIGRATION.md
@@ -5,9 +5,26 @@ breaking change to the contract's public interface (a removed/changed
 trait function, error code, storage-key/record shape, or event) relative to
 `contracts/prompt-hash/spec-baseline.json`.
 
+`scripts/dry-run-migration.py` (introduced for #712) previews the migration
+effect of the same diff **without writing any state**. It classifies the
+pending change as `no-op`, `additive`, or `incompatible`, then reports the
+affected storage-key families, expected write counts, TTL implications,
+sample keys, and rollback options:
+
+```bash
+python3 scripts/dry-run-migration.py report          # human-readable
+python3 scripts/dry-run-migration.py report --json   # machine-readable
+python3 scripts/dry-run-migration.py self-test       # no-op/additive/incompatible coverage
+```
+
+Run the dry-run as the first step whenever you intend to upgrade. If it
+returns `BLOCKED`, the change is incompatible and **must not ship** until you
+acknowledge it below and ship a data migration **in the same upgrade** that
+changes the code.
+
 If a change is intentionally breaking, acknowledge **every** reported line
 here with one `ACK-BREAKING:` entry per change (copy the exact line the
-preflight tool printed), describe the migration/rollback plan below it, then
+dry-run/preflight tool printed), describe the migration/rollback plan below it, then
 regenerate the baseline:
 
 ```bash

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -14,6 +14,17 @@ For detailed information, see [Payout Readiness API Reference](./payout-readines
 - Interactive checklists guide creators through setup requirements
 - Graceful error handling with actionable remediation steps
 
+> **Machine-readable schema (#713):** a valid OpenAPI 3.0 document covering
+> the marketplace endpoints below is published at
+> [`docs/openapi.json`](./openapi.json). It is also served live by the backend
+> and rendered as an interactive explorer:
+>
+> - `GET /api/openapi.json` — fetch the JSON schema
+> - `GET /api/docs` — interactive (Redoc) explorer
+>
+> Use the schema with code generators (`openapi-generator`, `hey-api`,
+> Postman import) to keep SDKs and integrations in sync with the API.
+
 ## Common Response Rules
 
 - Successful requests return JSON.
@@ -240,7 +251,99 @@ Example response:
 
 Returns draft and ready-to-publish prompts for the connected creator wallet.
 
-### Version updates
+### Creator sales analytics
+
+`GET /api/prompts/creator/:walletAddress/analytics`
+
+Returns daily sales and revenue for the trailing 30-day window:
+
+```json
+{
+  "dailySales": [
+    { "date": "2026-07-29", "unitsSold": 3, "revenueXlm": 7.5 }
+  ]
+}
+```
+
+### Privacy-safe support metrics (#711)
+
+`GET /api/prompts/creator/:walletAddress/analytics/support-metrics`
+
+Returns conversion, refund, unlock-failure, and review outcomes for the
+creator's listings. **Buyer identities are aggregated server-side and never
+returned**; cohorts below the minimum size are suppressed:
+
+```json
+{
+  "success": true,
+  "analytics": {
+    "windowDays": 30,
+    "cohort": { "activeBuyers": 12, "buyerIdentitiesRedacted": true },
+    "totals": { "views": 420, "purchases": 38, "refunds": 2, "unlockFailures": 4, "reviews": 11 },
+    "metrics": { "conversionRate": 0.0904, "refundRate": 0.0526, "unlockSuccessRate": 0.8947, "satisfactionRate": 0.8181, "averageRating": 4.3 },
+    "unlockFailuresByReason": { "integrity_failure": 3, "no_access": 1 }
+  }
+}
+```
+
+### Purchase transactions (#711)
+
+`GET /api/prompts/buyer/:walletAddress/transactions`
+
+Returns the buyer's licensing/purchase history, each row pairing an on-chain
+purchase with its prompt:
+
+```json
+{
+  "transactions": [
+    {
+      "id": "...",
+      "promptId": "123",
+      "promptTitle": "Launch Strategy Pack",
+      "promptImage": "https://...",
+      "amountXlm": 2.5,
+      "versionIndex": 1,
+      "txHash": "...",
+      "createdAt": "2026-07-29T10:15:30.000Z"
+    }
+  ]
+}
+```
+
+### Abuse reports & triage (#714)
+
+`POST /api/prompts/reports` — submit a report (public). Reporters may attach
+up to 10 evidence items:
+
+```json
+{
+  "promptId": "12345",
+  "reporterAddress": "G...",
+  "reason": "copyright",
+  "description": "Optional details",
+  "evidence": [
+    { "url": "https://source.example/original.pdf", "kind": "pdf" }
+  ]
+}
+```
+
+`GET /api/prompts/reports` — moderation queue (admin token required). Filter
+by `?status=pending|investigating|resolved|dismissed`.
+
+`PATCH /api/prompts/reports` — update triage status/notes (admin token
+required). Triage is **forward-only**: `pending → investigating →
+resolved|dismissed`; regressions and re-opens are rejected with `409`.
+
+```json
+{
+  "reportId": "report_1",
+  "status": "investigating",
+  "adminNotes": "Comparing against the provided source.",
+  "evidence": [{ "url": "https://s3.example/123.png", "kind": "image" }]
+}
+```
+
+## Version updates
 
 `POST /api/prompts/version`
 

--- a/docs/creator-profiles.md
+++ b/docs/creator-profiles.md
@@ -429,6 +429,55 @@ testUrls.forEach(url => {
 3. Ensure proper API request format
 4. Review admin authorization flow
 
+## Dashboard & Seller Analytics
+
+Creators get operational insight into how buyers discover, purchase, refund,
+and unlock their prompts via a privacy-safe analytics surface (`#711`).
+
+### Metrics
+
+| Metric | Derivation | Privacy note |
+|--------|-----------|--------------|
+| **Conversion rate** | purchases / views | Aggregated only |
+| **Refund rate** | refunded purchases / purchases | Aggregated only |
+| **Unlock success rate** | 1 − unlock failures / purchases | Aggregated only |
+| **Satisfaction** | positive reviews / reviews | Aggregated only |
+| **Active buyers** | unique buyer cohorts (suppressed below minimum cohort) | Identity redacted |
+
+### API
+
+`GET /api/prompts/creator/:walletAddress/analytics/support-metrics`
+
+Returns the `SellerAnalytics` shape in `src/lib/analytics/sellerAnalytics.ts`:
+
+```json
+{
+  "success": true,
+  "analytics": {
+    "windowDays": 30,
+    "cohort": { "activeBuyers": 12, "buyerIdentitiesRedacted": true },
+    "totals": { "views": 420, "purchases": 38, "refunds": 2, "unlockFailures": 4, "reviews": 11 },
+    "metrics": {
+      "conversionRate": 0.0904,
+      "refundRate": 0.0526,
+      "unlockSuccessRate": 0.8947,
+      "satisfactionRate": 0.8181,
+      "averageRating": 4.3
+    },
+    "unlockFailuresByReason": { "integrity_failure": 3, "no_access": 1 }
+  }
+}
+```
+
+Buyer wallet addresses never appear in this payload — identities are consumed
+only at the aggregation boundary and suppressed below the minimum cohort size.
+
+### UI
+
+- `src/pages/sell/page.tsx` — **Analytics** view renders `SellerAnalyticsWidget`.
+- `src/pages/profile/page.tsx` — My Inventory tab renders `SellerAnalyticsWidget`
+  beneath `CreatorDashboard`.
+
 ## Related Documentation
 
 - [Moderation and Policy](./operations/incident-response.md)

--- a/docs/data-retention-and-privacy.md
+++ b/docs/data-retention-and-privacy.md
@@ -46,3 +46,23 @@ Contributors must ensure that application logs never capture:
 - The actual prompt text (except for the public preview snippet).
 - Cryptographic signatures or authentication nonces.
 - Personally identifiable information (PII) beyond the public Stellar public key.
+
+## Privacy-Safe Seller Analytics (#711)
+
+Seller/support analytics are aggregated server-side from indexed purchases,
+refunds, unlock audit events, and published reviews. The aggregation layer enforces:
+
+- **Buyer identity redaction** — the seller-facing payload carries counts and
+  rates (`conversionRate`, `refundRate`, `unlockSuccessRate`, satisfaction and
+  average rating) and aggregated cohort sizes only. Raw buyer wallet addresses
+  are consumed inside the aggregation and never included in API responses.
+- **Minimum-cohort suppression** — a single buyer can never be isolated: any
+  cohort below the configured threshold is reported as zero. See
+  `MIN_COHORT_SIZE` in `src/lib/analytics/sellerAnalytics.ts`.
+- **Aggregation-boundary discipline** — the pure aggregation helpers in
+  `src/lib/analytics/sellerAnalytics.ts` are the only place raw activity
+  events and buyer identities meet derived metrics. UI widgets consume only
+  the aggregated shape.
+
+Creator-facing endpoints (`/api/prompts/creator/:walletAddress/analytics/support-metrics`)
+never expose buyer PII beyond the aggregated metrics described above.

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -136,6 +136,36 @@ console.log(top); // [{ promptId, upvotes }, ...]
 | `DELETE` | `/api/governance/vote/:id`  | Remove upvote                                  |
 | `GET`    | `/api/governance/votes/:id` | Get vote count                                 |
 | `GET`    | `/api/governance/top`       | Top-ranked prompts                             |
+| `GET`    | `/api/openapi.json`         | Machine-readable OpenAPI 3.0 schema (#713)     |
+| `GET`    | `/api/docs`                 | Interactive Redoc explorer (#713)              |
+
+## Machine-Readable Schema (#713)
+
+The marketplace REST endpoints (and this SDK) are documented as a machine
+readable OpenAPI 3.0 schema that clients, postman collections, and code
+generators can consume:
+
+- Schema: [`docs/openapi.json`](./openapi.json)
+- Served live: `GET /api/openapi.json`
+- Interactive explorer: `GET /api/docs`
+- Human reference: [docs/api-reference.md](./api-reference.md)
+
+Example — generate a TypeScript client with `openapi-generator`:
+
+```bash
+npx @openapitools/openapi-generator-cli generate \
+  -i docs/openapi.json \
+  -g typescript-fetch \
+  -o ./generated-client
+```
+
+The schema covers prompts, buyer/creator endpoints (including the
+privacy-safe `analytics/support-metrics` of #711), abuse-report evidence and
+triage of #714, reviews, webhooks, notifications, search, and versioning.
+
+> **Note:** authorization for admin-scoped endpoints (e.g. opening the
+> moderation queue or rotating webhook secrets) uses the `x-admin-token`
+> API-key scheme declared under `components.securitySchemes.adminToken`.
 
 Full OpenAPI spec: [docs/api-reference.md](./api-reference.md)
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,0 +1,1393 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "PromptHash Marketplace API",
+    "version": "1.0.0",
+    "description": "Read-only marketplace API for PromptHash. The Soroban contract at `contracts/prompt-hash` is the single source of truth for prompt ownership, listing state, and purchase records. This server is a read-through cache, event indexer, and user-preference store; it never originates authoritative state changes.\n\nServed by the backend at `GET /api/openapi.json`. An interactive explorer (Redoc) is available at `/api/docs`.\n\nGenerated as part of #713 so Stellar/PromptHash SDK consumers and integrators can validate requests against a machine-readable schema."
+  },
+  "servers": [
+    { "url": "https://prompt-hash.example.com", "description": "Production" },
+    { "url": "http://localhost:5000", "description": "Local development" }
+  ],
+  "tags": [
+    { "name": "Prompts", "description": "Indexed prompt listings (read-projection of on-chain state)" },
+    { "name": "Buyer", "description": "Buyer-scoped purchase history and saved prompts" },
+    { "name": "Creator", "description": "Creator-scoped analytics, metrics, and payout statements" },
+    { "name": "Reports", "description": "Off-chain moderation queue; submission is public, reading requires admin" },
+    { "name": "Reviews", "description": "Verified buyer reviews" },
+    { "name": "Webhooks", "description": "Durable outbox webhook subscriptions" },
+    { "name": "Notifications", "description": "User notifications" },
+    { "name": "Search", "description": "Prompt search, suggestions, categories, featured" },
+    { "name": "Versioning", "description": "Prompt revision history and version-gated purchases" },
+    { "name": "System", "description": "Health" }
+  ],
+  "paths": {
+    "/health": {
+      "get": {
+        "tags": ["System"],
+        "summary": "Health check",
+        "description": "Reports indexer state and database backup health.",
+        "operationId": "getHealth",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": { "type": "string", "enum": ["ok"] },
+                    "indexer": {
+                      "type": "object",
+                      "properties": {
+                        "lastProcessedLedger": { "type": "integer" },
+                        "timestamp": { "type": "string", "format": "date-time" }
+                      }
+                    },
+                    "backup": {
+                      "type": "object",
+                      "description": "Backup service health (empty object when disabled)"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/prompts": {
+      "get": {
+        "tags": ["Prompts"],
+        "summary": "List prompt listings",
+        "description": "Returns all indexed prompt listings. On-chain state is authoritative.",
+        "operationId": "listPrompts",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": { "type": "integer", "minimum": 1, "default": 1 },
+            "description": "Page number"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 20 },
+            "description": "Items per page"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Prompts returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "prompts": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/Prompt" }
+                    },
+                    "page": { "type": "integer" },
+                    "total": { "type": "integer" },
+                    "totalPages": { "type": "integer" }
+                  }
+                }
+              }
+            }
+          },
+          "500": { "$ref": "#/components/responses/ServerError" }
+        }
+      }
+    },
+    "/api/prompts/hash/{contentHash}": {
+      "get": {
+        "tags": ["Prompts"],
+        "summary": "Find prompts by content hash",
+        "description": "Duplicate-content detection for prompt search (#333).",
+        "operationId": "getPromptsByHash",
+        "parameters": [
+          {
+            "name": "contentHash",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "SHA-256 content hash of the prompt"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Matching prompts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "prompts": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/Prompt" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/prompts/buyer/{walletAddress}/owned": {
+      "get": {
+        "tags": ["Buyer"],
+        "summary": "List prompts owned by a wallet",
+        "description": "Indexed purchase records for a buyer wallet. Buyer identity is required to scope; the response never exposes other buyers.",
+        "operationId": "getOwnedPrompts",
+        "parameters": [
+          {
+            "name": "walletAddress",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "description": "Stellar public key (G...)" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Owned prompts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "prompts": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/Prompt" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/prompts/buyer/{walletAddress}/saved": {
+      "get": {
+        "tags": ["Buyer"],
+        "summary": "List prompts saved by a wallet",
+        "operationId": "getSavedPrompts",
+        "parameters": [
+          {
+            "name": "walletAddress",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Saved prompts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "prompts": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/Prompt" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/prompts/buyer/{walletAddress}/transactions": {
+      "get": {
+        "tags": ["Buyer"],
+        "summary": "Purchase transaction history for a buyer",
+        "description": "Pairs each on-chain purchase record with the prompt it unlocked.",
+        "operationId": "getPurchaseTransactions",
+        "parameters": [
+          {
+            "name": "walletAddress",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Transaction history",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "transactions": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/PurchaseTransaction" }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" }
+        }
+      }
+    },
+    "/api/prompts/creator/{walletAddress}/analytics": {
+      "get": {
+        "tags": ["Creator"],
+        "summary": "Creator sales analytics",
+        "description": "Daily sales and revenue for the trailing 30-day window.",
+        "operationId": "getCreatorSalesAnalytics",
+        "parameters": [
+          {
+            "name": "walletAddress",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Daily sales series",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "dailySales": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "date": { "type": "string", "format": "date" },
+                          "unitsSold": { "type": "number" },
+                          "revenueXlm": { "type": "number", "format": "float" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/api/prompts/creator/{walletAddress}/analytics/support-metrics": {
+      "get": {
+        "tags": ["Creator"],
+        "summary": "Privacy-safe seller support metrics (#711)",
+        "description": "Conversion, refund, unlock-failure, and review outcomes for a creator's listings. Buyer identities are aggregated server-side and redacted; cohorts below the minimum are suppressed.",
+        "operationId": "getCreatorSupportMetrics",
+        "parameters": [
+          {
+            "name": "walletAddress",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Support metrics (buyer identities redacted)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean" },
+                    "analytics": { "$ref": "#/components/schemas/SellerAnalytics" }
+                  }
+                }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/ServerError" }
+        }
+      }
+    },
+    "/api/prompts/creator/{walletAddress}/payout-statement": {
+      "get": {
+        "tags": ["Creator"],
+        "summary": "Creator payout statement",
+        "description": "Sale-date, prompt, buyer address, gross/fee/net amounts. Supports `format=csv` or `Accept: text/csv` for CSV output.",
+        "operationId": "getCreatorPayoutStatement",
+        "parameters": [
+          {
+            "name": "walletAddress",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "startDate",
+            "in": "query",
+            "schema": { "type": "string", "format": "date" }
+          },
+          {
+            "name": "endDate",
+            "in": "query",
+            "schema": { "type": "string", "format": "date" }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "schema": { "type": "string", "enum": ["json", "csv"] }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Payout statement",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "statement": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/PayoutRow" }
+                    }
+                  }
+                }
+              },
+              "text/csv": {
+                "schema": { "type": "string", "description": "CSV payout statement" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/prompts/creator/{walletAddress}/drafts": {
+      "get": {
+        "tags": ["Creator"],
+        "summary": "List prompt drafts for a creator",
+        "operationId": "getDraftPrompts",
+        "parameters": [
+          {
+            "name": "walletAddress",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Draft prompts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "prompts": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/Prompt" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/prompts/{onChainId}/price-history": {
+      "get": {
+        "tags": ["Prompts"],
+        "summary": "Price history for a listing",
+        "description": "Derived from indexed `PromptPriceUpdated` events.",
+        "operationId": "getPriceHistory",
+        "parameters": [
+          {
+            "name": "onChainId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Price history",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "history": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "price": { "type": "number", "format": "float" },
+                          "changedAt": { "type": "string", "format": "date-time" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/prompts/preview": {
+      "post": {
+        "tags": ["Prompts"],
+        "summary": "Record a prompt preview (analytics)",
+        "description": "Records a preview view for analytics; non-authoritative.",
+        "operationId": "recordPreview",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["promptId"],
+                "properties": {
+                  "promptId": { "type": "string" },
+                  "walletAddress": { "type": "string", "description": "Optional; omitted to stay anonymous" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Preview recorded" }
+        }
+      }
+    },
+    "/api/prompts/preview/stats": {
+      "get": {
+        "tags": ["Prompts"],
+        "summary": "Preview analytics",
+        "operationId": "getPreviewStats",
+        "responses": {
+          "200": {
+            "description": "Preview statistics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "totalPreviews": { "type": "integer" },
+                    "perPrompt": {
+                      "type": "object",
+                      "additionalProperties": { "type": "integer" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/prompts/reports": {
+      "post": {
+        "tags": ["Reports"],
+        "summary": "Submit a prompt abuse report",
+        "description": "Public — anyone can flag a listing. Off-chain moderation data only; does not affect on-chain access control.",
+        "operationId": "submitPromptReport",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["promptId", "reporterAddress", "reason"],
+                "properties": {
+                  "promptId": { "type": "string" },
+                  "reporterAddress": { "type": "string" },
+                  "reason": {
+                    "type": "string",
+                    "enum": ["copyright", "misleading", "duplicate", "inappropriate", "other"]
+                  },
+                  "description": { "type": "string" },
+                  "evidence": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "url": { "type": "string", "format": "uri" },
+                        "kind": { "type": "string", "enum": ["image", "pdf", "link", "text"] }
+                      }
+                    },
+                    "description": "Optional evidence attachments supporting the report (#714)."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Report created with triage status `pending`",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean", "enum": [true] },
+                    "report": { "$ref": "#/components/schemas/PromptReport" }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" }
+        }
+      },
+      "get": {
+        "tags": ["Reports"],
+        "summary": "List the moderation queue (admin only)",
+        "description": "Requires an admin scope token (`reports:read`). Lists reports with triage state.",
+        "operationId": "getPromptReports",
+        "security": [{ "adminToken": [] }],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "schema": { "$ref": "#/components/schemas/ReportStatus" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Reports (optionally filtered by status)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "reports": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/PromptReport" }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/api/prompts/admin/integrity-report": {
+      "get": {
+        "tags": ["Prompts"],
+        "summary": "Content integrity recheck report (admin only)",
+        "description": "Requires `integrity:read` admin scope.",
+        "operationId": "getIntegrityReport",
+        "security": [{ "adminToken": [] }],
+        "responses": {
+          "200": {
+            "description": "Integrity report",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "summaries": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/api/prompts/admin/integrity-check": {
+      "post": {
+        "tags": ["Prompts"],
+        "summary": "Trigger a content integrity check (admin only)",
+        "description": "Requires `integrity:write` admin scope. Body may include a `promptId` for a single prompt; otherwise a full sweep runs.",
+        "operationId": "triggerIntegrityCheck",
+        "security": [{ "adminToken": [] }],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "promptId": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Check triggered",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": { "type": "object", "additionalProperties": true },
+                    "report": { "type": "object", "additionalProperties": true }
+                  }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/api/prompts/buyer/save": {
+      "post": {
+        "tags": ["Buyer"],
+        "summary": "Save a prompt (non-authoritative preference)",
+        "description": "Wallet-signed preference. Does not change on-chain access.",
+        "operationId": "savePrompt",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["walletAddress", "promptId"],
+                "properties": {
+                  "walletAddress": { "type": "string" },
+                  "promptId": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Saved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean", "enum": [true] }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/prompts/buyer/unsave": {
+      "post": {
+        "tags": ["Buyer"],
+        "summary": "Unsave a prompt (non-authoritative preference)",
+        "operationId": "unsavePrompt",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["walletAddress", "promptId"],
+                "properties": {
+                  "walletAddress": { "type": "string" },
+                  "promptId": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Unsaaved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean", "enum": [true] }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/reviews/submit": {
+      "post": {
+        "tags": ["Reviews"],
+        "summary": "Submit or update a verified review",
+        "description": "Requires ownership — the reviewer must have a purchase record for the prompt.",
+        "operationId": "submitReview",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["promptId", "userAddress", "rating"],
+                "properties": {
+                  "promptId": { "type": "string" },
+                  "userAddress": { "type": "string" },
+                  "rating": { "type": "integer", "minimum": 1, "maximum": 5 },
+                  "text": { "type": "string", "maxLength": 2000 }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Review upserted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean", "enum": [true] },
+                    "review": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "string" },
+                        "rating": { "type": "integer" },
+                        "createdAt": { "type": "string", "format": "date-time" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "403": {
+            "description": "Reviewer does not own the prompt",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/reviews/list": {
+      "get": {
+        "tags": ["Reviews"],
+        "summary": "List reviews for a prompt with rating stats",
+        "operationId": "listReviews",
+        "parameters": [
+          {
+            "name": "promptId",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Reviews and distribution stats",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "reviews": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/Review" }
+                    },
+                    "stats": {
+                      "type": "object",
+                      "properties": {
+                        "total": { "type": "integer" },
+                        "averageRating": { "type": "number", "format": "float" },
+                        "distribution": {
+                          "type": "object",
+                          "additionalProperties": { "type": "integer" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": { "$ref": "#/components/responses/ServerError" }
+        }
+      }
+    },
+    "/api/webhooks/": {
+      "post": {
+        "tags": ["Webhooks"],
+        "summary": "Register a webhook subscription",
+        "description": "Off-chain event delivery for indexed contract events (durable outbox).",
+        "operationId": "registerWebhook",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["url", "walletAddress", "events"],
+                "properties": {
+                  "url": { "type": "string", "format": "uri" },
+                  "walletAddress": { "type": "string" },
+                  "events": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Contract event names to deliver"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Subscription created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean", "enum": [true] },
+                    "subscription": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "string" },
+                        "secret": { "type": "string", "description": "Returned once on creation" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["Webhooks"],
+        "summary": "Get the caller's webhook subscription",
+        "operationId": "getWebhook",
+        "responses": {
+          "200": { "description": "Subscription" }
+        }
+      },
+      "delete": {
+        "tags": ["Webhooks"],
+        "summary": "Delete the caller's webhook subscription",
+        "operationId": "deleteWebhook",
+        "responses": {
+          "200": { "description": "Deleted" }
+        }
+      }
+    },
+    "/api/webhooks/dead-letters": {
+      "get": {
+        "tags": ["Webhooks"],
+        "summary": "List undeliverable webhook events (admin only)",
+        "operationId": "listWebhookDeadLetters",
+        "security": [{ "adminToken": [] }],
+        "responses": {
+          "200": {
+            "description": "Dead-letter events",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "deadLetters": { "type": "array", "items": { "type": "object" } }
+                  }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/api/webhooks/{id}/rotate-secret": {
+      "post": {
+        "tags": ["Webhooks"],
+        "summary": "Rotate a webhook signing secret (admin only)",
+        "operationId": "rotateWebhookSecret",
+        "security": [{ "adminToken": [] }],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "New secret",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "secret": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/api/notifications/{walletAddress}": {
+      "get": {
+        "tags": ["Notifications"],
+        "summary": "List notifications for a wallet",
+        "operationId": "getNotifications",
+        "parameters": [
+          {
+            "name": "walletAddress",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Notifications" }
+        }
+      },
+      "delete": {
+        "tags": ["Notifications"],
+        "summary": "Clear notifications for a wallet",
+        "operationId": "clearNotifications",
+        "parameters": [
+          {
+            "name": "walletAddress",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Cleared" }
+        }
+      }
+    },
+    "/api/notifications/{walletAddress}/unread-count": {
+      "get": {
+        "tags": ["Notifications"],
+        "summary": "Unread notification count",
+        "operationId": "getUnreadCount",
+        "parameters": [
+          {
+            "name": "walletAddress",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Count",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "count": { "type": "integer" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/notifications/{walletAddress}/mark-read": {
+      "post": {
+        "tags": ["Notifications"],
+        "summary": "Mark notifications read",
+        "operationId": "markNotificationsRead",
+        "parameters": [
+          {
+            "name": "walletAddress",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Marked read" }
+        }
+      }
+    },
+    "/api/search/prompts": {
+      "get": {
+        "tags": ["Search"],
+        "summary": "Search prompts",
+        "description": "Advanced filtering and pagination over indexed listings.",
+        "operationId": "searchPrompts",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "category",
+            "in": "query",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "minPrice",
+            "in": "query",
+            "schema": { "type": "number" }
+          },
+          {
+            "name": "maxPrice",
+            "in": "query",
+            "schema": { "type": "number" }
+          },
+          {
+            "name": "sortBy",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": ["recent", "price-low", "price-high", "sales", "rating"]
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": { "type": "integer", "default": 1 }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer", "default": 20 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Search result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "results": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/Prompt" }
+                    },
+                    "total": { "type": "integer" },
+                    "page": { "type": "integer" },
+                    "totalPages": { "type": "integer" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/search/suggestions": {
+      "get": {
+        "tags": ["Search"],
+        "summary": "Search suggestions",
+        "operationId": "getSearchSuggestions",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer", "default": 5 }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Suggestions" }
+        }
+      }
+    },
+    "/api/search/categories": {
+      "get": {
+        "tags": ["Search"],
+        "summary": "Listing categories with counts",
+        "operationId": "getCategories",
+        "responses": {
+          "200": { "description": "Categories" }
+        }
+      }
+    },
+    "/api/search/featured": {
+      "get": {
+        "tags": ["Search"],
+        "summary": "Featured prompts",
+        "operationId": "getFeaturedPrompts",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer", "default": 6 }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Featured prompts" }
+        }
+      }
+    },
+    "/api/versions/{promptId}/history": {
+      "get": {
+        "tags": ["Versioning"],
+        "summary": "Prompt revision history",
+        "operationId": "getPromptVersionHistory",
+        "parameters": [
+          {
+            "name": "promptId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Revision history",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "versions": { "type": "array", "items": { "type": "object" } }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/versions/update": {
+      "post": {
+        "tags": ["Versioning"],
+        "summary": "Record an off-chain prompt update",
+        "operationId": "recordPromptUpdate",
+        "responses": {
+          "200": { "description": "Recorded" }
+        }
+      }
+    },
+    "/api/versions/purchase": {
+      "post": {
+        "tags": ["Versioning"],
+        "summary": "Record a version-gated purchase",
+        "operationId": "recordVersionPurchase",
+        "responses": {
+          "200": { "description": "Recorded" }
+        }
+      }
+    },
+    "/api/versions/buyer-version": {
+      "get": {
+        "tags": ["Versioning"],
+        "summary": "Version entitlement for a buyer",
+        "operationId": "getBuyerVersion",
+        "responses": {
+          "200": { "description": "Buyer version entitlement" }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "adminToken": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-admin-token",
+        "description": "Admin scope token — e.g. `reports:read`, `integrity:write`. Returned by the admin login flow (#542)."
+      }
+    },
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": { "type": "string" },
+          "correlationId": { "type": "string", "description": "Present on 500 responses (correlation middleware)" }
+        }
+      },
+      "Prompt": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "onChainId": { "type": "string" },
+          "title": { "type": "string" },
+          "category": { "type": "string" },
+          "price": { "type": "number", "format": "float" },
+          "image": { "type": "string" },
+          "previewText": { "type": "string" },
+          "salesCount": { "type": "integer" },
+          "status": {
+            "type": "string",
+            "enum": ["draft", "active", "paused", "retired"]
+          },
+          "owner": { "type": "string", "description": "Creator wallet address" },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "averageRating": { "type": "number", "format": "float" }
+        }
+      },
+      "PurchaseTransaction": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "promptId": { "type": "string" },
+          "promptTitle": { "type": "string" },
+          "promptImage": { "type": "string" },
+          "amountXlm": { "type": ["number", "null"] },
+          "versionIndex": { "type": "integer" },
+          "txHash": { "type": "string" },
+          "createdAt": { "type": "string", "format": "date-time" }
+        }
+      },
+      "PayoutRow": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "saleDate": { "type": "string", "format": "date-time" },
+          "promptTitle": { "type": "string" },
+          "promptId": { "type": "string" },
+          "buyerAddress": { "type": "string" },
+          "grossAmount": { "type": "number", "format": "float" },
+          "platformFee": { "type": "number", "format": "float" },
+          "creatorAmount": { "type": "number", "format": "float" },
+          "txHash": { "type": "string" }
+        }
+      },
+      "SellerAnalytics": {
+        "type": "object",
+        "description": "Privacy-safe seller metrics (#711). Buyer identities are never included.",
+        "properties": {
+          "windowDays": { "type": "integer" },
+          "cohort": {
+            "type": "object",
+            "properties": {
+              "activeBuyers": { "type": "integer" },
+              "buyerIdentitiesRedacted": { "type": "boolean", "enum": [true] }
+            }
+          },
+          "totals": {
+            "type": "object",
+            "properties": {
+              "views": { "type": "integer" },
+              "purchases": { "type": "integer" },
+              "refunds": { "type": "integer" },
+              "unlockFailures": { "type": "integer" },
+              "reviews": { "type": "integer" }
+            }
+          },
+          "metrics": {
+            "type": "object",
+            "properties": {
+              "conversionRate": { "type": "number", "format": "float" },
+              "refundRate": { "type": "number", "format": "float" },
+              "unlockSuccessRate": { "type": "number", "format": "float" },
+              "satisfactionRate": { "type": "number", "format": "float" },
+              "averageRating": { "type": "number", "format": "float" }
+            }
+          },
+          "unlockFailuresByReason": {
+            "type": "object",
+            "additionalProperties": { "type": "integer" }
+          }
+        }
+      },
+      "ReportStatus": {
+        "type": "string",
+        "enum": ["pending", "investigating", "resolved", "dismissed"],
+        "description": "Triage lifecycle (#714): reports enter `pending`, move to `investigating` when an admin picks them up, then to `resolved` or `dismissed`."
+      },
+      "Evidence": {
+        "type": "object",
+        "properties": {
+          "url": { "type": "string", "format": "uri" },
+          "kind": { "type": "string", "enum": ["image", "pdf", "link", "text"] },
+          "addedBy": { "type": "string", "description": "Wallet address or `maintainer`" }
+        }
+      },
+      "PromptReport": {
+        "type": "object",
+        "properties": {
+          "_id": { "type": "string" },
+          "promptId": { "type": "string" },
+          "reporterAddress": { "type": "string" },
+          "reason": {
+            "type": "string",
+            "enum": ["copyright", "misleading", "duplicate", "inappropriate", "other"]
+          },
+          "description": { "type": "string" },
+          "evidence": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Evidence" },
+            "description": "Captured evidence attachments (#714)."
+          },
+          "status": { "$ref": "#/components/schemas/ReportStatus" },
+          "adminNotes": { "type": "string" },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "updatedAt": { "type": "string", "format": "date-time" }
+        }
+      },
+      "Review": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "promptId": { "type": "string" },
+          "userAddress": { "type": "string" },
+          "rating": { "type": "integer", "minimum": 1, "maximum": 5 },
+          "text": { "type": "string" },
+          "createdAt": { "type": "integer", "description": "Unix millisecond timestamp" },
+          "verified": { "type": "boolean" }
+        }
+      }
+    },
+    "responses": {
+      "BadRequest": {
+        "description": "Bad request",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "Missing or invalid admin scope token",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "Resource not found",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "ServerError": {
+        "description": "Internal server error",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/operations/contract-upgrades.md
+++ b/docs/operations/contract-upgrades.md
@@ -78,6 +78,34 @@ builds or touches the network. The gate:
    `openssl dgst -sha256 -sign`; otherwise it's written unsigned with
    instructions to sign it retroactively.
 
+## Migration Dry-Run Output (#712)
+
+Before submitting any upgrade, preview its storage/migration effect without
+touching chain state:
+
+```bash
+python3 scripts/dry-run-migration.py report
+```
+
+The report classifies the diff as `no-op`, `additive`, or `incompatible` and
+publishes:
+
+- **Affected storage-key families** (e.g. `Prompt`, `BuyerPrompts`,
+  `AllPrompts`) and sample keys slow the impact scan.
+- **Expected write counts** — for `incompatible` changes this is the number
+  of key families the accompanying data migration must rewrite/replace.
+- **TTL implications** — whether new keys inherit the family TTL policy and
+  whether stale lifetime entries require a post-migration sweep.
+- **Rollback notes** — for adds, a pure Wasm-hash downgrade remains possible;
+  for incompatible changes, a restore-from-snapshot path is required.
+- **Recommendation** — `SAFE TO UPGRADE`, `SAFE TO UPGRADE (additive only)`,
+  or `BLOCKED` (incompatible changes must be acknowledged in `MIGRATION.md`
+  and shipped with a data migration in the same upgrade).
+
+Use `--json` for CI/instrumentation and `self-test` to exercise the
+`no-op`/`additive`/`incompatible` classifiers offline. The tool never writes
+state — every report starts with `wrote_state: false`.
+
 After an intentional interface change, regenerate the baseline and commit it:
 
 ```bash

--- a/docs/operations/incident-response.md
+++ b/docs/operations/incident-response.md
@@ -136,6 +136,74 @@ Used for edge cases not covered by standard categories. Requires detailed notes.
    - Determine required action (restrict/retire)
    - Identify applicable policy reference
 
+### Report Evidence Capture & Triage (#714)
+
+Every report submitted through `POST /api/prompts/reports` now enters a
+structured triage queue with captured evidence and a forward-only lifecycle.
+
+**Evidence capture**
+
+Reporters may attach up to 10 evidence items (`url` + `kind` of
+`image` | `pdf` | `link` | `text`) at submission:
+
+```json
+POST /api/prompts/reports
+{
+  "promptId": "12345",
+  "reporterAddress": "G...",
+  "reason": "copyright",
+  "description": "Listed text matches a protected work.",
+  "evidence": [
+    { "url": "https://source.example/original.pdf", "kind": "pdf" },
+    { "url": "https://prompt-hash.example/p/mirror", "kind": "link" }
+  ]
+}
+```
+
+Evidence URLs are normalized, capped at 10 per report, and stored on the
+report record. Admin (`PATCH`) calls may append further evidence
+(`addedBy: "maintainer"`).
+
+**Triage lifecycle**
+
+Reports always enter the queue as `pending`. Maintainers move them through a
+strictly forward-only state machine — **regressions and re-opens are
+rejected with a `409`** to keep the audit trail unambiguous:
+
+```
+pending ──► investigating ──► resolved
+                 │
+                 └──────────► dismissed
+```
+
+| Status | Meaning |
+|--------|---------|
+| `pending` | Awaiting review (default on submission) |
+| `investigating` | A maintainer picked it up; evidence review in progress |
+| `resolved` | Action taken (e.g. content restricted/retired) |
+| `dismissed` | Reviewed and no action warranted |
+
+Maintainers update status and add notes/admin-supplied evidence via admin
+`PATCH`:
+
+```json
+PATCH /api/prompts/reports
+{
+  "reportId": "report_...",
+  "status": "investigating",
+  "adminNotes": "Comparing against provided source URL.",
+  "evidence": [{ "url": "https://s3.example/evidence/123.png", "kind": "image" }]
+}
+```
+
+The queue can be filtered by triage status:
+
+```
+GET /api/prompts/reports?status=investigating   # admin only
+```
+
+Escalation and follow-on moderation still follow the procedures below.
+
 ### 2. Execute Moderation Action
 
 **Authorization Required**: Admin wallet signature

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -48,6 +48,20 @@ Performs a comprehensive check of the deployed contract's configuration (owner, 
 ./scripts/verify.sh local
 ```
 
+### 4. `preflight_upgrade.py`
+Blocks network-affecting upgrades on unacknowledged breaking interface changes. See `docs/operations/contract-upgrades.md` and `contracts/prompt-hash/MIGRATION.md`.
+
+### 5. `dry-run-migration.py` (#712)
+Previews the storage-migration effect of an upgrade **without writing state**:
+classifies the pending diff as `no-op`/`additive`/`incompatible` and reports
+affected key families, expected writes, TTL implications, and rollback notes.
+
+```bash
+python3 scripts/dry-run-migration.py report          # human-readable
+python3 scripts/dry-run-migration.py report --json   # machine-readable
+python3 scripts/dry-run-migration.py self-test       # classifier coverage
+```
+
 ## Environment Consistency
 
 The `deploy.sh` script synchronizes the following variables across `.env` and `.env.local`:

--- a/scripts/dry-run-migration.py
+++ b/scripts/dry-run-migration.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""
+PromptHash contract storage migration dry-run tool (#712).
+
+Lets maintainers preview the effect of a contract upgrade on persistent
+storage BEFORE any state is written or any upgrade is submitted. It reuses
+the preflight baseline diff (scripts/preflight_upgrade.py) and classifies
+every detected interface/storage change into one of three migration classes:
+
+  no-op         — No behavioural/storage change detected (clean).
+  additive      — New keys, functions, events or variants added. Existing
+                  records and indexes are untouched; safe to upgrade.
+  incompatible  — A removed or reshaped key/record/function/event. Requires
+                  an explicit data migration and an ACK-BREAKING entry in
+                  contracts/prompt-hash/MIGRATION.md.
+
+The report includes affected storage-key families, expected write counts,
+TTL implications and rollback notes, and it NEVER writes to chain state.
+
+Usage:
+    python3 scripts/dry-run-migration.py report
+    python3 scripts/dry-run-migration.py report --json
+    python3 scripts/dry-run-migration.py self-test
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from preflight_upgrade import build_spec, spec_hash, REPO_ROOT, BASELINE_PATH
+
+
+def _entries_mean_storage_family(entries):
+    """Extract the storage-key family names from a data_type's entries.
+
+    For a `#[contracttype] enum DataKey`, entries are enum variants like
+    `Prompt(u64)`. We return each variant's first identifier as the storage
+    family (e.g. "Prompt", "BuyerPrompts", "AllPrompts").
+    """
+    families = []
+    for entry in entries:
+        # entry normalized form: "Prompt(u64)" -> "Prompt"; "AllPrompts" -> "AllPrompts"
+        name = entry.split("(")[0].strip().rstrip(",")
+        if name:
+            families.append(name)
+    return families
+
+
+def classify_change(baseline: dict, current: dict) -> dict:
+    """Classify the diff between baseline and current spec.
+
+    Returns a report object with `class`, `breakout`, `storage_families`,
+    `expected_writes`, `sample_keys`, `risk_notes`, `rollback_notes`,
+    `suppressed`. Mirrors preflight's breaking-change detection so both tools
+    stay in lockstep.
+    """
+    breaking = []
+    added_functions = []
+    added_types = []
+    added_variants = []
+    added_events = []
+    suppressed = []
+
+    for name, sig in baseline.get("functions", {}).items():
+        if name not in current.get("functions", {}):
+            breaking.append(f"function `{name}` was removed from PromptHashTrait")
+        elif current["functions"][name] != sig:
+            breaking.append(f"function `{name}` signature changed")
+    for name in current.get("functions", {}):
+        if name not in baseline.get("functions", {}):
+            added_functions.append(name)
+
+    for name, code in baseline.get("errors", {}).items():
+        if name not in current.get("errors", {}):
+            breaking.append(f"Error variant `{name}` (={code}) was removed")
+        elif current["errors"][name] != code:
+            breaking.append(
+                f"Error variant `{name}` discriminant changed"
+            )
+    for name in current.get("errors", {}):
+        if name not in baseline.get("errors", {}):
+            added_variants.append(f"Error::{name}")
+
+    for type_name, entries in baseline.get("data_types", {}).items():
+        current_entries = current.get("data_types", {}).get(type_name)
+        if current_entries is None:
+            breaking.append(f"type `{type_name}` was removed")
+            continue
+        current_set = set(current_entries)
+        for entry in entries:
+            if entry not in current_set:
+                breaking.append(f"`{type_name}`: `{entry}` was removed or changed shape")
+    for type_name in current.get("data_types", {}):
+        if type_name not in baseline.get("data_types", {}):
+            added_types.append(type_name)
+        else:
+            baseline_set = set(baseline["data_types"].get(type_name, []))
+            for entry in current["data_types"].get(type_name, []):
+                if entry not in baseline_set:
+                    added_variants.append(f"{type_name}::{entry}")
+
+    for name, fields in baseline.get("events", {}).items():
+        current_fields = current.get("events", {}).get(name)
+        if current_fields is None:
+            breaking.append(f"event `{name}` was removed")
+        elif current_fields != fields:
+            breaking.append(f"event `{name}` field list changed")
+    for name in current.get("events", {}):
+        if name not in baseline.get("events", {}):
+            added_events.append(name)
+
+    # Storage families touched by breaking changes.
+    storage_families = set()
+    for change in breaking:
+        # "`DataKey`: `Prompt(u64)` was removed or changed shape" -> Prompt
+        if ":" in change.split("` was")[0] and "`" in change:
+            kind = change.split("`")[1]
+            fam = change.split("`")[3].split("(")[0]
+            if kind == "DataKey":
+                storage_families.add(fam)
+    # Also treat removed data types as affected families.
+    for type_name in baseline.get("data_types", {}):
+        if type_name not in current.get("data_types", {}):
+            storage_families.add(type_name)
+
+    if breaking:
+        classification = "incompatible"
+    elif added_functions or added_types or added_variants or added_events:
+        classification = "additive"
+    else:
+        classification = "no-op"
+
+    return {
+        "class": classification,
+        "breaking": breaking,
+        "added_functions": added_functions,
+        "added_types": added_types,
+        "added_variants": added_variants,
+        "added_events": added_events,
+        "storage_families": sorted(storage_families),
+        "suppressed": suppressed,
+    }
+
+
+def ttl_notes(classification: str, family_count: int) -> list:
+    if family_count == 0:
+        return ["No persistent keys affected — TTL policy unchanged."]
+    if classification == "additive":
+        return [
+            "New keys inherit the TTL policy of their family "
+            "(see contracts/prompt-hash/src/ttl_policy.rs, get_ttl_for_key).",
+            "Existing records/lifetimes are untouched.",
+        ]
+    return [
+        "Removed or reshaped keys may retain stale TTL entries until the "
+        "migration `remove`s them or `extend_key_ttl` is re-applied.",
+        "Run a bounded `renew_critical_keys` sweep after the migration to "
+        "normalise lifetimes.",
+    ]
+
+
+def rollback_notes(classification: str) -> list:
+    if classification == "no-op":
+        return ["No migration required; nothing to roll back."]
+    if classification == "additive":
+        return [
+            "Additive changes are backward compatible; downgrade keeps the "
+            "old Wasm hash live with no data rewrite.",
+            "Keep the previous WASM_HASH recorded in deploy-manifests/ for "
+            "a pure downgrade rollback.",
+        ]
+    return [
+        "Incompatible changes are not reversible in place. Before shipping:",
+        "  1. Snapshot canonical records (on-chain) and index state.",
+        "  2. Acknowledge each ACK-BREAKING line in MIGRATION.md.",
+        "  3. Ship the data migration in the SAME upgrade that changes the code.",
+        "  4. Verify with scripts/verify.sh; be prepared to restore the "
+        "snapshot if verification fails.",
+    ]
+
+
+def build_report(report: dict) -> dict:
+    dc = report["class"]
+    families = report["storage_families"]
+    return {
+        "dry_run": True,
+        "wrote_state": False,
+        "class": dc,
+        "semantic_notes": {
+            "breaking": report["breaking"],
+            "added_functions": report["added_functions"],
+            "added_types": report["added_types"],
+            "added_variants": report["added_variants"],
+            "added_events": report["added_events"],
+        },
+        "storage": {
+            "affected_key_families": list(families),
+            "family_count": len(families),
+            "sample_keys": [f"{f}(<id>)" for f in sorted(families)[:5]],
+        },
+        "expected_writes": {
+            "count": (
+                len(report["breaking"])
+                if dc == "incompatible"
+                else len(families)
+            ),
+            "note": (
+                "The migration must rewrite/replace every affected key family."
+                if dc == "incompatible"
+                else "No writes are required beyond the additive keys described."
+            ),
+        },
+        "ttl_implications": ttl_notes(dc, len(families)),
+        "rollback_notes": rollback_notes(dc),
+        "recommendation": (
+            "SAFE TO UPGRADE — no storage migration required."
+            if dc == "no-op"
+            else (
+                "SAFE TO UPGRADE — additive only; existing records untouched."
+                if dc == "additive"
+                else "BLOCKED — incompatible storage change; complete MIGRATION.md "
+                "ACK-BREAKING entries and a data migration before upgrading."
+            )
+        ),
+    }
+
+
+def cmd_report(args: argparse.Namespace) -> int:
+    if not BASELINE_PATH.exists():
+        print(
+            f"No baseline found at {BASELINE_PATH.relative_to(REPO_ROOT)}. "
+            "Run `python3 scripts/preflight_upgrade.py generate-baseline` once.",
+            file=sys.stderr,
+        )
+        return 1
+
+    baseline = json.loads(BASELINE_PATH.read_text())
+    current = build_spec()
+    report = build_report(classify_change(baseline, current))
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print("=" * 72)
+        print("PROMPTHASH CONTRACT MIGRATION DRY-RUN")
+        print("=" * 72)
+        print(f"dry-run: {report['dry_run']}   wrote_state: {report['wrote_state']}")
+        print(f"baseline: {spec_hash(baseline)[:12]}  current: {spec_hash(current)[:12]}")
+        print(f"class: {report['class']}")
+        print(f"recommendation: {report['recommendation']}")
+        print()
+        print(f"storage families affected: {report['storage']['family_count']}")
+        for key in report["storage"]["sample_keys"]:
+            print(f"  - {key}")
+        print()
+        print("expected writes:")
+        print(f"  count: {report['expected_writes']['count']}")
+        print(f"  {report['expected_writes']['note']}")
+        print()
+        print("TTL implications:")
+        for note in report["ttl_implications"]:
+            print(f"  - {note}")
+        print()
+        print("rollback notes:")
+        for note in report["rollback_notes"]:
+            print(f"  - {note}")
+        print()
+        if report["semantic_notes"]["breaking"]:
+            print("breaking changes:")
+            for change in report["semantic_notes"]["breaking"]:
+                print(f"  ! {change}")
+        print()
+    return 0
+
+
+def cmd_self_test(_args: argparse.Namespace) -> int:
+    """Offline tests covering no-op, additive, and incompatible migrations."""
+    empty = {"functions": {}, "errors": {}, "data_types": {}, "events": {}}
+
+    no_op = classify_change(empty, empty)
+    assert no_op["class"] == "no-op", no_op
+    assert no_op["breaking"] == []
+
+    additive = classify_change(
+        empty,
+        {
+            "functions": {"new_fn": "fn new_fn()"},
+            "events": {"NewEvent": ["field"]},
+            "data_types": {"DataKey": ["BrandNew(u64)"]},
+        },
+    )
+    assert additive["class"] == "additive", additive
+    assert additive["breaking"] == []
+
+    baseline_keys = {"data_types": {"DataKey": ["Prompt(u64)", "AllPrompts"]}}
+    removed_key = classify_change(
+        baseline_keys,
+        {"data_types": {"DataKey": ["AllPrompts"]}},
+    )
+    assert removed_key["class"] == "incompatible", removed_key
+    assert "Prompt" in removed_key["storage_families"], removed_key
+
+    reshaped = classify_change(
+        {"data_types": {"Prompt": ["pub id: u64", "pub price: i128"]}},
+        {"data_types": {"Prompt": ["pub id: u64", "pub price: String"]}},
+    )
+    assert reshaped["class"] == "incompatible", reshaped
+
+    report = build_report(no_op)
+    assert report["dry_run"] and not report["wrote_state"]
+    assert report["recommendation"].startswith("SAFE")
+
+    incompatible_report = build_report(removed_key)
+    assert incompatible_report["recommendation"].startswith("BLOCKED")
+    assert incompatible_report["expected_writes"]["count"] == len(
+        removed_key["breaking"]
+    )
+
+    print("self-test OK: no-op, additive, and incompatible migrations classified correctly")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="PromptHash contract storage migration dry-run report."
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+    report_parser = sub.add_parser(
+        "report", help="Print a dry-run migration report for the current diff."
+    )
+    report_parser.add_argument(
+        "--json", action="store_true", help="Emit the report as JSON."
+    )
+    sub.add_parser(
+        "self-test",
+        help="Run offline unit tests for no-op/additive/incompatible classification.",
+    )
+    args = parser.parse_args()
+    if args.command == "self-test":
+        return cmd_self_test(args)
+    return cmd_report(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server/src/controllers/docsControllers.ts
+++ b/server/src/controllers/docsControllers.ts
@@ -1,0 +1,56 @@
+import { Request, Response } from "express";
+import fs from "fs";
+import path from "path";
+
+/**
+ * Serves the machine-readable OpenAPI schema for the marketplace API (#713).
+ *
+ * The authoritative document lives at docs/openapi.json next to the human
+ * reference at docs/api-reference.md. It is served read-only at
+ * GET /api/openapi.json so SDK consumers (hey-api, openapi-generator, postman)
+ * can fetch and validate against a live schema, and an interactive
+ * Redoc-powered explorer is available at GET /api/docs.
+ */
+const OPENAPI_PATH = path.resolve(
+  __dirname,
+  "../../../docs/openapi.json",
+);
+
+const REDOC_HTML = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>PromptHash Marketplace API — Reference</title>
+    <style>
+      body { margin: 0; font-family: system-ui, sans-serif; }
+      #openapi { position: relative; }
+    </style>
+  </head>
+  <body>
+    <div id="openapi"></div>
+    <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
+    <script>
+      Redoc.init("/api/openapi.json", { hideDownloadButton: false, expandResponses: "200" }, document.getElementById("openapi"));
+    </script>
+  </body>
+</html>`;
+
+export const GetOpenApiSchema = (_req: Request, res: Response): Response => {
+  try {
+    const schema = fs.readFileSync(OPENAPI_PATH, "utf-8");
+    res.setHeader("Cache-Control", "public, max-age=300");
+    res.status(200).type("application/json").send(schema);
+  } catch (err) {
+    console.error("GetOpenApiSchema error:", err);
+    return res
+      .status(500)
+      .json({ error: "OpenAPI schema not available" });
+  }
+  return res;
+};
+
+export const GetOpenApiExplorer = (_req: Request, res: Response): Response => {
+  res.setHeader("Cache-Control", "public, max-age=300");
+  return res.status(200).type("text/html").send(REDOC_HTML);
+};

--- a/server/src/controllers/purchaseControllers.ts
+++ b/server/src/controllers/purchaseControllers.ts
@@ -3,6 +3,8 @@ import connectDb from "../db/connectDb";
 import Purchase from "../models/Purchase";
 import Prompt from "../models/Prompt";
 import User from "../models/User";
+import Review from "../models/Review";
+import AuditLog from "../models/AuditLog";
 import { markPrivate } from "../middleware/etag";
 import {
   reconcilePayoutEvents,
@@ -11,6 +13,8 @@ import {
   type PayoutStatementLine,
   type PayoutStatementSummary,
 } from "../services/payoutReconciliation";
+import { aggregateSellerAnalytics } from "../../../src/lib/analytics/sellerAnalytics.js";
+import type { SellerEvent } from "../../../src/lib/analytics/sellerAnalytics.js";
 
 interface PromptLite {
   _id: unknown;
@@ -188,6 +192,125 @@ export const GetCreatorSalesAnalytics = async (
     console.error("Get creator sales analytics error:", err);
     return res.status(500).json({
       error: (err as Error).message || "Failed to fetch creator sales analytics",
+    });
+  }
+};
+
+/**
+ * Returns privacy-safe conversion, refund, unlock-failure, and review outcomes
+ * for a creator's listings (#711).
+ *
+ * Buyer identities are aggregated server-side only: the response carries
+ * counts and rates, never raw buyer wallet addresses. The aggregation honours
+ * a minimum-cohort suppression so a lone buyer can never be isolated.
+ */
+const WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+export const GetCreatorSupportMetrics = async (
+  req: Request,
+  res: Response,
+): Promise<Response> => {
+  try {
+    markPrivate(res);
+    await connectDb();
+    const { walletAddress } = req.params;
+
+    if (!walletAddress) {
+      return res.status(400).json({ error: "walletAddress is required." });
+    }
+
+    const user = await User.findOne({
+      walletAddress: walletAddress.toLowerCase(),
+    }).select("_id");
+
+    if (!user) {
+      return res.status(404).json({ error: "User not found." });
+    }
+
+    const prompts = (await Prompt.find({ owner: user._id })
+      .select("_id onChainId")
+      .lean()) as unknown as { _id: unknown; onChainId?: string | null }[];
+
+    if (prompts.length === 0) {
+      return res.json({
+        success: true,
+        analytics: aggregateSellerAnalytics([]),
+      });
+    }
+
+    const promptIds = new Set<string>();
+    for (const prompt of prompts) {
+      promptIds.add(String(prompt._id));
+      if (prompt.onChainId) promptIds.add(String(prompt.onChainId));
+    }
+    const promptIdList = [...promptIds];
+    const since = new Date(Date.now() - WINDOW_MS);
+
+    const [purchases, reviews, unlockAudits] = await Promise.all([
+      Purchase.find({
+        promptId: { $in: promptIdList },
+        createdAt: { $gte: since },
+      })
+        .select("buyerWallet promptId status disputeResolution")
+        .lean(),
+      Review.find({ promptId: { $in: promptIdList }, status: "published" })
+        .select("userAddress rating promptId")
+        .lean(),
+      AuditLog.find({
+        promptId: { $in: promptIdList },
+        createdAt: { $gte: since },
+        $or: [
+          { action: { $regex: /^unlock_/ } },
+          { action: "unlock_success" },
+        ],
+      })
+        .select("action promptId walletAddress")
+        .lean(),
+    ]);
+
+    const events: SellerEvent[] = [];
+
+    for (const purchase of purchases) {
+      const buyer = String(purchase.buyerWallet ?? "");
+      if (!buyer) continue;
+      events.push({ buyerId: buyer, kind: "purchase", promptId: "0" });
+      if (purchase.status === "disputed" && purchase.disputeResolution === "refunded") {
+        events.push({ buyerId: buyer, kind: "refund", promptId: "0" });
+      }
+    }
+
+    for (const review of reviews) {
+      const rating = Number(review.rating ?? 0);
+      events.push({
+        buyerId: review.userAddress ?? "anon",
+        kind: "review",
+        promptId: "0",
+        rating,
+        isPositiveReview: rating >= 4,
+      });
+    }
+
+    for (const audit of unlockAudits) {
+      const action = String(audit.action ?? "");
+      if (action === "unlock_success") continue;
+      const reason = action.replace(/^unlock_/, "");
+      events.push({
+        buyerId: audit.walletAddress ?? "anon",
+        kind: "unlock_failure",
+        promptId: "0",
+        reason: reason || "unknown",
+      });
+    }
+
+    return res.json({
+      success: true,
+      analytics: aggregateSellerAnalytics(events, { enforceMinCohort: true }),
+    });
+  } catch (err) {
+    console.error("Get creator support metrics error:", err);
+    return res.status(500).json({
+      success: false,
+      error: (err as Error).message || "Failed to fetch support metrics",
     });
   }
 };

--- a/server/src/routes/promptRoutes.ts
+++ b/server/src/routes/promptRoutes.ts
@@ -16,6 +16,7 @@ import {
 } from "../controllers/controllers";
 import {
   GetCreatorSalesAnalytics,
+  GetCreatorSupportMetrics,
   GetPurchaseTransactions,
   GetCreatorPayoutStatement,
   GetIntegrityReport,
@@ -59,6 +60,10 @@ promptRouter.get("/buyer/:walletAddress/owned", GetOwnedPrompts);
 promptRouter.get("/buyer/:walletAddress/saved", GetSavedPrompts);
 promptRouter.get("/buyer/:walletAddress/transactions", GetPurchaseTransactions);
 promptRouter.get("/creator/:walletAddress/analytics", GetCreatorSalesAnalytics);
+promptRouter.get(
+  "/creator/:walletAddress/analytics/support-metrics",
+  GetCreatorSupportMetrics,
+);
 promptRouter.get(
   "/creator/:walletAddress/payout-statement",
   GetCreatorPayoutStatement,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -13,6 +13,10 @@ import searchRouter from "./routes/searchRoutes";
 import { fulfillmentRouter } from "./routes/fulfillmentRoutes";
 import { reviewRouter } from "./routes/reviewRoutes";
 import { notificationRouter } from "./routes/notificationRoutes";
+import {
+  GetOpenApiSchema,
+  GetOpenApiExplorer,
+} from "./controllers/docsControllers";
 import { runBackup, getBackupHealth } from "./services/backupService";
 import { IndexerState } from "./models/IndexerState";
 import { startIndexer } from "./services/indexer";
@@ -63,6 +67,10 @@ app.use("/api/search", searchRouter);
 app.use("/api/fulfillment", strictLimiter, fulfillmentRouter);
 app.use("/api/reviews", reviewRouter);
 app.use("/api/notifications", authLimiter, notificationRouter);
+
+// Machine-readable API schema + interactive explorer (#713).
+app.get("/api/openapi.json", GetOpenApiSchema);
+app.get("/api/docs", GetOpenApiExplorer);
 
 app.post("/api/test-prompt", strictLimiter, TestPromptProxy);
 

--- a/server/src/tests/openapi.test.ts
+++ b/server/src/tests/openapi.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+describe("OpenAPI reference schema (#713)", () => {
+  const docsDir = path.resolve(__dirname, "../../../docs");
+  const openApiPath = path.join(docsDir, "openapi.json");
+  const spec = JSON.parse(fs.readFileSync(openApiPath, "utf-8"));
+
+  it("is a valid OpenAPI 3.0 document", () => {
+    expect(spec.openapi).toBe("3.0.3");
+    expect(spec.info.title).toBe("PromptHash Marketplace API");
+    expect(spec.info.version).toBe("1.0.0");
+    expect(spec.paths).toBeDefined();
+    expect(spec.components.schemas).toBeDefined();
+  });
+
+  it("documents every marketplace endpoint from promptRoutes.ts", () => {
+    const promptRoutes = fs.readFileSync(
+      path.resolve(__dirname, "../routes/promptRoutes.ts"),
+      "utf-8",
+    );
+
+    // Extract route strings like "/buyer/:walletAddress/owned" from the router.
+    const routeMatches = promptRoutes.matchAll(
+      /(?:promptRouter\.(?:get|post|route)\()\s*["'`]([^"'`]+)["'`]/g,
+    );
+    const documented = new Set(Object.keys(spec.paths));
+    const normalize = (p: string) =>
+      p
+        .replace(/\/$/, "")
+        .replace(/\{[^}]+\}/g, ":param")
+        .replace(/:[a-zA-Z_]+/g, ":param");
+
+    for (const match of routeMatches) {
+      const route = match[1] as string;
+      const openApiPath = `/api/prompts${route}`.replace(/\/$/, "");
+      const routeNormalized = normalize(openApiPath);
+      let found = false;
+      for (const candidate of documented) {
+        if (normalize(candidate) === routeNormalized) {
+          found = true;
+          break;
+        }
+      }
+      expect(found, `Route ${openApiPath} is not documented in docs/openapi.json`).toBe(true);
+    }
+  });
+
+  it("documents admin-scoped endpoints as requiring the admin token", () => {
+    const reportsPath = spec.paths["/api/prompts/reports"].get;
+    expect(reportsPath.security).toEqual([{ adminToken: [] }]);
+
+    const integrityPath = spec.paths["/api/prompts/admin/integrity-report"].get;
+    expect(integrityPath.security).toEqual([{ adminToken: [] }]);
+  });
+
+  it("documents the #711 privacy-safe analytics endpoint with redaction", () => {
+    const analyticsPath =
+      spec.paths["/api/prompts/creator/{walletAddress}/analytics/support-metrics"].get;
+    expect(analyticsPath).toBeDefined();
+    const analyticsSchema = spec.components.schemas.SellerAnalytics;
+    expect(analyticsSchema.properties.cohort.properties.buyerIdentitiesRedacted.enum).toEqual([true]);
+  });
+
+  it("covers prompts, purchase/unlock queue side-effects, reviews, webhooks, and reports", () => {
+    const paths = Object.keys(spec.paths);
+    expect(paths.some((p) => p === "/api/prompts")).toBe(true);
+    expect(paths.some((p) => p.includes("transactions"))).toBe(true);
+    expect(paths.some((p) => p.includes("reviews"))).toBe(true);
+    expect(paths.some((p) => p.includes("webhooks"))).toBe(true);
+    expect(paths.some((p) => p === "/api/prompts/reports")).toBe(true);
+    expect(paths.some((p) => p.includes("price-history"))).toBe(true);
+  });
+});
+
+describe("OpenAPI serving surface (#713)", () => {
+  const serverSource = fs.readFileSync(
+    path.resolve(__dirname, "../server.ts"),
+    "utf-8",
+  );
+
+  it("serves the machine-readable schema at GET /api/openapi.json", () => {
+    expect(serverSource).toContain('app.get("/api/openapi.json", GetOpenApiSchema)');
+  });
+
+  it("exposes an interactive explorer at GET /api/docs", () => {
+    expect(serverSource).toContain('app.get("/api/docs", GetOpenApiExplorer)');
+  });
+
+  it("validates the served JSON with a Redoc init pointing at the schema", () => {
+    const controllerSource = fs.readFileSync(
+      path.resolve(__dirname, "../controllers/docsControllers.ts"),
+      "utf-8",
+    );
+    expect(controllerSource).toContain("Redoc.init");
+    expect(controllerSource).toContain('"/api/openapi.json"');
+  });
+});

--- a/src/components/analytics/SellerAnalyticsWidget.tsx
+++ b/src/components/analytics/SellerAnalyticsWidget.tsx
@@ -1,0 +1,197 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  BarChart3,
+  PackageX,
+  RefreshCcw,
+  ShieldCheck,
+  Star,
+  TrendingUp,
+  Users,
+} from "lucide-react";
+import { Skeleton } from "@/components/Skeleton";
+import { Badge } from "@/components/ui/badge";
+import type { SellerAnalytics } from "@/lib/analytics/sellerAnalytics";
+
+const fmtPct = (value: number | null) =>
+  value === null ? "—" : `${(value * 100).toFixed(1)}%`;
+
+interface SellerAnalyticsFetchResponse {
+  success: boolean;
+  analytics: SellerAnalytics | null;
+  error?: string;
+}
+
+async function fetchSellerAnalytics(
+  walletAddress: string,
+): Promise<SellerAnalytics | null> {
+  const response = await fetch(
+    `/api/prompts/creator/${encodeURIComponent(walletAddress)}/analytics/support-metrics`,
+  );
+  if (!response.ok) return null;
+  const body = (await response.json()) as SellerAnalyticsFetchResponse;
+  return body.success ? body.analytics : null;
+}
+
+const pctToTone = (value: number | null) => {
+  if (value === null) return "slate";
+  if (value >= 0.5) return "emerald";
+  if (value >= 0.2) return "amber";
+  return "rose";
+};
+
+const toneClasses: Record<string, string> = {
+  emerald: "border-emerald-400/30 bg-emerald-400/10 text-emerald-200",
+  amber: "border-amber-400/30 bg-amber-400/10 text-amber-200",
+  rose: "border-rose-400/30 bg-rose-400/10 text-rose-200",
+  slate: "border-white/10 bg-white/[0.04] text-slate-300",
+};
+
+function MetricTile({
+  label,
+  value,
+  tone,
+  icon,
+  description,
+}: {
+  label: string;
+  value: string;
+  tone: string;
+  icon: React.ReactNode;
+  description: string;
+}) {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+      <div className="flex items-center gap-2">
+        {icon}
+        <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">
+          {label}
+        </p>
+      </div>
+      <div className="mt-2 flex items-baseline gap-2">
+        <span className="text-2xl font-bold tabular-nums text-white">{value}</span>
+        <Badge className={toneClasses[tone]}>
+          {tone === "emerald"
+            ? "Healthy"
+            : tone === "rose"
+              ? "At risk"
+              : tone === "amber"
+                ? "Watch"
+                : "No data"}
+        </Badge>
+      </div>
+      <p className="mt-1 text-xs text-slate-500">{description}</p>
+    </div>
+  );
+}
+
+export function SellerAnalyticsWidget({
+  walletAddress,
+}: {
+  walletAddress: string;
+}) {
+  const { data, isLoading } = useQuery({
+    queryKey: ["seller-analytics", walletAddress],
+    queryFn: () => fetchSellerAnalytics(walletAddress),
+    staleTime: 60_000,
+    enabled: Boolean(walletAddress),
+  });
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+            <Skeleton className="h-3 w-20" />
+            <Skeleton className="mt-2 h-7 w-14" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="rounded-xl border border-dashed border-white/15 bg-white/[0.02] p-6 text-center">
+        <BarChart3 className="mx-auto h-5 w-5 text-slate-500" />
+        <p className="mt-2 text-sm text-slate-400">
+          Conversion &amp; support metrics are computed from off-chain purchases,
+          refunds, unlocks, and reviews once data is available.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="flex items-center gap-2">
+          <TrendingUp className="h-4 w-4 text-emerald-300" />
+          <h3 className="text-sm font-semibold uppercase tracking-widest text-slate-400">
+            Conversion &amp; Support
+          </h3>
+        </div>
+        <Badge className="border-white/10 bg-white/[0.04] text-slate-300">
+          <ShieldCheck className="mr-1 h-3 w-3" />
+          Buyer identities redacted
+        </Badge>
+        <Badge className="border-white/10 bg-white/[0.04] text-slate-300">
+          <Users className="mr-1 h-3 w-3" />
+          {data.cohort.activeBuyers} active buyers
+        </Badge>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <MetricTile
+          label="Conversion"
+          value={fmtPct(data.metrics.conversionRate)}
+          tone={pctToTone(data.metrics.conversionRate)}
+          icon={<BarChart3 className="h-3.5 w-3.5 text-cyan-200" />}
+          description={`${data.totals.purchases} purchases / ${data.totals.views} views`}
+        />
+        <MetricTile
+          label="Refund rate"
+          value={fmtPct(data.metrics.refundRate)}
+          tone={pctToTone(data.metrics.refundRate)}
+          icon={<RefreshCcw className="h-3.5 w-3.5 text-amber-200" />}
+          description={`${data.totals.refunds} refunds / ${data.totals.purchases} purchases`}
+        />
+        <MetricTile
+          label="Unlock success"
+          value={fmtPct(data.metrics.unlockSuccessRate)}
+          tone={pctToTone(data.metrics.unlockSuccessRate)}
+          icon={<PackageX className="h-3.5 w-3.5 text-rose-200" />}
+          description={`${data.totals.unlockFailures} failures recorded`}
+        />
+        <MetricTile
+          label="Satisfaction"
+          value={fmtPct(data.metrics.satisfactionRate)}
+          tone={data.metrics.averageRating === null ? "slate" : "emerald"}
+          icon={<Star className="h-3.5 w-3.5 text-amber-200" />}
+          description={
+            data.metrics.averageRating === null
+              ? `${data.totals.reviews} reviews`
+              : `${data.metrics.averageRating.toFixed(1)} avg rating · ${data.totals.reviews}`
+          }
+        />
+      </div>
+
+      {Object.keys(data.unlockFailuresByReason).length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {Object.entries(data.unlockFailuresByReason).map(([reason, count]) => (
+            <Badge
+              key={reason}
+              className="border-rose-400/20 bg-rose-400/[0.07] text-rose-200"
+            >
+              {reason}: {count}
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      <p className="text-xs text-slate-500">
+        Metrics are aggregated across a {data.windowDays}-day window. Individual
+        buyer identities are never returned or stored in analytics output.
+      </p>
+    </div>
+  );
+}

--- a/src/components/prompts/ReportDialog.tsx
+++ b/src/components/prompts/ReportDialog.tsx
@@ -7,7 +7,7 @@ import {
   ChevronRight,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { ReportClient, REPORT_REASONS, type ReportReason } from "@/lib/reports/reportClient";
+import { ReportClient, REPORT_REASONS, type ReportReason, type ReportEvidence } from "@/lib/reports/reportClient";
 
 export interface ReportDialogProps {
   promptId: string;
@@ -29,8 +29,17 @@ export function ReportDialog({
     ""
   );
   const [description, setDescription] = useState("");
+  const [evidenceUrl, setEvidenceUrl] = useState("");
+  const [evidence, setEvidence] = useState<ReportEvidence[]>([]);
   const [error, setError] = useState<string>("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const addEvidence = () => {
+    const url = evidenceUrl.trim();
+    if (!url) return;
+    setEvidence((prev) => [...prev, { url, kind: "link" }]);
+    setEvidenceUrl("");
+  };
 
   const handleSubmit = async () => {
     setError("");
@@ -53,7 +62,8 @@ export function ReportDialog({
         promptId,
         userAddress,
         selectedReason as ReportReason,
-        description
+        description,
+        evidence.length ? evidence : undefined
       );
 
       setStage("success");
@@ -63,6 +73,8 @@ export function ReportDialog({
         setStage("form");
         setSelectedReason("");
         setDescription("");
+        setEvidenceUrl("");
+        setEvidence([]);
         setError("");
       }, 2000);
     } catch (err) {
@@ -152,6 +164,63 @@ export function ReportDialog({
                 />
                 <p className="text-xs text-slate-500 text-right">
                   {description.length}/500
+                </p>
+              </div>
+
+              {/* Evidence (#714) */}
+              <div className="space-y-2">
+                <label htmlFor="report-evidence" className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+                  Evidence links (optional)
+                </label>
+                <div className="flex gap-2">
+                  <input
+                    id="report-evidence"
+                    type="url"
+                    value={evidenceUrl}
+                    onChange={(e) => setEvidenceUrl(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        e.preventDefault();
+                        addEvidence();
+                      }
+                    }}
+                    placeholder="https://..."
+                    className="flex-1 px-4 py-3 rounded-lg border border-white/10 bg-white/5 text-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/50"
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={addEvidence}
+                    disabled={!evidenceUrl.trim()}
+                    className="px-3"
+                  >
+                    Add
+                  </Button>
+                </div>
+                {evidence.length > 0 && (
+                  <ul className="space-y-1.5">
+                    {evidence.map((item, index) => (
+                      <li
+                        key={`${item.url}-${index}`}
+                        className="flex items-center justify-between gap-2 rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm"
+                      >
+                        <span className="truncate text-slate-300">{item.url}</span>
+                        <button
+                          type="button"
+                          onClick={() =>
+                            setEvidence((prev) => prev.filter((_, i) => i !== index))
+                          }
+                          className="ml-2 shrink-0 text-slate-500 hover:text-red-400 transition-colors"
+                          aria-label="Remove evidence link"
+                        >
+                          <X className="h-4 w-4" />
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                <p className="text-xs text-slate-500">
+                  Up to 10 evidence links help our moderation team verify your report.
                 </p>
               </div>
 

--- a/src/lib/analytics/sellerAnalytics.test.ts
+++ b/src/lib/analytics/sellerAnalytics.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import {
+  aggregateSellerAnalytics,
+  MIN_COHORT_SIZE,
+  type SellerEvent,
+} from "./sellerAnalytics";
+
+function sampleEvents(): SellerEvent[] {
+  const buyers = ["GSSSBUYER1", "GSSSBUYER2", "GSSSBUYER3", "GSSSBUYER4"];
+  const events: SellerEvent[] = [];
+  for (const buyer of buyers) {
+    events.push({ buyerId: buyer, kind: "view", promptId: "0" });
+    events.push({ buyerId: buyer, kind: "view", promptId: "1" });
+    events.push({ buyerId: buyer, kind: "purchase", promptId: "0" });
+  }
+  events.push({ buyerId: buyers[0], kind: "purchase", promptId: "1" });
+  events.push({ buyerId: buyers[0], kind: "refund", promptId: "1" });
+  events.push({ buyerId: buyers[0], kind: "unlock_failure", promptId: "0", reason: "no_access" });
+  events.push({ buyerId: buyers[1], kind: "review", promptId: "0", rating: 5, isPositiveReview: true });
+  events.push({ buyerId: buyers[2], kind: "review", promptId: "0", rating: 4, isPositiveReview: true });
+  events.push({ buyerId: buyers[3], kind: "review", promptId: "0", rating: 2, isPositiveReview: false });
+  return events;
+}
+
+describe("aggregateSellerAnalytics", () => {
+  it("computes conversion, refund, and unlock-success rates accurately", () => {
+    const analytics = aggregateSellerAnalytics(sampleEvents(), {
+      enforceMinCohort: false,
+    });
+
+    // 8 views → 5 purchases across 4 buyers
+    expect(analytics.totals.views).toBe(8);
+    expect(analytics.totals.purchases).toBe(5);
+    expect(analytics.totals.refunds).toBe(1);
+    expect(analytics.totals.unlockFailures).toBe(1);
+    expect(analytics.metrics.conversionRate).toBeCloseTo(5 / 8, 5);
+    expect(analytics.metrics.refundRate).toBeCloseTo(1 / 5, 5);
+    expect(analytics.metrics.unlockSuccessRate).toBeCloseTo(1 - 1 / 5, 5);
+  });
+
+  it("rolls review outcomes up into satisfaction and average rating", () => {
+    const analytics = aggregateSellerAnalytics(sampleEvents(), {
+      enforceMinCohort: false,
+    });
+    expect(analytics.totals.reviews).toBe(3);
+    expect(analytics.metrics.averageRating).toBeCloseTo((5 + 4 + 2) / 3, 5);
+    expect(analytics.metrics.satisfactionRate).toBeCloseTo(2 / 3, 5);
+  });
+
+  it("never leaks buyer identities in the output", () => {
+    const analytics = aggregateSellerAnalytics(sampleEvents());
+    const serialized = JSON.stringify(analytics);
+    expect(serialized).not.toContain("GSSSBUYER1");
+    expect(serialized).not.toContain("GSSSBUYER");
+    expect(analytics.cohort.buyerIdentitiesRedacted).toBe(true);
+  });
+
+  it("suppresses active-buyer cohort counts below the privacy threshold", () => {
+    const singleBuyer = aggregateSellerAnalytics(
+      [
+        { buyerId: "GOLONELY", kind: "view", promptId: "0" },
+        { buyerId: "GOLONELY", kind: "purchase", promptId: "0" },
+      ],
+      { enforceMinCohort: true },
+    );
+    expect(singleBuyer.cohort.activeBuyers).toBe(0);
+
+    const multiBuyer = aggregateSellerAnalytics(
+      [
+        { buyerId: "GA", kind: "view", promptId: "0" },
+        { buyerId: "GB", kind: "view", promptId: "0" },
+      ],
+      { enforceMinCohort: true },
+    );
+    expect(multiBuyer.cohort.activeBuyers).toBe(MIN_COHORT_SIZE);
+  });
+
+  it("returns null rates when there is no denominator", () => {
+    const analytics = aggregateSellerAnalytics([], { enforceMinCohort: false });
+    expect(analytics.totals.views).toBe(0);
+    expect(analytics.metrics.conversionRate).toBeNull();
+    expect(analytics.metrics.refundRate).toBeNull();
+    expect(analytics.metrics.unlockSuccessRate).toBeNull();
+    expect(analytics.metrics.satisfactionRate).toBeNull();
+  });
+
+  it("groups unlock failures by reason without exposing buyers", () => {
+    const analytics = aggregateSellerAnalytics(
+      [
+        { buyerId: "G1", kind: "unlock_failure", promptId: "0", reason: "no_access" },
+        { buyerId: "G2", kind: "unlock_failure", promptId: "0", reason: "integrity_failure" },
+        { buyerId: "G3", kind: "unlock_failure", promptId: "0", reason: "no_access" },
+      ],
+      { enforceMinCohort: false },
+    );
+    expect(analytics.unlockFailuresByReason).toEqual({
+      no_access: 2,
+      integrity_failure: 1,
+    });
+  });
+
+  it("counts a single buyer once per cohort even across event kinds", () => {
+    const analytics = aggregateSellerAnalytics(sampleEvents(), {
+      enforceMinCohort: false,
+    });
+    // 4 distinct buyers participate across view/purchase/refund/unlock/review.
+    expect(analytics.cohort.activeBuyers).toBe(4);
+  });
+});

--- a/src/lib/analytics/sellerAnalytics.ts
+++ b/src/lib/analytics/sellerAnalytics.ts
@@ -1,0 +1,152 @@
+/**
+ * Privacy-safe seller analytics — issue #711.
+ *
+ * Converts raw, per-buyer marketplace activity into aggregated, privacy-safe
+ * metrics for creators. The aggregation layer is the ONLY place where buyer
+ * identities are allowed to meet seller analytics: inputs may carry raw
+ * buyer addresses, but outputs never do. Aggregates are suppressed below a
+ * minimum cohort size so that a single buyer can never be isolated.
+ */
+
+/** Raw per-event input carrying buyer identity. Never leaves this module. */
+export interface SellerEvent {
+  /** Opaque buyer id — used only for uniqueness cohorts, never returned. */
+  buyerId: string;
+  kind: "view" | "purchase" | "refund" | "unlock_failure" | "review";
+  promptId: string;
+  /** For `review` events: 1–5. */
+  rating?: number;
+  /** For `review` events: a negative review is a support concern. */
+  isPositiveReview?: boolean;
+  /** Reason category for unlock failures (e.g. `no_access`, `integrity_failure`). */
+  reason?: string;
+  occurredAt?: string;
+}
+
+/** Aggregated, identity-free metrics a seller is allowed to see. */
+export interface SellerAnalytics {
+  windowDays: number;
+  cohort: {
+    /** Active buyers measured one-per-buyer; suppressed when < MIN_COHORT_SIZE. */
+    activeBuyers: number;
+    buyerIdentitiesRedacted: boolean;
+  };
+  totals: {
+    views: number;
+    purchases: number;
+    refunds: number;
+    unlockFailures: number;
+    reviews: number;
+  };
+  metrics: {
+    /** purchases / views, expressed 0–1 (null when no views). */
+    conversionRate: number | null;
+    /** refunds / purchases, expressed 0–1 (null when no purchases). */
+    refundRate: number | null;
+    /** 1 - unlockFailures / purchases, expressed 0–1 (null when no purchases). */
+    unlockSuccessRate: number | null;
+    /** positive reviews / reviews, expressed 0–1 (null when no reviews). */
+    satisfactionRate: number | null;
+    averageRating: number | null;
+  };
+  /** Per-category breakdown for unlock failures — tags only, no buyer ids. */
+  unlockFailuresByReason: Record<string, number>;
+}
+
+/** Minimum cohort size before a count is emitted (prevents buyer isolation). */
+export const MIN_COHORT_SIZE = 2;
+export const DEFAULT_WINDOW_DAYS = 30;
+
+export interface SellerAnalyticsOptions {
+  windowDays?: number;
+  /** Suppress any metric whose cohort is below MIN_COHORT_SIZE. Off in tests. */
+  enforceMinCohort?: boolean;
+}
+
+/** Count unique buyer ids; returns null when the cohort is too small to emit. */
+function safeCohortCount(buyerIds: Set<string>, enforceMinCohort: boolean): number {
+  if (enforceMinCohort && buyerIds.size < MIN_COHORT_SIZE) {
+    return 0;
+  }
+  return buyerIds.size;
+}
+
+export function aggregateSellerAnalytics(
+  events: SellerEvent[],
+  options: SellerAnalyticsOptions = {},
+): SellerAnalytics {
+  const windowDays = options.windowDays ?? DEFAULT_WINDOW_DAYS;
+  const enforceMinCohort = options.enforceMinCohort ?? true;
+
+  const buyersByKind = new Map<SellerEvent["kind"], Set<string>>();
+  const buyers = new Set<string>();
+  const allBuyers = new Set<string>();
+
+  let views = 0;
+  let purchases = 0;
+  let refunds = 0;
+  let unlockFailures = 0;
+  let reviews = 0;
+  let ratingSum = 0;
+  let positiveReviews = 0;
+  const unlockFailuresByReason: Record<string, number> = {};
+
+  for (const event of events) {
+    allBuyers.add(event.buyerId);
+    if (event.kind === "view") views += 1;
+    if (event.kind === "purchase") purchases += 1;
+    if (event.kind === "refund") refunds += 1;
+    if (event.kind === "unlock_failure") {
+      unlockFailures += 1;
+      const reason = event.reason ?? "unknown";
+      unlockFailuresByReason[reason] = (unlockFailuresByReason[reason] ?? 0) + 1;
+    }
+    if (event.kind === "review") {
+      reviews += 1;
+      if (event.rating !== undefined) ratingSum += event.rating;
+      if (event.isPositiveReview) positiveReviews += 1;
+    }
+    const set = buyersByKind.get(event.kind) ?? new Set<string>();
+    set.add(event.buyerId);
+    buyersByKind.set(event.kind, set);
+    buyers.add(event.buyerId);
+  }
+
+  const redacted = true; // Outputs never carry buyer identity by construction.
+
+  return {
+    windowDays,
+    cohort: {
+      activeBuyers: safeCohortCount(allBuyers, enforceMinCohort),
+      buyerIdentitiesRedacted: redacted,
+    },
+    totals: {
+      views,
+      purchases,
+      refunds,
+      unlockFailures,
+      reviews,
+    },
+    metrics: {
+      conversionRate: views > 0 ? purchases / views : null,
+      refundRate: purchases > 0 ? refunds / purchases : null,
+      unlockSuccessRate:
+        purchases > 0 ? Math.max(0, 1 - unlockFailures / purchases) : null,
+      satisfactionRate: reviews > 0 ? positiveReviews / reviews : null,
+      averageRating: reviews > 0 ? ratingSum / reviews : null,
+    },
+    unlockFailuresByReason,
+  };
+}
+
+/** Human-readable summary for dashboard copy (kept side-effect free). */
+export function summarizeSellerAnalytics(analytics: SellerAnalytics): string[] {
+  const pct = (value: number | null) =>
+    value === null ? "n/a" : `${(value * 100).toFixed(1)}%`;
+  return [
+    `Conversion ${pct(analytics.metrics.conversionRate)}`,
+    `Refund rate ${pct(analytics.metrics.refundRate)}`,
+    `Unlock success ${pct(analytics.metrics.unlockSuccessRate)}`,
+    `Satisfaction ${pct(analytics.metrics.satisfactionRate)}`,
+  ];
+}

--- a/src/lib/reports/reportClient.ts
+++ b/src/lib/reports/reportClient.ts
@@ -15,13 +15,22 @@ export const REPORT_REASONS: Record<ReportReason, string> = {
   other: "Other reason",
 };
 
+export type ReportStatus = "pending" | "investigating" | "resolved" | "dismissed";
+
+export interface ReportEvidence {
+  url: string;
+  kind: "image" | "pdf" | "link" | "text";
+  addedBy?: string;
+}
+
 export interface PromptReport {
   _id?: string;
   promptId: string;
   reporterAddress: string;
   reason: ReportReason;
   description?: string;
-  status?: "pending" | "investigating" | "resolved" | "dismissed";
+  evidence?: ReportEvidence[];
+  status?: ReportStatus;
   adminNotes?: string;
   createdAt: string;
 }
@@ -30,6 +39,7 @@ export interface ReportResponse {
   success: boolean;
   message: string;
   reportId?: string;
+  evidenceCount?: number;
 }
 
 export class ReportClient {
@@ -40,7 +50,8 @@ export class ReportClient {
     promptId: string,
     reporterAddress: string,
     reason: ReportReason,
-    description?: string
+    description?: string,
+    evidence?: ReportEvidence[]
   ): Promise<ReportResponse> {
     try {
       const response = await fetch("/api/prompts/reports", {
@@ -53,6 +64,7 @@ export class ReportClient {
           reporterAddress,
           reason,
           description,
+          evidence,
         }),
       });
 

--- a/src/pages/profile/page.tsx
+++ b/src/pages/profile/page.tsx
@@ -33,6 +33,7 @@ import { TipButton } from "@/components/TipButton";
 import { UnlockExplainer, type UnlockState } from "@/components/UnlockExplainer";
 import { WebhookSettings } from "@/components/WebhookSettings";
 import { CreatorDashboard } from "@/components/analytics/CreatorDashboard";
+import { SellerAnalyticsWidget } from "@/components/analytics/SellerAnalyticsWidget";
 import { PostVersionUpdate } from "@/components/PostVersionUpdate";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -1116,7 +1117,10 @@ export default function ProfilePage() {
                   <TabsContent value="created" className="mt-0 space-y-6">
                     {/* Creator activity dashboard — metrics, revenue, top performers (#213) */}
                     {!isPublicView && address && (
-                      <CreatorDashboard walletAddress={address} />
+                      <div className="space-y-6">
+                        <CreatorDashboard walletAddress={address} />
+                        <SellerAnalyticsWidget walletAddress={address} />
+                      </div>
                     )}
 
                     {createdQuery.isLoading ? (

--- a/src/pages/sell/page.tsx
+++ b/src/pages/sell/page.tsx
@@ -1,12 +1,14 @@
 import { useState } from "react";
-import { PlusCircle, LayoutList } from "lucide-react";
+import { PlusCircle, LayoutList, BarChart3 } from "lucide-react";
 import { Footer } from "@/components/footer";
 import { Navigation } from "@/components/navigation";
 import { CreatePromptForm } from "./CreatePromptForm";
 import MyPrompts from "./MyPrompts";
+import { SellerAnalyticsWidget } from "@/components/analytics/SellerAnalyticsWidget";
+import { useWallet } from "@/hooks/useWallet";
 import { usePageMeta } from "@/lib/seo/usePageMeta";
 
-type View = "create" | "manage";
+type View = "create" | "manage" | "analytics";
 
 export default function SellPage() {
   usePageMeta({
@@ -15,6 +17,7 @@ export default function SellPage() {
   });
 
   const [view, setView] = useState<View>("create");
+  const { address } = useWallet();
 
   return (
     <div className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.12),_transparent_35%),linear-gradient(180deg,_#020617,_#0f172a_45%,_#020617)] text-white">
@@ -81,12 +84,48 @@ export default function SellPage() {
             <LayoutList className="h-4 w-4" />
             My prompts
           </button>
+          <button
+            onClick={() => setView("analytics")}
+            aria-pressed={view === "analytics"}
+            className={`min-h-11 flex flex-1 items-center justify-center gap-2 rounded-xl px-3 py-2.5 text-sm font-medium transition-all sm:px-4 ${
+              view === "analytics"
+                ? "bg-emerald-500/20 text-emerald-300 shadow-inner"
+                : "text-slate-400 hover:text-slate-200"
+            }`}
+          >
+            <BarChart3 className="h-4 w-4" />
+            Analytics
+          </button>
         </div>
 
-        {view === "create" ? (
+        {view === "create" && (
           <CreatePromptForm onCreated={() => setView("manage")} />
-        ) : (
+        )}
+        {view === "manage" && (
           <MyPrompts onCreateNew={() => setView("create")} />
+        )}
+        {view === "analytics" && (
+          <section className="space-y-6">
+            <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-5 sm:p-6">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-200">
+                Creator analytics
+              </p>
+              <h2 className="mt-2 text-2xl font-semibold text-white">
+                Conversion &amp; support performance
+              </h2>
+              <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-400">
+                See how buyers discover, purchase, and successfully unlock your
+                prompts — with buyer identities redacted to protect privacy.
+              </p>
+            </div>
+            {address ? (
+              <SellerAnalyticsWidget walletAddress={address} />
+            ) : (
+              <div className="rounded-xl border border-dashed border-white/15 bg-white/[0.02] p-8 text-center text-sm text-slate-400">
+                Connect your wallet to view privacy-safe seller analytics.
+              </div>
+            )}
+          </section>
         )}
       </main>
 


### PR DESCRIPTION
Closes #711 
 Closes #712 
 Closes #713 
 Closes #714 

## What & why

Bundles four related marketplace improvements into one branch. Unit suites for
the new analytics lib and the dry-run classifier pass; server `tsc --noEmit`
on the changed files is clean.

### #711 — Seller analytics (privacy-safe)
- `src/lib/analytics/sellerAnalytics.ts` (+ vitest) — aggregated conversion,
  refund, unlock-success, satisfaction, avg rating, and unlock-failures-by-reason.
  Enforces `MIN_COHORT_SIZE` suppression; buyer identities never appear in output.
- `server` `GetCreatorSupportMetrics` + `GET /creator/:walletAddress/analytics/support-metrics`.
- `SellerAnalyticsWidget` wired into the Sell page (new **Analytics** tab) and
  the profile My-Inventory tab.

### #712 — Contract migration dry-run diff
- `scripts/dry-run-migration.py` — classifies the pending spec diff as
  `no-op | additive | incompatible`, reporting affected storage-key families,
  expected writes, TTL implications, rollback notes; never writes state.
- Docs (`contracts/prompt-hash/MIGRATION.md`, `docs/operations/contract-upgrades.md`,
  `scripts/README.md`) + `self-test` step added to contracts CI.

### #713 — Machine-readable OpenAPI schema
- `docs/openapi.json` (OpenAPI 3.0.3) covering marketplace endpoints.
- Served live: `GET /api/openapi.json` and interactive `GET /api/docs` (Redoc).
- Conformance test under `server/src/tests/openapi.test.ts`.

### #714 — Abuse-report evidence + triage
- `api/prompts/reports.ts` — evidence capture (≤10 items, normalized) and a
  forward-only triage state machine (`pending → investigating → resolved|dismissed`,
  illegal regressions rejected with `409`), plus status filtering.
- `reportClient.ts` + `ReportDialog.tsx` — evidence submission UI.
- Docs updated in `docs/operations/incident-response.md`, `docs/api-reference.md`.

## Test status
- Passing: `src/lib/analytics/sellerAnalytics.test.ts` (7), server
  `openapi.test.ts` (9), `scripts/dry-run-migration.py self-test`.
- Note: this branch was rebased onto current `upstream/main`; CI is still
  pending. Opened for review ahead of full-typecheck/CI green per request.