### PR TITLE
fix(moderation): fix #735 link admin moderation to reversible audit evidence

### DIFF
--- a/contracts/prompt-hash/src/contract.rs
+++ b/contracts/prompt-hash/src/contract.rs
@@ -182,10 +182,14 @@ impl PromptHashTrait for PromptHashContract {
         status: PromptSaleStatus,
         reason: super::types::ModerationReason,
         policy_reference: soroban_sdk::String,
+        reverses_timestamp: u64,
     ) -> Result<(), Error> {
         admin.require_auth();
         let owner = ownable::get_owner(&env).ok_or(Error::Unauthorized)?;
         ensure(owner == admin, Error::Unauthorized)?;
+
+        // Ensure structured evidence reference is provided
+        ensure(!policy_reference.is_empty(), Error::InvalidMetadata)?;
 
         let mut prompt = Storage::require_prompt(&env, prompt_id)?;
         ensure(
@@ -194,26 +198,49 @@ impl PromptHashTrait for PromptHashContract {
         )?;
         ensure(prompt.status != status, Error::InvalidStatusTransition)?;
 
+        // If this action reverses a prior moderation decision, verify the original action record exists
+        if reverses_timestamp != 0 {
+            let _orig = Storage::get_moderation_record(&env, prompt_id, reverses_timestamp)?;
+        }
+
+        let previous_state = prompt.status.clone();
         let now = env.ledger().timestamp();
         
-        // Store moderation audit record
+        // Store moderation audit record with durable evidence trail and reversal link
         let moderation_record = super::types::ModerationRecord {
             prompt_id,
             moderator: admin.clone(),
             action: status.clone(),
+            previous_state: previous_state.clone(),
             reason: reason.clone(),
             policy_reference: policy_reference.clone(),
             timestamp: now,
+            reverses_timestamp,
         };
-        let key = super::types::DataKey::ModerationRecord(prompt_id, now);
-        env.storage().persistent().set(&key, &moderation_record);
-        Storage::extend_key_ttl(&env, &key);
+        Storage::set_moderation_record(&env, &moderation_record);
 
         prompt.status = status.clone();
         Storage::update_prompt(&env, &prompt);
         Storage::update_status_indexes(&env, &prompt);
-        Events::emit_prompt_admin_moderated(&env, prompt_id, admin, status, reason, policy_reference);
+        Events::emit_prompt_admin_moderated(
+            &env,
+            prompt_id,
+            admin,
+            status,
+            previous_state,
+            reason,
+            policy_reference,
+            reverses_timestamp,
+        );
         Ok(())
+    }
+
+    fn get_moderation_record(
+        env: Env,
+        prompt_id: u64,
+        timestamp: u64,
+    ) -> Result<super::types::ModerationRecord, Error> {
+        Storage::get_moderation_record(&env, prompt_id, timestamp)
     }
 
     fn set_prompt_max_supply(

--- a/contracts/prompt-hash/src/events.rs
+++ b/contracts/prompt-hash/src/events.rs
@@ -23,8 +23,10 @@ struct PromptAdminModerated {
     pub prompt_id: u64,
     pub admin: Address,
     pub status: PromptSaleStatus,
+    pub previous_state: PromptSaleStatus,
     pub reason: ModerationReason,
     pub policy_reference: String,
+    pub reverses_timestamp: u64,
 }
 
 #[contractevent]
@@ -293,15 +295,19 @@ impl Events {
         prompt_id: u64,
         admin: Address,
         status: PromptSaleStatus,
+        previous_state: PromptSaleStatus,
         reason: ModerationReason,
         policy_reference: String,
+        reverses_timestamp: u64,
     ) {
         PromptAdminModerated {
             prompt_id,
             admin,
             status,
+            previous_state,
             reason,
             policy_reference,
+            reverses_timestamp,
         }
         .publish(env);
     }

--- a/contracts/prompt-hash/src/storage.rs
+++ b/contracts/prompt-hash/src/storage.rs
@@ -1432,4 +1432,26 @@ impl Storage {
 
         risks
     }
+
+    pub fn get_moderation_record(
+        env: &Env,
+        prompt_id: u64,
+        timestamp: u64,
+    ) -> Result<super::types::ModerationRecord, super::types::Error> {
+        let key = super::types::DataKey::ModerationRecord(prompt_id, timestamp);
+        env.storage()
+            .persistent()
+            .get(&key)
+            .ok_or(super::types::Error::MissingMetadata)
+    }
+
+    pub fn set_moderation_record(
+        env: &Env,
+        record: &super::types::ModerationRecord,
+    ) {
+        let key = super::types::DataKey::ModerationRecord(record.prompt_id, record.timestamp);
+        env.storage().persistent().set(&key, record);
+        Self::extend_key_ttl(env, &key);
+    }
 }
+

--- a/contracts/prompt-hash/src/test.rs
+++ b/contracts/prompt-hash/src/test.rs
@@ -6943,3 +6943,92 @@ fn test_listing_snapshot_hash_binds_to_current_listing_state() {
     assert!(!client.verify_listing_snapshot(&prompt_id, &h1));
     assert!(client.verify_listing_snapshot(&prompt_id, &h2));
 }
+
+#[test]
+fn test_admin_moderation_delist_restore_and_evidence_audit_trail() {
+    use crate::types::ModerationReason;
+
+    let env: Env = Default::default();
+    let context = setup(&env);
+    let client = PromptHashContractClient::new(&env, &context.contract);
+    let creator = Address::generate(&env);
+
+    let prompt_id = create_prompt(&env, &client, &creator, "Mod Test", 1_000, &context.xlm);
+    let initial_prompt = client.get_prompt(&prompt_id);
+    assert_eq!(initial_prompt.status, PromptSaleStatus::Active);
+
+    // 1. Evidence validation: empty policy reference should be rejected
+    let empty_evidence_res = client.try_admin_set_prompt_sale_status(
+        &context.admin,
+        &prompt_id,
+        &PromptSaleStatus::Paused,
+        &ModerationReason::PolicyViolation,
+        &String::from_str(&env, ""),
+        &0,
+    );
+    assert_eq!(empty_evidence_res, Err(Ok(Error::InvalidMetadata)));
+
+    // 2. Delist prompt (Active -> Paused) with structured evidence reference
+    let delist_timestamp = 1_000_000;
+    env.ledger().with_mut(|l| l.timestamp = delist_timestamp);
+    let evidence_ref_1 = String::from_str(&env, "DOC-REF-POLICY-735-A");
+    client.admin_set_prompt_sale_status(
+        &context.admin,
+        &prompt_id,
+        &PromptSaleStatus::Paused,
+        &ModerationReason::PolicyViolation,
+        &evidence_ref_1,
+        &0,
+    );
+
+    let delisted_prompt = client.get_prompt(&prompt_id);
+    assert_eq!(delisted_prompt.status, PromptSaleStatus::Paused);
+
+    // Verify durable moderation audit record on-chain
+    let delist_record = client.get_moderation_record(&prompt_id, &delist_timestamp);
+    assert_eq!(delist_record.prompt_id, prompt_id);
+    assert_eq!(delist_record.moderator, context.admin);
+    assert_eq!(delist_record.previous_state, PromptSaleStatus::Active);
+    assert_eq!(delist_record.action, PromptSaleStatus::Paused);
+    assert_eq!(delist_record.reason, ModerationReason::PolicyViolation);
+    assert_eq!(delist_record.policy_reference, evidence_ref_1);
+    assert_eq!(delist_record.reverses_timestamp, 0);
+
+    // 3. Reversal reference validation: invalid reverses_timestamp must be rejected
+    let invalid_reversal_res = client.try_admin_set_prompt_sale_status(
+        &context.admin,
+        &prompt_id,
+        &PromptSaleStatus::Active,
+        &ModerationReason::Other,
+        &String::from_str(&env, "RESTORE-EVID"),
+        &9_999_999, // Non-existent action timestamp
+    );
+    assert_eq!(invalid_reversal_res, Err(Ok(Error::MissingMetadata)));
+
+    // 4. Restore prompt (Paused -> Active) linking back to original delisting action
+    let restore_timestamp = 2_000_000;
+    env.ledger().with_mut(|l| l.timestamp = restore_timestamp);
+    let evidence_ref_2 = String::from_str(&env, "RESTORE-REF-APPEAL-735-B");
+    client.admin_set_prompt_sale_status(
+        &context.admin,
+        &prompt_id,
+        &PromptSaleStatus::Active,
+        &ModerationReason::Other,
+        &evidence_ref_2,
+        &delist_timestamp,
+    );
+
+    let restored_prompt = client.get_prompt(&prompt_id);
+    assert_eq!(restored_prompt.status, PromptSaleStatus::Active);
+
+    // Verify restore audit record references the original delist timestamp
+    let restore_record = client.get_moderation_record(&prompt_id, &restore_timestamp);
+    assert_eq!(restore_record.prompt_id, prompt_id);
+    assert_eq!(restore_record.moderator, context.admin);
+    assert_eq!(restore_record.previous_state, PromptSaleStatus::Paused);
+    assert_eq!(restore_record.action, PromptSaleStatus::Active);
+    assert_eq!(restore_record.reason, ModerationReason::Other);
+    assert_eq!(restore_record.policy_reference, evidence_ref_2);
+    assert_eq!(restore_record.reverses_timestamp, delist_timestamp);
+}
+

--- a/contracts/prompt-hash/src/types.rs
+++ b/contracts/prompt-hash/src/types.rs
@@ -109,7 +109,10 @@ pub enum Error {
     MaxSupplyBelowCommitted = 84,
     DisputeWindowClosed = 85,
     DisputeWindowNotElapsed = 86,
+    InvalidMetadata = 87,
+    MissingMetadata = 88,
 }
+
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -247,16 +250,18 @@ pub enum ModerationReason {
     Other,
 }
 
-/// Moderation audit record preserving complete policy action history.
+/// Moderation audit record preserving complete policy action history and reversal links.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ModerationRecord {
     pub prompt_id: u64,
     pub moderator: Address,
     pub action: PromptSaleStatus,
+    pub previous_state: PromptSaleStatus,
     pub reason: ModerationReason,
     pub policy_reference: String,
     pub timestamp: u64,
+    pub reverses_timestamp: u64,
 }
 
 #[contracttype]
@@ -739,7 +744,14 @@ pub trait PromptHashTrait {
         status: PromptSaleStatus,
         reason: ModerationReason,
         policy_reference: String,
+        reverses_timestamp: u64,
     ) -> Result<(), Error>;
+
+    fn get_moderation_record(
+        env: Env,
+        prompt_id: u64,
+        timestamp: u64,
+    ) -> Result<ModerationRecord, Error>;
 
     fn set_prompt_max_supply(
         env: Env,


### PR DESCRIPTION
Closes #735

This PR resolves #735 by introducing structured, durable, and reversible audit evidence for all admin content moderation actions (delisting, restoring, and flagging prompts) on the Stellar Soroban smart contract (contracts/prompt-hash).

Problem Solved
Prior to this fix, moderation decisions stored basic status updates without capturing the previous listing state, validating that non-empty policy evidence references were supplied, or linking restoration/reversal decisions back to the original moderation event. As a result, maintainers lacked a reliable, tamper-proof audit trail to audit or safely roll back moderation errors (#735).

How the Flow Works Now
Mandatory Evidence Validation: When an admin invokes admin_set_prompt_sale_status, the contract enforces non-empty evidence references in policy_reference (ensure(!policy_reference.is_empty(), Error::InvalidMetadata)). Calls with missing evidence references are immediately rejected (#735).
State & Reversal Context Capture: The contract records previous_state alongside target action (PromptSaleStatus), moderator (Address), reason (ModerationReason), policy_reference (String), timestamp (u64), and reverses_timestamp (u64) inside an updated ModerationRecord struct (#735).
Reversal Link Integrity: When a moderation action represents a restoration or rollback (reverses_timestamp != 0), the contract verifies that the referenced original action record exists on-chain via Storage::get_moderation_record (Error::MissingMetadata), maintaining audit chain continuity (#735).
Admin Audit View & Event Path: Exposes get_moderation_record(env, prompt_id, timestamp) as a view function and emits an enhanced PromptAdminModerated event containing all structured audit metadata for indexers (#735).
Why This Change Matters
By enforcing evidence validation and linkage between reversals and initial moderation actions directly at the smart contract level, maintainers obtain a durable, verifiable, and reversible audit log on the Stellar ledger (#735).